### PR TITLE
Host kernel return type restriction into the restrictions section

### DIFF
--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -96,9 +96,9 @@ The following restrictions are applied to device functions and kernels:
     allocate storage are permitted.
   \item
     Kernel functions must always have a \codeinline{void} return type.  A kernel lambda
-    trailing-return-type that is not void is therefore illegal, as is a return statement
+    trailing-return-type that is not \codeinline{void} is therefore illegal, as is a return statement
     (that would return from the kernel function) with an expression that does not convert
-    to void.
+    to \codeinline{void}.
   \item
     The odr-use of polymorphic classes and classes with virtual inheritance is allowed.
     However, no virtual member functions are allowed to be called in a SYCL kernel or any functions called by the kernel.

--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -95,6 +95,11 @@ The following restrictions are applied to device functions and kernels:
     \codeinline{new} operator and any user-defined overloads that do not
     allocate storage are permitted.
   \item
+    Kernel functions must always have a \codeinline{void} return type.  A kernel lambda
+    trailing-return-type that is not void is therefore illegal, as is a return statement
+    (that would return from the kernel function) with an expression that does not convert
+    to void.
+  \item
     The odr-use of polymorphic classes and classes with virtual inheritance is allowed.
     However, no virtual member functions are allowed to be called in a SYCL kernel or any functions called by the kernel.
   \item


### PR DESCRIPTION
The kernel return type requirement (must be void) is written in text form in the middle of a spec paragraph, but isn't easy to find.  This change adds it also to the list of kernel function restrictions, and mentions what to avoid to not violate the restriction.