### PR TITLE
Clarify that image and image accessor get_size() returns the same res…

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1019,8 +1019,10 @@ Tables~\ref{table.specialmembers.common.reference} and
   \addRow
     { size_t get_size() const }
     {
-      Returns the size in bytes of the SYCL \codeinline{image} this SYCL
-      \codeinline{accessor} is accessing.
+      Returns the size in bytes of the SYCL \codeinline{image} that this SYCL
+      \codeinline{accessor} is accessing.  This must return the same result as
+      calling \codeinline{get_size()} on the \codeinline{image} associated with this
+      \codeinline{accessor}.
     }
   \addRow
     { size_t get_count() const }


### PR DESCRIPTION
…ult.

Signed-off-by: James Brodman <james.brodman@intel.com>