### PR TITLE
Remove OpenCL interop for stream class

### DIFF
--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -90,7 +90,7 @@ For more details regarding these facilities and considerations for their use see
 \subsection{Common reference semantics}
 \label{sec:reference-semantics}
 
-Each of the following \gls{sycl-runtime} classes: \codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler}, \codeinline{accessor} and \codeinline{stream} must obey the following statements, where \codeinline{T} is the runtime class type:
+Each of the following \gls{sycl-runtime} classes: \codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler} and \codeinline{accessor} must obey the following statements, where \codeinline{T} is the runtime class type:
 
 \begin{itemize}
 


### PR DESCRIPTION
This pull request removes OpenCL interop support from the `stream` class as there is no suitable OpenCL C equivelant and enforcing one would cause problems for printf-based implementations of the `stream` class.