### PR TITLE
Fix a lot of keyword-related issues with some PDF search impact

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -29,9 +29,9 @@ access to the data within an execution schedule.
 
 Because of this the interface of the \codeinline{accessor} will
 be different depending on the possible combinations of those parameters. There
-are three main categories of accessor; buffer accesors (see Section
-~\ref{sub.section.accessors.buffer}), local accessors (see Section
-~\ref{sub.section.accessors.local}) and image accessors (see Section
+are three main categories of accessor; buffer accesors (see Section%
+~\ref{sub.section.accessors.buffer}), local accessors (see Section%
+~\ref{sub.section.accessors.local}) and image accessors (see Section%
 ~\ref{sub.section.accessors.image}).
 
 %*******************************************************************************
@@ -86,9 +86,9 @@ or after the execution of a kernel. If a command group contains only
 of the buffer (or sub-range of the buffer, if provided) are not
 preserved. If a user wants to modify only certain parts of a buffer,
 preserving other parts of the buffer, then the user should specify the
-exact sub-range of modification of the buffer. 
-Atomic access is only valid to \codeinline{local}, \codeinline{global\_buffer}
-and \codeinline{host\_buffer} targets (see next section).
+exact sub-range of modification of the buffer.
+Atomic access is only valid to \codeinline{local}, \codeinline{global_buffer}
+and \codeinline{host_buffer} targets (see next section).
 
 The \codeinline{access::mode} enumeration, shown in Table~\ref{interfaces.accessmode.description}, describes the potential modes of an \codeinline{accessor}.
 
@@ -305,7 +305,7 @@ in~\ref{table.accessors.buffer.capabilities}.
       \hline
         \tf{global_buffer}
         & device
-        & \nlineVI{\tf{read}}{\tf{write}}{\tf{read\_write}}{\tf{discard\_write}} {\tf{discard\_read_write}}{\tf{atomic}}
+        & \nlineVI{\tf{read}}{\tf{write}}{\tf{read_write}}{\tf{discard_write}} {\tf{discard_read_write}}{\tf{atomic}}
         & The data type of the SYCL buffer being accessed.
         & Between \tf{0} and \tf{3} (inclusive).
         & \nlineII{\tf{false_t}}{\tf{true_t}} \\
@@ -319,7 +319,7 @@ in~\ref{table.accessors.buffer.capabilities}.
       \hline
         \tf{host_buffer}
         & host
-        & \nlineV{\tf{read}}{\tf{write}}{\tf{read\_write}}{\tf{discard\_write}} {\tf{discard\_read_write}}
+        & \nlineV{\tf{read}}{\tf{write}}{\tf{read_write}}{\tf{discard_write}} {\tf{discard_read_write}}
         & The data type of the SYCL buffer being accessed.
         & Between \tf{0} and \tf{3} (inclusive).
         & \nline{\tf{false_t}} \\
@@ -584,9 +584,9 @@ Tables~\ref{table.specialmembers.common.reference} and
       specified by \codeinline{index}.
     }
   \addRow
