### PR TITLE
Fix accessor constructors: add allocator as part of buffer type

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -353,7 +353,7 @@ Tables~\ref{table.specialmembers.common.reference} and
   specialization}
 {table.constructors.accessor.buffer}
   \addRow
-    { accessor(buffer<dataT, 1> \&bufferRef) }
+    { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef) }
     {
       Available only when: \codeinline{((isPlaceholder ==
       access::placeholder::false_t \&\& accessTarget ==
@@ -369,7 +369,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       placeholder \codeinline{accessor}.
     }
   \addRowTwoL
-    { accessor(buffer<dataT, 1> \&bufferRef, }
+    { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef, }
     { handler \&commandGroupHandlerRef) }
     {
       Available only when: \codeinline{(isPlaceholder ==
@@ -383,7 +383,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       commandGroupHandlerRef}.
     }
   \addRow
-    { accessor(buffer<dataT, dimensions> \&bufferRef) }
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef) }
     {
       Available only when: \codeinline{((isPlaceholder ==
       access::placeholder::false_t \&\& accessTarget ==
@@ -399,7 +399,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       accessor}.
     }
   \addRowTwoL
-    { accessor(buffer<dataT, dimensions> \&bufferRef, }
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
     { handler \&commandGroupHandlerRef) }
     {
       Available only when: \codeinline{(isPlaceholder ==
@@ -412,7 +412,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef}.
     }
   \addRowThreeL
-    { accessor( buffer<dataT, dimensions> \&bufferRef, }
+    { accessor( buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
     { range<dimensions> accessRange, id<dimensions> }
     { accessOffset = \{\}) }
     {
@@ -430,7 +430,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       placeholder \codeinline{accessor}.
     }
   \addRowFourL
-    { accessor( buffer<dataT, dimensions> \&bufferRef, }
+    { accessor( buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
     { handler \&commandGroupHandlerRef, }
     { range<dimensions> accessRange, }
     { id<dimensions> accessOffset = \{\}) }

--- a/latex/headers/accessorBuffer.h
+++ b/latex/headers/accessorBuffer.h
@@ -13,36 +13,42 @@ class accessor {
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer))) && dimensions == 0 */
-  accessor(buffer<dataT, 1> &bufferRef);
+  template <typename AllocatorT>
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef);
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions == 0 */
-  accessor(buffer<dataT, 1> &bufferRef, handler &commandGroupHandlerRef);
+  template <typename AllocatorT>
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef, handler &commandGroupHandlerRef);
 
   /* Available only when: ((isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer))) && dimensions > 0 */
-  accessor(buffer<dataT, dimensions> &bufferRef);
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef);
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
-  accessor(buffer<dataT, dimensions> &bufferRef,
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
     handler &commandGroupHandlerRef);
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
-  accessor(buffer<dataT, dimensions> &bufferRef, range<dimensions> accessRange,
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef, range<dimensions> accessRange,
     id<dimensions> accessOffset = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
-  accessor(buffer<dataT, dimensions> &bufferRef,
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
     handler &commandGroupHandlerRef, range<dimensions> accessRange,
     id<dimensions> accessOffset = {});
 


### PR DESCRIPTION
This change allows accessors to be created to buffers which have an allocator other than the default AllocatorT.

The change aligns with what was already done for image accessors.