### PR TITLE
Rule of Zero for Common by-value semantics classes (Gitlab issue 260)

### DIFF
--- a/latex/acknowledgements.tex
+++ b/latex/acknowledgements.tex
@@ -23,6 +23,8 @@
 \item
     Brian Sumner, AMD
 \item
+    Nevin Liber, Argonne National Laboratory
+\item
     Anastasia Stulova, ARM
 \item
     Bal\'azs Keszthelyi, Broadcom

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -451,7 +451,7 @@
   description={For a given class, if at least one of the
   copy constructor, move constructor, copy assignment operator, move assignment operator or destructor
   is explicitly declared,
-  all of them should be explicity declared.
+  all of them should be explicity declared
   }
 }
 
@@ -461,7 +461,7 @@
   description={For a given class, if the
   copy constructor, move constructor, copy assignment operator, move assignment operator and destructor
   would all be inlined, public and defaulted,
-  none of them should be explicity declared.
+  none of them should be explicity declared
   }
 }
 

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -445,6 +445,26 @@
   )}
 }
 
+\newglossaryentry{rule-of-five}
+{
+  name={rule of five},
+  description={For a given class, if at least one of the
+  copy constructor, move constructor, copy assignment operator, move assignment operator or destructor
+  is explicitly declared,
+  all of them should be explicity declared.
+  }
+}
+
+\newglossaryentry{rule-of-zero}
+{
+  name={rule of zero},
+  description={For a given class, if the
+  copy constructor, move constructor, copy assignment operator, move assignment operator and destructor
+  would all be inlined, public and defaulted,
+  none of them should be explicity declared.
+  }
+}
+
 \newglossaryentry{smcp}
 {
   name={SMCP},

--- a/latex/headers/common-byval.h
+++ b/latex/headers/common-byval.h
@@ -5,15 +5,17 @@ class T {
   ...
 
  public:
-  T(const T &rhs) = default;
+  // Rule of Zero: the following five special member functions should not be explicitly declared
 
-  T(T &&rhs) = default;
+  // T(const T &rhs) = default;
 
-  T &operator=(const T &rhs) = default;
+  // T(T &&rhs) = default;
 
-  T &operator=(T &&rhs) = default;
+  // T &operator=(const T &rhs) = default;
 
-  ~T() = default;
+  // T &operator=(T &&rhs) = default;
+
+  // ~T() = default;
 
   bool operator==(const T &rhs) const;
 

--- a/latex/headers/common-byval.h
+++ b/latex/headers/common-byval.h
@@ -20,13 +20,9 @@ class T {
 
  public:
   // If any of the following five special member functions are not
-  
   // public, inline or defaulted, then all five of them should be
-    
   // explicitly declared (see rule of five).
-    
   // Otherwise, none of them should be explicitly declared
-    
   // (see rule of zero).
 
   // T(const T &rhs);

--- a/latex/headers/common-byval.h
+++ b/latex/headers/common-byval.h
@@ -19,17 +19,25 @@ class T {
   ...
 
  public:
-  // Rule of Zero: the following five special member functions should not be explicitly declared
+  // If any of the following five special member functions are not
+  
+  // public, inline or defaulted, then all five of them should be
+    
+  // explicitly declared (see rule of five).
+    
+  // Otherwise, none of them should be explicitly declared
+    
+  // (see rule of zero).
 
-  // T(const T &rhs) = default;
+  // T(const T &rhs);
 
-  // T(T &&rhs) = default;
+  // T(T &&rhs);
 
-  // T &operator=(const T &rhs) = default;
+  // T &operator=(const T &rhs);
 
-  // T &operator=(T &&rhs) = default;
+  // T &operator=(T &&rhs);
 
-  // ~T() = default;
+  // ~T();
 
   ...
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -187,7 +187,7 @@ Each of the following \gls{sycl-runtime} classes: \codeinline{id}, \codeinline{r
 
 Some \gls{sycl-runtime} classes will have additional behavior associated with copy, movement, assignment or destruction semantics. If these are specified they are in addition to those specified above unless stated otherwise.
 
-Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements.  If all of the special member functions are inlined, public and defaulted, none of them should be explicitly declared (Rule of Zero); otherwise, all of them should be explicitly declared (Rule of Five).
+Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements, following the \gls{rule-of-five} and \gls{rule-of-zero}.
 
 These common special member functions and hidden friend functions are described in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -187,13 +187,13 @@ Each of the following \gls{sycl-runtime} classes: \codeinline{id}, \codeinline{r
 
 Some \gls{sycl-runtime} classes will have additional behavior associated with copy, movement, assignment or destruction semantics. If these are specified they are in addition to those specified above unless stated otherwise.
 
-Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements, following the \gls{rule-of-five} and \gls{rule-of-zero}.
+Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements, following the \gls{rule-of-five} and the \gls{rule-of-zero}.
 
 These common special member functions and hidden friend functions are described in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \lstinputlistingSkipLicense{headers/common-byval.h}
 
-\startTable{Special member function}
+\startTable{Special member function \textit{(see \gls{rule-of-five} \& \gls{rule-of-zero})}}
 \addFootNotes{Common special member functions for by-value semantics}
 {table.specialmembers.common.byval}
   \addRow

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -179,7 +179,8 @@ Each of the following \gls{sycl-runtime} classes: \codeinline{id}, \codeinline{r
 
 Some \gls{sycl-runtime} classes will have additional behavior associated with copy, movement, assignment or destruction semantics. If these are specified they are in addition to those specified above unless stated otherwise.
 
-Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements.
+Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements.  If all of the special member functions are inlined, public and defaulted, none of them should be explicitly declared (Rule of Zero); otherwise, all of them should be explicitly declared (Rule of Five).
+
 
 These common special member functions and member functions are described in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -190,29 +190,29 @@ These common special member functions and member functions are described in Tabl
 \addFootNotes{Common special member functions for by-value semantics}
 {table.specialmembers.common.byval}
   \addRow
-    {T(const T \&rhs) = default}
+    {T(const T \&rhs);}
     {
-      Default copy constructor.  
+      Copy constructor.
     }
   \addRow
-    {T(T \&\&rhs) = default}
+    {T(T \&\&rhs);}
     {
-      Default move constructor.
+      Move constructor.
     }  
    \addRow
-   {T \&operator=(const T \&rhs) = default}
+   {T \&operator=(const T \&rhs);}
    {
-     Default copy assignment operator.
+     Copy assignment operator.
    }
    \addRow
-   {T \&operator=(T \&\&rhs) = default}
+   {T \&operator=(T \&\&rhs);}
    {
-     Default move assignment operator.
+     Move assignment operator.
    }
    \addRow
-   {\~T() = default}
+   {\~T();}
    {
-     Default destructor.
+     Destructor.
    }
 \completeTable
 


### PR DESCRIPTION
In section 4.3.3, we spell out that the five special member functions (copy/move constructor/assignment operator and destructor) are =default.  This violates the C++ Core Guideline C.20: If you can avoid defining default operations, do. We should use the Rule of Zero (and possibly recommend using the Rule of Five if any of them have to be explicitly declared).