### PR TITLE
Define cl::sycl::local_accessor which is already mentioned in the spec text

### DIFF
--- a/latex/headers/accessorLocal.h
+++ b/latex/headers/accessorLocal.h
@@ -50,5 +50,11 @@ class accessor {
   /* Available only when: accessTarget == access::target::local */
   local_ptr<dataT> get_pointer() const;
 };
+
+/* Alias to make local memory accessors less verbose */
+template <typename dataT, int dimensions = 1>
+using local_accessor = accessor<dataT, dimensions, access::mode::read_write
+  access::target::local>;
+
 }  // namespace sycl
 }  // namespace cl

--- a/latex/headers/accessorLocal.h
+++ b/latex/headers/accessorLocal.h
@@ -53,7 +53,7 @@ class accessor {
 
 /* Alias to make local memory accessors less verbose */
 template <typename dataT, int dimensions = 1>
-using local_accessor = accessor<dataT, dimensions, access::mode::read_write
+using local_accessor = accessor<dataT, dimensions, access::mode::read_write,
   access::target::local>;
 
 }  // namespace sycl


### PR DESCRIPTION
`cl::sycl::local_accessor` is mentioned in the spec text (1.2.1 s3.5.2.1):

> To allocate local memory within a kernel, the user can either pass a cl::sycl::local_accessor object to the
kernel as a parameter, or can define a variable in workgroup scope inside cl::sycl::parallel_for_work_group.

`local_accessor` isn't actually defined anywhere, though, so it isn't clear how to use it.

This change defines it as a type alias in the local accessor section.  Presumably implementations are already defining this, but it needs to be in the spec for uniformity.

Code is simplified for example from:

```c++
accessor<int, 1, access::mode::read_write, access::target::local> lmem_acc(range<1>(128), cgh);
```

to:

```c++
local_accessor<int> lmem_acc(range<1>(128), cgh);
```

Assuming that this is accepted to merge, I'll add CTS checks for the alias.