### PR TITLE
Remove incorrect coordT types in image accessor samplerless read method

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1036,9 +1036,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       access::mode::read}.
       \newline
       Reads and returns an element of the image at the coordinates specified by \codeinline{coords}. Permitted types for \codeinline{coordT} are \codeinline{
-      cl_int} and \codeinline{cl_float} when \codeinline{dimensions == 1}, \codeinline{cl_int2} and \codeinline{cl_float2} when \codeinline{dimensions ==
-      2} and \codeinline{cl_int4} and \codeinline{cl_float4} when \codeinline{
-      dimensions == 3}.
+      cl_int} when \codeinline{dimensions == 1}, \codeinline{cl_int2} when \codeinline{dimensions ==
+      2} and \codeinline{cl_int4} when \codeinline{dimensions == 3}.
     }
   \addRowTwoSL
     { template <typename coordT> }


### PR DESCRIPTION
Signed-off-by: James Brodman <james.brodman@intel.com>