-    { \_\_unspecified\_\_ \&operator[](size_t index) const }
+    { \__unspecified__ \&operator[](size_t index) const }
     {
-      Available only when: \codeinline{dimensions > 1}.  
+      Available only when: \codeinline{dimensions > 1}.
       \newline
       Returns an instance of an undefined intermediate type representing a
       a SYCL \codeinline{accessor} of the same type as this SYCL \codeinline{
@@ -697,7 +697,7 @@ in~\ref{table.accessors.local.capabilities}.
       \hline
         \tf{local}
         & device
-        & \nlineII{\tf{read\_write}}{\tf{atomic}}
+        & \nlineII{\tf{read_write}}{\tf{atomic}}
         & All available data types supported in a SYCL kernel function.
         & Between \tf{0} and \tf{3} (inclusive).
         & \tf{false_t} \\
@@ -834,9 +834,9 @@ member functions and common member functions are listed in
       at the index specified by \codeinline{index}.
     }
   \addRow
-    { \_\_unspecified\_\_ \&operator[](size_t index) const }
+    { \__unspecified__ \&operator[](size_t index) const }
     {
-      Available only when: \codeinline{dimensions > 1}.  
+      Available only when: \codeinline{dimensions > 1}.
       \newline
       Returns an instance of an undefined intermediate type representing a
       a SYCL \codeinline{accessor} of the same type as this SYCL \codeinline{
@@ -929,21 +929,21 @@ in~\ref{table.accessors.image.capabilities}.
         \tf{image}
         & device
         & \tf{\nlineIII{read}{write}{discard_write}}
-        & \nlineIV{\tf{cl\_int4}}{\tf{cl\_uint4}}{\tf{cl\_float4}}{\tf{cl\_half4}}
+        & \nlineIV{\tf{cl_int4}}{\tf{cl_uint4}}{\tf{cl_float4}}{\tf{cl_half4}}
         & Between \tf{1} and \tf{3} (inclusive).
         & \tf{false_t} \\
       \hline
         \tf{image_array}
         & device
         & \tf{\nlineIII{read}{write}{discard_write}}
-        & \nlineIV{\tf{cl\_int4}}{\tf{cl\_uint4}}{\tf{cl\_float4}}{\tf{cl\_half4}}
+        & \nlineIV{\tf{cl_int4}}{\tf{cl_uint4}}{\tf{cl_float4}}{\tf{cl_half4}}
         & Between \tf{1} and \tf{2} (inclusive).
         & \tf{false_t} \\
       \hline
         \tf{host_image}
         & host
         & \tf{\nlineIII{read}{write}{discard_write}}
-        & \nlineIV{\tf{cl\_int4}}{\tf{cl\_uint4}}{\tf{cl\_float4}}{\tf{cl\_half4}}
+        & \nlineIV{\tf{cl_int4}}{\tf{cl_uint4}}{\tf{cl_float4}}{\tf{cl_half4}}
         & Between \tf{1} and \tf{3} (inclusive).
         & \tf{false_t} \\
       \hline
@@ -1071,7 +1071,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       and \codeinline{cl_int4} when \codeinline{dimensions == 3}.
     }
   \addRowTwoL
-    { \_\_image\_array\_slice\_\_ }
+    { \__image_array_slice__ }
     { operator[](size_t index) const }
     {
       Available only when: \codeinline{accessTarget ==

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -15,7 +15,7 @@ run on either an OpenCL device or on the \gls{host}.
 
 The terminology used for SYCL inherits that of OpenCL with some
 SYCL-specific additions. A function object that can execute on either
-an OpenCL \keyword{device} or a \gls{host} \gls{device} is called a
+an OpenCL \gls{device} or a \gls{host} \gls{device} is called a
 \gls{sycl-kernel-function}.
 
 To ensure maximum backward-compatibility, a software developer can produce
@@ -89,32 +89,37 @@ kernel to the host code.
 The \codeinline{parallel_for} method creates an instance of a kernel object.
 The kernel object is the entity that will be enqueued within a
 command group.  In the case of \codeinline{parallel_for} the
-\keyword{kernel function} will be executed over the given range from 0 to 1023.
-The different methods to execute kernels can be found in Section~\ref{subsec:invokingkernels}.
+\gls{sycl-kernel-function} will be executed over the given range from 0 to 1023.
+The different methods to
+execute kernels can be found in Section~\ref{subsec:invokingkernels}.
 
-A \keyword{kernel function} can only be defined within a \keyword{command group
-scope}, and a \keyword{command group scope} may include only a single \keyword{kernel
-function}. Command group scope is the syntactic scope wrapped by the construction
-of a \gls{command-group-function-object} as seen on line 20. The \gls{command-group-function-object} takes as a parameter a command group \codeinline{handler} which is
-a runtime constructed object. 
-All the requirements for a kernel to execute are defined in this 
-\keyword{command group scope}, as described in Section~\ref{sec:executionmodel}.
-In this case the constructor used for \lstinline$myQueue$ on line 14 is the default
-constructor, which allows the queue to select the best underlying device to
-execute on, leaving the decision up to the runtime.
+A \gls{sycl-kernel-function} can only be defined within a
+\gls{command-group-scope}, and a \gls{command-group-scope} may include
+only a single \gls{sycl-kernel-function}. Command group scope is the
+syntactic scope wrapped by the construction of a
+\gls{command-group-function-object} as seen on line 20. The
+\gls{command-group-function-object} takes as a parameter a command
+group \codeinline{handler} which is a runtime constructed object.
 
-In SYCL, data that is required within a \keyword{kernel function} must
-be contained within a \keyword{buffer} or \keyword{image}, as described in
+All the requirements for a kernel to execute are defined in this
+\gls{command-group-scope}, as described in
+Section~\ref{sec:executionmodel}.  In this case the constructor used
+for \codeinline{myQueue} on line 14 is the default constructor, which
+allows the queue to select the best underlying device to execute on,
+leaving the decision up to the runtime.
+
+In SYCL, data that is required within a \gls{sycl-kernel-function} must
+be contained within a \gls{buffer} or \gls{image}, as described in
 Section~\ref{sec:memory.model}. We
-construct a buffer on line 17. Access to the \keyword{buffer} is controlled via
+construct a buffer on line 17. Access to the \gls{buffer} is controlled via
 an \gls{accessor} which is constructed on line 22 through the
 \codeinline{get_access} method of the buffer. The \gls{buffer} is used to
 keep track of access to the data and the \gls{accessor} is used to request
 access to the data on a queue, as well as to track the dependencies between
-\keyword{kernel functions}. In this example the \keyword{accessor} is used to
-write to the data buffer on line 26. All \keyword{buffers} must be constructed
-in the application-scope, whereas all \keyword{accessors}
-must be constructed in the \keyword{command group scope}.
+\gls{sycl-kernel-function}. In this example the \gls{accessor} is used to
+write to the data buffer on line 26. All \glspl{buffer} must be constructed
+in the application-scope, whereas all \glspl{accessor}
+must be constructed in the \gls{command-group-scope}.
 
 
 \section{The SYCL Platform Model}
@@ -174,11 +179,12 @@ compile-time macro: \codeinline{CL_SYCL_LANGUAGE_VERSION}.
 
 \section{SYCL Execution Model}
 
-The execution of a SYCL program occurs in two parts: 
-\glspl{sycl-kernel-function} and a \keyword{application} that executes on the \gls{host}.
-The SYCL \glspl{kernel} execution is governed by the \textit{SYCL 
-Kernel Execution Model}, whereas the SYCL application that executes
-on the \gls{host} is governed by the \textit{SYCL Application Execution Model}.
+The execution of a SYCL program occurs in two parts:
+\glspl{sycl-kernel-function} and a \gls{sycl-application} that
+executes on the \gls{host}.  The SYCL \glspl{kernel} execution is
+governed by the \textit{SYCL Kernel Execution Model}, whereas the
+\gls{sycl-application} that executes on the \gls{host} is governed by
+the \textit{SYCL Application Execution Model}.
 
 Like OpenCL, SYCL is capable of running kernels on multiple device types. 
 However, SYCL adds functionality on top of OpenCL due to the integration into a host
@@ -201,18 +207,18 @@ The kernels are executed as soon as their requirements have been satisfied.
 
 \subsubsection{OpenCL resources managed by SYCL Application}
 
-In OpenCL, a developer must create a \keyword{context} to be able to execute
-commands on a device. Creating a context involves choosing a \keyword{platform}
-and a list of \keyword{devices}. In SYCL, contexts, platforms and devices all
+In OpenCL, a developer must create a \gls{context} to be able to execute
+commands on a device. Creating a context involves choosing a \gls{platform}
+and a list of \glspl{device}. In SYCL, contexts, platforms and devices all
 exist, but the user can choose whether to specify them or have the SYCL
 implementation create them automatically.  The minimum required object for
-submitting work to devices in SYCL is the \keyword{queue}, which contains
+submitting work to devices in SYCL is the \gls{queue}, which contains
 references to a platform, device and context internally.
 
 The resources managed by SYCL are:
 
 \begin{enumerate}
-\item \Glspl{platform}: All features of OpenCL are implemented by platforms.
+\item \Glspl{platform}: all features of OpenCL are implemented by platforms.
 A platform can be viewed as a given hardware vendor's runtime and the devices
 accessible through it. Some devices will only be accessible to one vendor's
 runtime and hence multiple platforms may be present. SYCL manages the different
@@ -220,7 +226,7 @@ platforms for the user. In SYCL, a platform resource is accessible through a
 \codeinline{cl::sycl::platform} object. SYCL also provides a host platform
 object, which only contains a single host device.
 
-\item \Glspl{context}: Any OpenCL resource that is acquired by the user is
+\item \Glspl{context}: any OpenCL resource that is acquired by the user is
 attached to a context. A context contains a collection of devices that the host
 can use and manages memory objects that can be shared between the devices. Data
 movement between devices within a context may be efficient and hidden by the
@@ -229,7 +235,7 @@ may involve the host. A given context can only wrap devices owned
 by a single platform. In SYCL, a context resource is accessible through a \codeinline{cl::sycl::context}
 object.
 
-\item \Glspl{device}: Platforms provide one or more devices for executing
+\item \Glspl{device}: platforms provide one or more devices for executing
 kernels. In SYCL, a device is accessible through a \codeinline{cl::sycl::device}
 object. SYCL provides the abstract \codeinline{cl::sycl::device_selector} class
 which the user can subclass to define how the runtime should select the best
@@ -239,7 +245,7 @@ that select devices based on common criteria, such as type of device. SYCL,
 unlike OpenCL, defines a host device, which means any work that uses the host
 device will execute on the host and not on any OpenCL device.
 
-\item \Glspl{kernel}: The SYCL functions that run on SYCL devices (i.e.\ 
+\item \Glspl{kernel}: the SYCL functions that run on SYCL devices (i.e.\ 
 either an OpenCL device, or the host device) are defined as C++ function
 objects (a named function object type or a lambda function).
 In SYCL, all kernels must have a \gls{kernel-name}, which must be a
@@ -247,8 +253,8 @@ globally-accessible C++ type name. This is required to enable kernels compiled
 with one compiler to be linked to host code compiled with a different compiler.
 
 For named function objects, the type name of the function object is sufficient
-as the \keyword{kernel name}, but for C++11 lambda functions, the user must
-provide a user-defined type name as the \keyword{kernel name}.
+as the \gls{kernel-name}, but for C++ lambda functions, the user must
+provide a user-defined type name as the \gls{kernel-name}.
 
 \item \Glspl{program-object}: OpenCL objects that store implementation data
 for the SYCL kernels. These objects are only required for advanced use in SYCL
@@ -585,7 +591,7 @@ The Memory Model for SYCL Devices is based on the OpenCL Memory model.
 Work-items executing in a kernel have access to four distinct memory regions:
 
 \begin{itemize}
-    \item \keyword{Global memory} is accessible to all work-items in all
+    \item \Gls{global-memory} is accessible to all work-items in all
 work-groups. Work-items can read from or write to any element of a global memory
 object. Reads and writes to global memory may be cached depending on the
 capabilities of the device. Global memory is persistent across kernel
@@ -593,20 +599,20 @@ invocations, however there is no guarantee that two concurrently executing
 kernels can simultaneously write to the same memory object and expect correct
 results.
 
-    \item \keyword{Constant memory} is a region of global memory that remains
+    \item \Gls{constant-memory} is a region of global memory that remains
 constant during the execution of a kernel. The host allocates and initializes
 memory objects placed into constant memory.
 
-    \item \keyword{Local memory} is a distinct memory region shared between
+    \item \Gls{local-memory} is a distinct memory region shared between
 work-items in a single work-group and inaccessible to work-items in other
 work-groups. This memory region can be used to allocate variables that are
 shared by all work-items in a work-group. Work-group-level visibility allows
 local memory to be implemented as dedicated regions of memory on an OpenCL
 device where this is appropriate.
 
-    \item \keyword{Private memory} is a region of memory private to a work-item.
+    \item \Gls{private-memory} is a region of memory private to a work-item.
 Variables defined in one work-item's private memory are not visible to another
-work-item. 
+work-item.
 \end{itemize}
 
 \subsubsection{Access to memory}
@@ -1027,8 +1033,8 @@ Note that an instance of the SYCL \codeinline{buffer} or SYCL \codeinline{image}
 
 \section{Memory objects}
 
-Memory objects in SYCL fall into one of two categories: \keyword{buffer} objects
-and \keyword{image} objects. A buffer object stores a one-, two- or
+Memory objects in SYCL fall into one of two categories: \gls{buffer} objects
+and \gls{image} objects. A buffer object stores a one-, two- or
 three-dimensional collection of elements that are stored linearly directly back
 to back in the same way C or C++ stores arrays. An image object is used to store
 a one-, two- or three-dimensional texture, frame-buffer or image that may be
@@ -1124,7 +1130,7 @@ computer system. The framework contains the following components:
      OpenCL implementation is available, then the SYCL implementation provides only
      the \gls{host-device} to run kernels on. 
    \item
-      \keyword{SYCL Device Compiler(s)}: The SYCL \glspl{device-compiler} compile SYCL C++
+      SYCL \glspl{device-compiler}: The SYCL \glspl{device-compiler} compile SYCL C++
        kernels into a format which can be executed on an OpenCL device at runtime.
        There may be more than one SYCL device compiler in a SYCL implementation. The
        format of the compiled SYCL kernels is not defined.  A SYCL device compiler may,

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -415,7 +415,7 @@ offset and being of the size of its global range, split into work-groups of the
 size of its local range.
 
 Each work-item in the ND-range is identified by a value of type
-\codeinline{nd\_item<N>}.  The type \codeinline{nd\_item<N>} encapsulates a
+\codeinline{nd_item<N>}.  The type \codeinline{nd_item<N>} encapsulates a
 global id, local id and work-group id, all of type \codeinline{id<N>},
 the iteration space offset also of type \codeinline{id<N>}, as well as
 global and local ranges and synchronization operations necessary to
@@ -512,7 +512,7 @@ specific mechanism.
 \caption{Actions performed when three command groups are submitted 
 to two distinct queues, and possible OpenCL implementation of them by
   a SYCL runtime. Note that each SYCL buffer ($b1,b2$) is implemented as
-  separate \codeinline{cl\_mem} objects per context}
+  separate \codeinline{cl_mem} objects per context}
 \label{fig:devicetodevice}
 \end{figure}
 

--- a/latex/builtin_functions.tex
+++ b/latex/builtin_functions.tex
@@ -13,13 +13,19 @@ The SYCL built-in functions are available throughout the SYCL application, and d
 %***********************************************************************************
 % Description of the built-in types available for SYCL host and device
 %***********************************************************************************
-\subsection{Description of the built-in types available for SYCL host and device  }
-All of the OpenCL built-in types are available in the namespace \keyword{cl::sycl}. For the
-purposes of this document we use generic type names for describing sets of valid SYCL types. The generic type names themselves are not valid SYCL types, but they represent a set of valid types, as defined in
-Tables~\ref{table.gentypes}. Each generic type within a section is comprised of
-a combination of scalar and/or SYCL \codeinline{vec} class specializations. Note
-that any reference to the base type refers to the type of a scalar or the element
-type of a SYCL \codeinline{vec} specialization.
+\subsection{Description of the built-in types available for SYCL host
+  and device }
+
+All of the OpenCL built-in types are available in the namespace
+\codeinline{cl::sycl}. For the purposes of this document we use
+generic type names for describing sets of valid SYCL types. The
+generic type names themselves are not valid SYCL types, but they
+represent a set of valid types, as defined in
+Tables~\ref{table.gentypes}. Each generic type within a section is
+comprised of a combination of scalar and/or SYCL \codeinline{vec}
+class specializations. Note that any reference to the base type refers
+to the type of a scalar or the element type of a SYCL \codeinline{vec}
+specialization.
 
 In the OpenCL 1.2 specification document\cite[ch. 6.12.1]{opencl12} in Table 6.7 the work-item
 functions are defined where they provide the size of the enqueued kernel NDRange. These
@@ -231,15 +237,15 @@ section~\ref{nditem-class} and \ref{group-class}.
 \subsection{Math functions}
 
 In SYCL the OpenCL math functions are available in the namespace
-\keyword{cl::sycl} on host and device with the same precision guarantees as
-defined in the OpenCL 1.2 specification document
-\cite[ch. 7]{opencl12} for host and device. For a SYCL platform the numerical
-requirements for host need to match the numerical requirements of the OpenCL
-math built-in functions. The built-in functions can take as input float or
-optionally double and their \keyword{vec} counterparts, for dimensions 1, 2, 3, 4,
-8 and 16. On the host the vector types use the \keyword{vec}
-class and on an OpenCL device use the corresponding OpenCL
-vector types.
+\codeinline{cl::sycl} on host and device with the same precision
+guarantees as defined in the OpenCL 1.2 specification document
+\cite[ch. 7]{opencl12} for host and device. For a SYCL platform the
+numerical requirements for host need to match the numerical
+requirements of the OpenCL math built-in functions. The built-in
+functions can take as input float or optionally double and their
+\codeinline{vec} counterparts, for dimensions 1, 2, 3, 4, 8 and 16. On
+the host the vector types use the \codeinline{vec} class and on an
+OpenCL device use the corresponding OpenCL vector types.
 
 The built-in functions available for SYCL host and device, with the same
 precision requirements for both host and device, are described in
@@ -547,9 +553,10 @@ rounding mode.}
 \completeTable
 %-------------------------------------------------------------------------------
 
-In SYCL the implementation defined precision math functions  are defined in the
-namespace \keyword{cl::sycl::native}. The functions that are available within
-this namespace are specified in Tables~\ref{table.native.math.functions}.
+In SYCL the implementation defined precision math functions are
+defined in the namespace \codeinline{cl::sycl::native}. The functions
+that are available within this namespace are specified in
+Tables~\ref{table.native.math.functions}.
 
 %-------------------------------------------------------------------------------
 
@@ -676,8 +683,12 @@ The maximum error is implementation-defined.
 \completeTable
 %-------------------------------------------------------------------------------
 
-In SYCL the half precision math functions are defined in \keyword{cl::sycl::half_precision}. The functions that are available within this namespace are specified in Tables~\ref{table.half.math.functions}. These
-functions are implemented with a minimum of 10-bits of accuracy i.e. an ULP value is less than or equal to 8192 ulp.
+In SYCL the half precision math functions are defined in
+\codeinline{cl::sycl::half_precision}. The functions that are
+available within this namespace are specified in
+Tables~\ref{table.half.math.functions}. These functions are
+implemented with a minimum of 10-bits of accuracy i.e. an ULP value is
+less than or equal to 8192 ulp.
 
 %-------------------------------------------------------------------------------
 \startTable{Half Math function}
@@ -720,15 +731,19 @@ to +216.}
 % Integer functions
 %*******************************************************************************
 \subsection{Integer functions}
-In SYCL the OpenCL integer math functions are available in the namespace
-\keyword{cl::sycl} on host and device as defined in the OpenCL 1.2 specification
-document\cite[par. 6.12.3] {opencl12}. The built-in functions can take as input
-char, unsigned char, short, unsigned short, int, unsigned int, long long int,
-unsigned long long int and their \keyword{vec} counterparts, for dimensions 2,
-3, 4, 8 and 16. On the host the vector types use the
-\keyword{vec} class and on an OpenCL device use the
-corresponding OpenCL vector types. The supported integer math functions are
-described in Table~\ref{table.integer.functions}.
+
+In SYCL the OpenCL integer math functions are available in the
+namespace \codeinline{cl::sycl} on host and device as defined in the
+OpenCL 1.2 specification document\cite[par. 6.12.3] {opencl12}. The
+built-in functions can take as input \codeinline{char},
+\codeinline{unsigned char}, \codeinline{short}, \codeinline{unsigned
+  short}, \codeinline{int}, \codeinline{unsigned int},
+\codeinline{long long int}, \codeinline{unsigned long long int} and
+their \codeinline{vec} counterparts, for dimensions 2, 3, 4, 8 and
+16. On the host the vector types use the \codeinline{vec} class and on
+an OpenCL device use the corresponding OpenCL vector types. The
+supported integer math functions are described in
+Table~\ref{table.integer.functions}.
 
 %-------------------------------------------------------------------------------
 \startTable{Integer Function}
@@ -859,14 +874,15 @@ result is implementation-defined.
 % Common functions
 %*******************************************************************************
 \subsection{Common functions}
-In SYCL the OpenCL \keyword{common} functions are available in the namespace
-\keyword{cl::sycl} on host and device as defined in the OpenCL 1.2 specification
-document\cite[par. 6.12.4]{opencl12}. They are described here in
-Table~\ref{table.common.functions}. The built-in functions can take as input
-float or optionally double and their \keyword{vec} counterparts, for dimensions
-2, 3, 4, 8 and 16. On the host the vector types use the
-\keyword{vec} class and on an OpenCL device use the
-corresponding OpenCL vector types.
+In SYCL the OpenCL \keyword{common} functions are available in the
+namespace \codeinline{cl::sycl} on host and device as defined in the
+OpenCL 1.2 specification document\cite[par. 6.12.4]{opencl12}. They
+are described here in Table~\ref{table.common.functions}. The built-in
+functions can take as input \codeinline{float} or optionally
+\codeinline{double} and their \codeinline{vec} counterparts, for
+dimensions 2, 3, 4, 8 and 16. On the host the vector types use the
+\codeinline{vec} class and on an OpenCL device use the corresponding
+OpenCL vector types.
 
 %-------------------------------------------------------------------------------
 \startTable{Common Function} \addFootNotes{Common functions which work
@@ -966,15 +982,16 @@ if $x < 0$. Returns $0.0$ if x is a NaN.
 %*******************************************************************************
 \subsection{Geometric Functions}
 
-In SYCL the OpenCL \keyword{geometric} functions are available in the namespace
-\keyword{cl::sycl} on host and device as defined in the OpenCL 1.2 specification
-document \cite[par. 6.12.5]{opencl12}. The built-in functions can take as input
-float or optionally double and their \keyword{vec} counterparts, for dimensions
-2, 3 and 4. On the host the vector types use the
-\keyword{vec} class and on an OpenCL device use the
-corresponding OpenCL vector types. All of the geometric functions use
-round-to-nearest-even rounding mode. Table~\ref{table.geometric.functions}
-contains the definitions of supported geometric functions.
+In SYCL the OpenCL \keyword{geometric} functions are available in the
+namespace \codeinline{cl::sycl} on host and device as defined in the
+OpenCL 1.2 specification document \cite[par. 6.12.5]{opencl12}. The
+built-in functions can take as input float or optionally double and
+their \codeinline{vec} counterparts, for dimensions 2, 3 and 4. On the
+host the vector types use the \codeinline{vec} class and on an OpenCL
+device use the corresponding OpenCL vector types. All of the geometric
+functions use round-to-nearest-even rounding
+mode. Table~\ref{table.geometric.functions} contains the definitions
+of supported geometric functions.
 
 %-------------------------------------------------------------------------------
 \startTable{Geometric Function} \addFootNotes{Geometric functions
@@ -1063,19 +1080,21 @@ before proceeding with the calculation.
 %*******************************************************************************
 \subsection{Relational functions}
 
-In SYCL the OpenCL \keyword{relational} functions are available in the namespace
-\keyword{cl::sycl} on host and device as defined in the OpenCL 1.2 specification
-document \cite[par. 6.12.6]{opencl12}. The built-in functions can take as input
-char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned
-long, float or optionally double and their \keyword{vec} counterparts, for
-dimensions 2,3,4,8, and 16. On the host the vector types use
-the \keyword{vec} class and on an OpenCL device use the
-corresponding OpenCL vector types.
-The relational operators are available on both host and device.  The
-relational functions are provided in addition to the the operators and will
-return 0 if the conditional
-is \keyword{false} and 1 otherwise.
-The available built-in functions are described in
+In SYCL the OpenCL \keyword{relational} functions are available in the
+namespace \codeinline{cl::sycl} on host and device as defined in the
+OpenCL 1.2 specification document \cite[par. 6.12.6]{opencl12}. The
+built-in functions can take as input \codeinline{char},
+\codeinline{unsigned char}, \codeinline{short}, \codeinline{unsigned
+  short}, \codeinline{int}, \codeinline{unsigned int},
+\codeinline{long}, \codeinline{unsigned long}, \codeinline{float} or
+optionally \codeinline{double} and their \codeinline{vec}
+counterparts, for dimensions 2,3,4,8, and 16. On the host the vector
+types use the \codeinline{vec} class and on an OpenCL device use the
+corresponding OpenCL vector types.  The relational operators are
+available on both host and device.  The relational functions are
+provided in addition to the the operators and will return 0 if the
+conditional is \codeinline{false} and 1 otherwise.  The available
+built-in functions are described in
 Tables~\ref{table.relational.functions}
 
 \fixme{fixed typo originating from the OpenCL 1.2 spec: when those functions
@@ -1230,7 +1249,7 @@ of elements and bits as \codeinline{gentype}.
 
 The functionality from the OpenCL functions as defined in the OpenCL 1.2
 specification document\cite[par. 6.12.7]{opencl12} is available in SYCL through
-the \keyword{vec} class in section \ref{sec:vector.type}.
+the \codeinline{vec} class in section \ref{sec:vector.type}.
 
 \subsection{Synchronization Functions}
 

--- a/latex/builtin_functions.tex
+++ b/latex/builtin_functions.tex
@@ -353,17 +353,17 @@ component of x equals mantissa returned * 2exp.
   Log gamma function. Returns the natural
 logarithm of the absolute value of the gamma
 function. The sign of the gamma function is
-returned in the signp argument of lgamma\_r.
+returned in the signp argument of \codeinline{lgamma_r}.
 }
 \addRow
 {
-  genfloat lgamma\_r (genfloat x, genintptr signp)
+  genfloat lgamma_r (genfloat x, genintptr signp)
 }
 {
   Log gamma function. Returns the natural
 logarithm of the absolute value of the gamma
 function. The sign of the gamma function is
-returned in the signp argument of lgamma\_r.
+returned in the signp argument of \codeinline{lgamma_r}.
 }
 
 
@@ -775,11 +775,11 @@ does not modulo overflow.
 
 \addRowTwoL {  geninteger mad_hi (}
 {geninteger a, geninteger b, geninteger c)}
- {Returns mul\_hi(a, b) + c. }
+ {Returns \codeinline{mul_hi(a, b)+c}. }
 
 \addRowTwoL { geninteger mad_sat (geninteger a,}
 {geninteger b, geninteger c)}
-{Returns a * b + c and saturates the result.}
+{Returns \codeinline{a * b + c} and saturates the result.}
 
 \addRowTwoSL
 {geninteger max (geninteger x, geninteger y)}
@@ -794,7 +794,7 @@ does not modulo overflow.
 
 \addRow {geninteger mul_hi (geninteger x, geninteger y) }
 {
-Computes x * y and returns the high half of the
+Computes \codeinline{x * y} and returns the high half of the
 product of x and y.
 }
 
@@ -1042,11 +1042,11 @@ infinitely precise result of
 \codeinline{result = p / sqrt (pow(p.x,2) + pow(p.y,2) + ... );}\newline
 with the following exceptions:
 \begin{enumerate}
-\item If the sum of squares is greater than FLT\_MAX
+\item If the sum of squares is greater than \codeinline{FLT_MAX}
 then the value of the floating-point values in the
 result vector are undefined.
 
-\item If the sum of squares is less than FLT\_MIN then
+\item If the sum of squares is less than \codeinline{FLT_MIN} then
 the implementation may return back p.
 
 \item If the device is in ``denorms are flushed to zero''

--- a/latex/conf.tex
+++ b/latex/conf.tex
@@ -380,6 +380,9 @@ stringstyle=\color[rgb]{0.639,0.082,0.082},
 }
 
 
+% We should use \gls and other functions from glossaries instead now.
+% This can be seen as a \todo inside the document about adding new
+% glossary entries...
 \newcommand{\keyword}[1]{\textit{#1}}
 
 

--- a/latex/conf.tex
+++ b/latex/conf.tex
@@ -448,6 +448,9 @@ Comment [#1\themycomment]:~\newline #2}%
 \newcommand{\nlineIV}[4]{#1 \newline #2 \newline #3 \newline #4 \newline }
 \newcommand{\nlineV}[5]{#1 \newline #2 \newline #3 \newline #4 \newline #5 \newline }
 \newcommand{\nlineVI}[6]{#1 \newline #2 \newline #3 \newline #4 \newline #5 \newline #6 \newline }
+% The problem of this implementation is that #1 is parsed with the
+% wrong catcode, which means that if it starts with a _, it has to be
+% escaped \_
 \newcommand{\codeinline}[1]{\lstinline[basicstyle=\ttfamily\small]$#1$}
 \newcommand{\scriptinline}[1]{\lstinline[basicstyle=\ttfamily\scriptsize]$#1$}
 \lstdefinestyle{nonumbers}{numbers=none}

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1160,7 +1160,7 @@ are listed in Table~\ref{table.constructors.device-event} and
 
 %-------------------------------------------------------------------------------
 \startTable{Member function}
-\addFootNotes{Member functions of the SYCL \codeinline{device\_event} class}{table.members.device-event}
+\addFootNotes{Member functions of the SYCL \codeinline{device_event} class}{table.members.device-event}
   \addRow
     { void wait() }
     {
@@ -1836,8 +1836,8 @@ descriptor.}
 {info::kernel::attributes}
 {string_class}
 {
-  % Curious in this case we need to escape this \_\_
-  Return any attributes specified using the \codeinline{\_\_attribute\_\_} qualifier
+  % Curious in this case we need to escape this __
+  Return any attributes specified using the \codeinline{\__attribute__} qualifier
   with the kernel function declaration in the program source.
 }
 

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -277,7 +277,7 @@ A synopsis of the SYCL \codeinline{nd_range} class is provided below. The constr
 \label{id-class}
 
 \tclass{id}{\tf{int} dimensions} is a vector of dimensions that is used to
-represent an \keyword{index} into a global or local
+represent an \gls{id} into a global or local
 \codeinline{range}. It can be used as an index in an accessor of the
 same rank. The \tf{[n]} operator returns the component \tf{n} as an
 \tf{size_t}.
@@ -1208,7 +1208,7 @@ abstraction and flexibility in the parallel programming models that can be
 implemented on top of SYCL.
 
 The \gls{command-group-function-object} and the \codeinline{handler} class
-serve as an interface for the encapsulation of \keyword{command group scope}.
+serve as an interface for the encapsulation of \gls{command-group-scope}.
 A \gls{sycl-kernel-function} is defined as a function object. All the device data accesses are
 defined inside this group and any transfers are managed by the \gls{sycl-runtime}. The
 rules for the data transfers regarding device and
@@ -1241,7 +1241,7 @@ execution.
 The command group \codeinline{handler} class provides the interface
 for all of the member functions that are able to be executed inside the command group
 scope, and it is also provided as a scoped object to all of the data access
-requests. The \keyword{command group handler} class provides the interface
+requests. The \gls{handler} class provides the interface
 in which every command in the command group scope will be submitted to a queue.
 
 %***********************************************************************************
@@ -1253,7 +1253,7 @@ in which every command in the command group scope will be submitted to a queue.
 
 A \gls{handler} object can only be constructed by the SYCL
 runtime. All of the accessors defined in \gls{command-group-scope} take as a
-parameter an instance of the \keyword{command group handler}, and all the
+parameter an instance of the \gls{handler}, and all the
 kernel invocation functions are member functions of this class.
 
 The constructors of the SYCL \codeinline{handler} class are described in Table~\ref{table.constructors.handler}.
@@ -1308,8 +1308,8 @@ handler methods.
 \label{subsec:invokingkernels}
 
 \Glspl{kernel} can be invoked as \keyword{single tasks}, basic
-\keyword{data-parallel kernels}, OpenCL-style \keyword{nd-range} in
-\keyword{work-groups}, or SYCL \keyword{hierarchical parallelism}.
+\keyword{data-parallel} \glspl{kernel}, OpenCL-style \gls{nd-range} in
+\glspl{work-group}, or SYCL \keyword{hierarchical parallelism}.
 
 Each function takes a kernel name template parameter. The \gls{kernel-name}
 must be a datatype that is unique for each kernel invocation. If a
@@ -1401,7 +1401,7 @@ Table~\ref{table.members.handler.kernel} lists all the members of the
     {
       Defines and invokes a \gls{sycl-kernel-function} as a lambda function
       or a named function object type,
-      for the specified \keyword{nd_range} and given an \keyword{nd_item}
+      for the specified \gls{nd-range} and given an \gls{nd-item}
       for indexing in the indexing space defined by the \gls{nd-range}.
       If it is a named function object and the function object type is globally
       visible there is no need for the developer
@@ -1582,7 +1582,7 @@ the developer may also pass an offset. An offset is an
 instance of the \codeinline{id} class added to the identifier 
 for each point in the range.
 
-In all of these cases the underlying \keyword{nd_range} will be created
+In all of these cases the underlying \gls{nd-range} will be created
 and the kernel defined as a function object will be created and enqueued
 as part of the command group scope.
 
@@ -1708,7 +1708,7 @@ The \codeinline{kernel} class is an abstraction of a \gls{kernel} object
 in SYCL. In the
 most common case the kernel object will contain the compiled version of a kernel
 invoked inside a command group using one of the parallel interface functions as
-described in~\ref{subsec:invokingkernels}. The \keyword{\gls{sycl-runtime}} will create 
+described in~\ref{subsec:invokingkernels}. The \gls{sycl-runtime} will create
 a kernel object, when it needs to enqueue the kernel on a command queue.
 
 In the case where a developer would like to pre-compile a kernel or compile and
@@ -2117,9 +2117,10 @@ A SYCL \codeinline{program} can be queried for all of the following information 
 \subsection{Defining kernels}
 \fixme{updated text for kernel functions.}
 In SYCL functions that are executed in parallel on a SYCL device are referred to
-as \keyword{kernel functions}. A \keyword{kernel} containing such a
-\keyword{kernel function} is enqueued on a device queue in order to be executed on
-that particular device. The return type of the \keyword{kernel function} is
+as \gls{sycl-kernel-function}. A \gls{kernel} containing such a
+\gls{sycl-kernel-function} is enqueued on a device queue in order to
+be executed on
+that particular device. The return type of the \gls{sycl-kernel-function} is
 \tf{void}, and all kernel accesses between host and device are defined using the
 accessor class~\ref{subsec:accessors}.
 
@@ -2163,7 +2164,7 @@ Usual restrictions of passing parameters to kernels apply.
 
 In C++11, function objects can be defined using lambda functions. We allow lambda
 functions to define kernels in SYCL, but we have an extra requirement to
-\keyword{name lambda functions} in order to enable the linking of the SYCL
+name \keyword{lambda functions} in order to enable the linking of the SYCL
 device kernels with the host code to invoke them. The name of a lambda function
 in SYCL is a C++ class. If the lambda function relies on template arguments,
 then the name of the lambda function must contain those template arguments. The
@@ -2191,7 +2192,7 @@ as a named function object
 \ref{sec:interfaces.kernels.as.function-objects} or lambda function
 \ref{sec:interfaces.kernels.as.lambdas}. The user can obtain a program
 object for the kernel with the \codeinline{get_kernel} method. This
-method is templated by the \keyword{kernel name}, so that the user
+method is templated by the \gls{kernel-name}, so that the user
 can specify the kernel whose associated kernel they wish to obtain.
 
 In the following example, the kernel is defined as a lambda function.
@@ -2200,11 +2201,11 @@ and then passes it to the \codeinline{parallel_for}.
 
 \lstinputlisting{code/myprogram.cpp}
 
-In the above example, the \keyword{kernel function} is defined in the
+In the above example, the \gls{sycl-kernel-function} is defined in the
 \codeinline{parallel_for} invocation as part of a lambda function which is named
 using the type of the forward declared class ``myKernel''. The type of the
 function object and the program object enable the compilation and linking of the kernel
-in the program class, \keyword{a priori} of its actual invocation as a kernel
+in the program class, \emph{a priori} of its actual invocation as a kernel
 object. For more details on the SYCL device compiler please refer to
 chapter~\ref{chapter.device.compiler}.
 
@@ -2223,8 +2224,8 @@ called in a \codeinline{parallel_for}.
 In OpenCL C \cite{opencl12} program and kernel objects can be created
 using the OpenCL C API, which is available in the SYCL
 system. Interoperability of OpenCL C kernels and the SYCL system is
-achieved by allowing the creation of a \keyword{SYCL kernel} object from
-an \keyword{OpenCL kernel} object.
+achieved by allowing the creation of a SYCL \codeinline{kernel} object from
+an OpenCL \gls{kernel} object.
 
 The constructor using kernel objects from \ref{table.constructors.kernel}:
 \begin{lstlisting}[style=nonumbers]

--- a/latex/extensions.tex
+++ b/latex/extensions.tex
@@ -92,7 +92,7 @@ The \codeinline{accessor} class for target
 \codeinline{access::target::image} in SYCL support member functions for writing
 3D image memory objects, but this functionality is \keyword{only
 allowed} on a device if the extension \tf{cl_khr_3d_image_writes} is
-supported on that \keyword{device}.
+supported on that \gls{device}.
 
 \section{Interoperability with OpenGL}
 

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -276,7 +276,7 @@
   name={index space classes},
   description={The OpenCL Kernel Execution Model defines an nd-range index
               space. The \gls{sycl-runtime} class that defines an nd-range is the 
-              \codeinline{cl::sycl::nd\_range}, which takes as input the sizes
+              \codeinline{cl::sycl::nd_range}, which takes as input the sizes
               of global and local work-items, represented using the 
               \codeinline{cl::sycl::range} class. The kernel library classes
               for indexing in the defined nd-range are the following classes: 
@@ -285,7 +285,7 @@
                  representing a \gls{id}. 
               \item \codeinline{cl::sycl::item} : The index class that contains
                  the \gls{global-id} and \gls{local-id}. 
-              \item \codeinline{cl::sycl::nd\_item} : The index class that
+              \item \codeinline{cl::sycl::nd_item} : The index class that
                  contains the \gls{global-id}, \gls{local-id} and the
                  \gls{work-group-id}.
               \item \codeinline{cl::sycl::group} : The group class that contains
@@ -492,7 +492,7 @@
 \newglossaryentry{work-item}
 {
   name={work-item},
-  description={The SYCL work-item (\codeinline{cl::sycl::nd\_item} class) is a
+  description={The SYCL work-item (\codeinline{cl::sycl::nd_item} class) is a
                representation of an OpenCL work item. One of a collection of
                parallel executions of a kernel invoked on a \gls{device} by a
                command. A work-item is executed by one or more processing

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -28,7 +28,9 @@
 
 \newglossaryentry{async-handler}
 {
-  name={async\_handler},
+  name={\texttt{async\_handler}},
+  % Add a sorting key to counter-act the name full of LaTeX formatting
+  sort=async-handler,
   description={An asynchronous error handler object is a function class instance
                providing necessary code for handling all the asynchronous
                exceptions triggered from the execution of command groups on a

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -34,8 +34,16 @@
 
 \newglossaryentry{async-handler}
 {
-  name={\texttt{async\_handler}},
-  % Add a sorting key to counter-act the name full of LaTeX formatting
+  % Do not use this because it looks like MacOS X Preview 10.1
+  % (944.6.16.1) cannot search it
+  % name={\texttt{async\_handler}},
+  %
+  % This one seems better on Mac. But Safari 12.1.1 (14607.2.6.1.1)
+  % has still some problems
+  % in both cases to find all the 43 occurrences. Actually 33 are found
+  % forward and 10 found backward... I find this... awkward :-(
+  name={\texttt{async\string_handler}},
+  % Add a sorting key to counter-act the LaTeX formatting
   sort=async-handler,
   description={An asynchronous error handler object is a function class instance
                providing necessary code for handling all the asynchronous

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -1,5 +1,11 @@
 %\chapter{Glossary}
 
+
+% \todo 2019/06/10
+% Look at the remaining \keyword macro in the document and add the
+% lacking entries here
+
+
 %The purpose of this glossary is to define the key concepts involved in
 %specifying OpenCL SYCL. This section includes definitions of terminology used
 %throughout the specification document.
@@ -259,7 +265,7 @@
                three-dimensional structured array. The \gls{sycl-runtime} will make
                available images in OpenCL contexts in order to execute
                semantically correct kernels in different OpenCL contexts.
-               For the full description please refer to section [\ref{id-class}]}
+               For the full description please refer to section [\ref{subsec:images}]}
 }
 
 \newglossaryentry{implementation-defined}
@@ -310,7 +316,7 @@
   name=kernel,
   description={A SYCL kernel which can be executed on a \gls{device},
   including the \gls{host-device}. Is created implicitly when defining a
-  \gls{sycl-kernel-function} (See~\ref{sec:expr-parall-thro}) but can also be
+  \gls{sycl-kernel-function} (see~\ref{sec:expr-parall-thro}) but can also be
   created manually in order to pre-compile \glspl{sycl-kernel-function}}
 }
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3718,7 +3718,7 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 \startTable{Constructor}
     \addFootNotes{Constructors of the \codeinline{stream} class}{table.constructors.stream}
   \addRow
-    {stream(size\_t bufferSize, size\_t maxStatementSize, handler\& cgh)}
+    {stream(size_t bufferSize, size_t maxStatementSize, handler\& cgh)}
     {
       Constructs a SYCL \codeinline{stream} instance associated with the command group specified by \codeinline{cgh}, with a maximum buffer size specified by the parameter \codeinline{bufferSize} and a maximum statement size specified by the parameter \codeinline{maxStatementSize}.
     }

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -985,8 +985,8 @@ descriptor.}
 \label{sec:data.access.and.storage}
 
 In SYCL, data storage and access are handled by separate classes.
-\keyword{Buffers} and \keyword{images} handle
-storage and ownership of the data, whereas \keyword{\glspl{accessor}} handle access to
+\Glspl{buffer} and \glspl{image} handle
+storage and ownership of the data, whereas \glspl{accessor} handle access to
 the data. Buffers and images in SYCL are different from OpenCL buffers and images
 in that they can be bound to more than one device or context and they get
 destroyed when they go out-of-scope. They also handle ownership of the
@@ -2872,10 +2872,10 @@ is not handled, the application will exit abnormally.
 If an error occurs when running or enqueuing a command group which has
 a secondary queue specified, then the command group may be enqueued
 to the secondary queue instead of the primary queue. The error handling in this
-case is also configured using the \keyword{async_handler} provided for both
-queues. If there is no \keyword{async_handler} given on any of the queues,
+case is also configured using the \gls{async-handler} provided for both
+queues. If there is no \gls{async-handler} given on any of the queues,
 then no asynchronous error reporting is done and no exceptions are thrown. If
-the primary queue fails and there is an \keyword{async_handler} given at
+the primary queue fails and there is an \gls{async-handler} given at
 this queue's construction, which populates the \codeinline{exception_list}
 parameter, then any errors will be added and can be thrown whenever the user
 chooses to handle those exceptions. Since there were errors on the primary
@@ -2883,7 +2883,7 @@ queue and a secondary queue was given, then the execution of the kernel is
 re-scheduled to the secondary queue and any error reporting for the kernel
 execution on that queue is done through that queue, in the same way as
 described above. The secondary queue may fail as well, and the errors will be
-thrown if there is an \keyword{async_handler} and either
+thrown if there is an \gls{async-handler} and either
 \codeinline{wait_and_throw()} or \codeinline{throw()} are called on that queue.
 The \gls{command-group-function-object} event returned by that function will be
 relevant to the queue where the kernel has been enqueued.

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -220,7 +220,7 @@ Tables~\ref{table.specialmembers.common.reference} and
     {  typename info::param_traits}
     {  <info::queue, param>::return_type}
     {  get_info ()  const}
-    {Queries the platform for \keyword{cl_command_queue_info}}
+    {Queries the platform for \codeinline{cl_command_queue_info}}
   \addRowTwoL
     {template <typename T>}
     {event submit(T cgf)}

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -203,7 +203,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       in the queue.  Synchronous errors will be reported via SYCL
       exceptions. Asynchronous errors will be passed to the
       \gls{async-handler} passed to the queue on
-      construction. If no \codeinline{async\_handler} was provided then
+      construction. If no \codeinline{async_handler} was provided then
       asynchronous exceptions will be lost.
     }
   \addRow
@@ -212,14 +212,14 @@ Tables~\ref{table.specialmembers.common.reference} and
       Checks to see if any asynchronous errors have been produced by
       the queue and if so reports them by passing them to the
       \gls{async-handler} passed to the queue on
-      construction. If no \codeinline{async\_handler} was provided then
+      construction. If no \codeinline{async_handler} was provided then
       asynchronous exceptions will be lost.
     }
   \addRowFourL
     { template <info::queue param> }
     {  typename info::param_traits}
     {  <info::queue, param>::return_type}
-    {  get\_info ()  const}
+    {  get_info ()  const}
     {Queries the platform for \keyword{cl_command_queue_info}}
   \addRowTwoL
     {template <typename T>}

--- a/latex/sycl_explicit_memory.tex
+++ b/latex/sycl_explicit_memory.tex
@@ -10,17 +10,17 @@ OpenCL host API (e.g, enqueue copy operations).
 
 The SYCL memory objects involved in a copy operation are specified using
 accessors.
-Explicit copy operations have a source and a destination. 
+Explicit copy operations have a source and a destination.
 When an accessor is the \textit{source} of the operation, the destination can be 
-a host pointer or another accessor. 
-The \textit{source} accessor can have either  \textbf{read} or \textbf{read\_write} access 
-mode. 
+a host pointer or another accessor.
+The \textit{source} accessor can have either \codeinline{read} or
+\codeinline{read_write} access mode.
 
 When an accessor is the \textit{destination} of the explicit copy operation,
 the source can be a host pointer or another accessor.
-The \textit{destination} accessor can have either 
-\textbf{write}, \textbf{read\_write}, \textbf{discard\_write}, 
-\textbf{discard\_read\_write} access modes.
+The \textit{destination} accessor can have either
+\codeinline{write}, \codeinline{read_write}, \codeinline{discard_write},
+\codeinline{discard_read_write} access modes.
 
 When accessors are both the origin and the destination,
 the operation is executed on objects controlled by the SYCL runtime.
@@ -117,3 +117,11 @@ contents of the buffer on the device unchanged.
 
 \lstinputlisting{code/explicitcopy.cpp}
 
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: "sycl-1.2.1"
+%%% TeX-auto-untabify: t
+%%% TeX-PDF-mode: t
+%%% ispell-local-dictionary: "american"
+%%% End:

--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -127,14 +127,14 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     { template<int... swizzleIndexes> }
     {\__swizzled_vec__ swizzle() const}
     {
-      Return an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Return an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
     }
   \addRow
     {\__swizzled_vec__ XYZW_ACCESS() const}
     {
       Available only when \codeinline{numElements <= 4}.
       \newline \newline
-      Returns an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
       \newline \newline
       Where \codeinline{XYZW_ACCESS} is: \codeinline{x} for \codeinline{numElements == 1}, \codeinline{x, y} for \codeinline{numElements == 2}, \codeinline{x, y, z} for \codeinline{numElements == 3} and \codeinline{x, y, z, w} for \codeinline{numElements == 4}.
     }
@@ -143,14 +143,14 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     {
       Available only when \codeinline{numElements == 4}.
       \newline \newline
-      Returns an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
       \newline \newline
       Where \codeinline{RGBA_ACCESS} is: \codeinline{r, g, b, a}.
     }
   \addRow
     {\__swizzled_vec__ INDEX_ACCESS() const}
     {
-      Returns an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in~\ref{swizzled-vec-class}.
       \newline \newline
       Where \codeinline{INDEX_ACCESS} is: \codeinline{s0} for \codeinline{numElements == 1}, \codeinline{s0, s1} for \codeinline{numElements == 2}, \codeinline{s0, s1, s2} for \codeinline{numElements == 3}, \codeinline{s0, s1, s2, s3} for \codeinline{numElements == 4}, \codeinline{s0, s1, s2, s3, s4, s5, s6, s7, s8} for \codeinline{numElements == 8} and \codeinline{s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF} for \codeinline{numElements == 16}.
     }
@@ -159,7 +159,7 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     {
       Available only when \codeinline{numElements <= 4}, and when the macro \codeinline{SYCL_SIMPLE_SWIZZLES} is defined before including \codeinline{cl/sycl.hpp}.
       \newline \newline
-      Returns an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in~\ref{swizzled-vec-class}.
     \newline \newline
     Where XYZW\_SWIZZLE is all permutations with repetition of \codeinline{x, y} for \codeinline{numElements == 2}, \codeinline{x, y, z} for \codeinline{numElements == 3} and \codeinline{x, y, z, w} for \codeinline{numElements == 4}. For example \codeinline{xzyw} and \codeinline{xyyy}.
     }
@@ -168,7 +168,7 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     {
       Available only when \codeinline{numElements == 4}, and when the macro \codeinline{SYCL_SIMPLE_SWIZZLES} is defined before including \codeinline{cl/sycl.hpp}.
       \newline \newline
-      Returns an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
+      Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
     \newline \newline
     Where RGBA\_SWIZZLE is all permutations with repetition of \codeinline{r, g, b, a}. For example \codeinline{bgra} and \codeinline{rrba}.
     }
@@ -176,25 +176,25 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     {\__swizzled_vec__ lo() const}
     {
       Available only when: \codeinline{numElements > 1}.
-      Return an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence made up of the lower half of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
+      Return an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence made up of the lower half of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
     }
   \addRow
     {\__swizzled_vec__ hi() const}
     {
       Available only when: \codeinline{numElements > 1}.
-      Return an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence made up of the upper half of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
+      Return an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence made up of the upper half of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
     }
   \addRow
     {\__swizzled_vec__ odd() const}
     {
       Available only when: \codeinline{numElements > 1}.
-      Return an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence made up of the odd indexes of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
+      Return an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence made up of the odd indexes of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
     }    
   \addRow
     {\__swizzled_vec__ even() const}
     {
       Available only when: \codeinline{numElements > 1}.
-      Return an instance of the implementation defined intermediate class template \codeinline{\_\_swizzled_vec\_\_} representing an index sequence made up of the even indexes of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
+      Return an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence made up of the even indexes of this SYCL vec which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}. When \codeinline{numElements == 3} this SYCL \codeinline{vec} is treated as though \codeinline{numElements == 4} with the fourth element undefined.
     }
   \addRowTwoL
   {template <access::address_space addressSpace>}
@@ -632,3 +632,12 @@ SYCL \codeinline{vec} is loaded differs between big-endian and little-endian.
 
 Users should consult vendor documentation for guidance on how to handle kernel
 arguments in these situations.
+
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: "sycl-1.2.1"
+%%% TeX-auto-untabify: t
+%%% TeX-PDF-mode: t
+%%% ispell-local-dictionary: "american"
+%%% End:


### PR DESCRIPTION
This is a try to fix https://github.com/KhronosGroup/SYCL-Docs/issues/3

Replace most of the `\keyword` by `\codeinline` or `\gls`-like glossaries

This fix some wrong typing in the sense of computer programming.
It fixes also a lot of typesetting problems, such as PDF search due to
wrong "_" rendering.
The remaining \keyword is some technical debt about creating new
glossary entries in the specification.

Do not use `\textbf` for keywords.

The "_" are replaced by space in the PDF search otherwise...
Use `\codeinline` as expected instead.

Remove useless `\_` and fix some typesetting

A lot of escaping of `_` were actually useless and might cause some
trouble in the PDF output.

Use correct typesetting of `async_handler` in the glossary.

This makes the "_" to be searchable.

Now there are 43 instances of `async_handler` found.

Improve `async_handler` glossary encoding for MacOS X Preview search.

On the crazy part on Mac OS X:
- MacOS X Preview 10.1 (944.6.16.1) finds the 43 instances, but when I change the PDF in its back, it just crashes;
- Safari 12.1.1 (14607.2.6.1.1) can somehow find all the 43 occurrences, but actually 33 are found while searching forward while 10 are found while searching backward... :-( I find this... awkward :-) I would like to program this bug, I would not know how to do it... :-(

If there are people using Mac OS X who want to open some bug reports, go for it.