### PR TITLE
Clarify wording for simple swizzle member functions

### DIFF
--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -161,7 +161,7 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
       \newline \newline
       Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in~\ref{swizzled-vec-class}.
     \newline \newline
-    Where XYZW\_SWIZZLE is all permutations with repetition of \codeinline{x, y} for \codeinline{numElements == 2}, \codeinline{x, y, z} for \codeinline{numElements == 3} and \codeinline{x, y, z, w} for \codeinline{numElements == 4}. For example \codeinline{xzyw} and \codeinline{xyyy}.
+      Where XYZW\_SWIZZLE is all permutations with repetition, of any subset with length greater than \codeinline{1}, of \codeinline{x, y} for \codeinline{numElements == 2}, \codeinline{x, y, z} for \codeinline{numElements == 3} and \codeinline{x, y, z, w} for \codeinline{numElements == 4}. For example a four element \codeinline{vec} provides permutations including \codeinline{xzyw}, \codeinline{xyyy} and \codeinline{xz}.
     }
   \addRow
     {\__swizzled_vec__ RGBA_SWIZZLE() const}
@@ -170,7 +170,8 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
       \newline \newline
       Returns an instance of the implementation defined intermediate class template \codeinline{\__swizzled_vec__} representing an index sequence which can be used to apply the swizzle in a valid expression as described in \ref{swizzled-vec-class}.
     \newline \newline
-    Where RGBA\_SWIZZLE is all permutations with repetition of \codeinline{r, g, b, a}. For example \codeinline{bgra} and \codeinline{rrba}.
+    Where RGBA\_SWIZZLE is all permutations with repetition, of any subset with length greater than \codeinline{1}, of \codeinline{r, g, b, a}.
+    For example a four element \codeinline{vec} provides permutations including \codeinline{rbga}, \codeinline{rggg} and \codeinline{rb}.
     }
   \addRow
     {\__swizzled_vec__ lo() const}


### PR DESCRIPTION
This pull request clarifies the wording of simple swizzle member functions to specify that swizzles can be of a size less than the original `vec`.

This should resolve #29.