### PR TITLE
explicitcopy.cpp example fix, invalid accessor constructor

### DIFF
--- a/latex/code/explicitcopy.cpp
+++ b/latex/code/explicitcopy.cpp
@@ -14,7 +14,7 @@ myQueue.submit([&](handler &cgh) {
   // Retrieve a ranged write accessor to a global buffer with access to the
   // first half of the buffer
   accessor<int, 1, access::mode::write, access::target::global_buffer>
-      acc(b, range<1>(nElems / 2), id<1>(0));
+      acc(b, cgh, range<1>(nElems / 2), id<1>(0));
   // Copy the first five elements of the vector into the buffer associated with
   // the accessor
   cgh.copy(v.data(), acc);


### PR DESCRIPTION
The constructor of the accessor in this example doesn't seem to fit with 
any of the accessor constructors in the specification, I also tested the 
example with ComputeCpp and it fails to compile.

The closest accessor constructor seems to be line 45 of the accessor 
interface in section 4.7.6.6 Buffer accessor interface:

```
/* Available only when: (isPlaceholder == access::placeholder::false_t 
&& (accessTarget == access::target::global_buffer || accessTarget ==
access::target::constant_buffer)) && dimensions > 0 */
accessor(buffer<dataT, dimensions> &bufferRef, 
handler &commandGroupHandlerRef, range<dimensions> accessRange, 
id<dimensions> accessOffset = {});
```

The other option would be on line 40 of the interface:

```
/* Available only when: (isPlaceholder == access::placeholder::false_t 
&& accessTarget == access::target::host_buffer) || (isPlaceholder ==
access::placeholder::true_t && (accessTarget ==  access::target::global_buffer
|| accessTarget == access::target::constant_buffer)) && dimensions > 0 */
accessor(buffer<dataT, dimensions> &bufferRef, range<dimensions> 
accessRange, id<dimensions> accessOffset = {});
```

But as it doesn't seem the intent is for the accessor to be a 
placeholder with global access the line 45 constructor seems to fit the 
original intent better.