### PR TITLE
Remove get_size() for image accessors and add missing get_range() definitions

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1057,8 +1057,25 @@ Tables~\ref{table.specialmembers.common.reference} and
       Returns the number of elements of the SYCL \codeinline{image} this SYCL \codeinline{accessor} is accessing.
     }
   \addRow
+    { range<dimensions+1> get_range() const }
+    {
+      Available only when:
+      \codeinline{accessTarget == access::target::image_array)}.
+      \newline
+      Returns a \codeinline{range} object which represents the number of
+      elements of \codeinline{dataT} per dimension that this
+      \codeinline{accessor} may access.
+      \newline
+      The \codeinline{range} object returned must equal to the
+      \codeinline{range} of the \codeinline{image} this \codeinline{accessor}
+      is associated with.
+    }
+  \addRow
     { range<dimensions> get_range() const }
     {
+      Available only when:
+      \codeinline{accessTarget != access::target::image_array)}.
+      \newline
       Returns a \codeinline{range} object which represents the number of
       elements of \codeinline{dataT} per dimension that this
       \codeinline{accessor} may access.

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1017,12 +1017,6 @@ Tables~\ref{table.specialmembers.common.reference} and
     image specialization}
   {table.members.accessor.image}
   \addRow
-    { size_t get_size() const }
-    {
-      Returns the size in bytes of the SYCL \codeinline{image} this SYCL
-      \codeinline{accessor} is accessing.
-    }
-  \addRow
     { size_t get_count() const }
     {
       Returns the number of elements of the SYCL \codeinline{image} this SYCL \codeinline{accessor} is accessing.

--- a/latex/headers/accessorImage.h
+++ b/latex/headers/accessorImage.h
@@ -42,7 +42,13 @@ class accessor {
 
   size_t get_count() const;
 
+  /* Available only when: (accessTarget !=
+  access::target::image_array) */
   range<dimensions> get_range() const;
+
+  /* Available only when: (accessTarget ==
+  access::target::image_array) */
+  range<dimensions+1> get_range() const;
 
   /* Available only when: (accessTarget == access::target::image && 
   accessMode == access::mode::read) || (accessTarget ==

--- a/latex/headers/accessorImage.h
+++ b/latex/headers/accessorImage.h
@@ -26,8 +26,6 @@ class accessor {
 
   /* -- common interface members -- */
 
-  size_t get_size() const;
-
   size_t get_count() const;
 
   /* Available only when: (accessTarget == access::target::image && 


### PR DESCRIPTION
This pull request proposes that we remove the `get_size()` member function for image accessors as it cannot be efficiently implemented within device code since OpenCL does not make any guarantees as to the position and padding of the elements of an image in device memory.

This change also adds missing `get_range` definitions for image and local accessors, and introduces an improved wording for all `get_range` definitions.

This pull request, if approved will replace https://github.com/KhronosGroup/SYCL-Docs/pull/27.