### PR TITLE
Clarify matching of C++ fundamental types between host and device

### DIFF
--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -197,7 +197,7 @@ In a SYCL device compiler, the device definition of all standard C++ fundamental
 types from Table~\ref{table.types.fundamental} must match the host definition of those types, in both
 size and alignment. A device
 compiler may have this preconfigured so that it can match them based on the
-definitions of those types on the platform. Or there may be a necessity for a
+definitions of those types on the platform, or there may be a necessity for a
 device compiler command-line option to ensure the types are the same.
 
 The standard C++ fixed width types, e.g. \codeinline{int8_t},

--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -193,10 +193,9 @@ plus any extensions from the C++14 specification.
 %*******************************************************************************
 \section{Built-in scalar data types}
 \label{subsection:scalartypes}
-In a SYCL device compiler, the standard C++ fundamental types, including
-\codeinline{int}, \codeinline{short}, \codeinline{long},
-\codeinline{long long int} need to be configured so that the device
-definitions of those types match the host definitions of those types. A device
+In a SYCL device compiler, the device definition of all standard C++ fundamental
+types from Table~\ref{table.types.fundamental} must match the host definition of those types, in both
+size and alignment. A device
 compiler may have this preconfigured so that it can match them based on the
 definitions of those types on the platform. Or there may be a necessity for a
 device compiler command-line option to ensure the types are the same.


### PR DESCRIPTION
Remove incomplete list of types from paragraph (refer to table instead), and clarify meaning of "configured to match".