### PR TITLE
Issue259 hiddenfriends

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -340,7 +340,7 @@ Tables~\ref{table.constructors.accessor.buffer} and
 member functions and common member functions are listed in
 \ref{sec:reference-semantics} in
 Tables~\ref{table.specialmembers.common.reference} and
-\ref{table.members.common.reference}, respectively.
+\ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: accessor
 \lstinputlisting[captionpos=b,caption=Accessor class for buffers, label=accessor.buffer.interface]
@@ -717,7 +717,7 @@ Tables~\ref{table.constructors.accessor.local} and
 \ref{table.members.accessor.local} respectively. The additional common special
 member functions and common member functions are listed in
 \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and
-\ref{table.members.common.reference}, respectively.
+\ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: accessor
 \lstinputlisting[captionpos=b,caption=Accessor class for locals, label=accessor.local.interface]
@@ -969,7 +969,7 @@ Tables~\ref{table.constructors.accessor.image} and
 member functions and common member functions are listed in
 \ref{sec:reference-semantics} in
 Tables~\ref{table.specialmembers.common.reference} and
-\ref{table.members.common.reference}, respectively.
+\ref{table.hiddenfriends.common.reference}, respectively.
 
 \lstinputlisting[caption=Accessor interface for images,label=images.listing1]{headers/accessorImage.h}
 

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -26,7 +26,7 @@ The SYCL \codeinline{device} class provides the common reference semantics
 
 \subsubsection{Device interface}
 
-A synopsis of the SYCL \codeinline{device} class is provided below. The constructors, member functions and static member functions of the SYCL \codeinline{device} class are listed in Tables~\ref{table.constructors.device}, \ref{table.members.device} and \ref{table.staticmembers.device} respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+A synopsis of the SYCL \codeinline{device} class is provided below. The constructors, member functions and static member functions of the SYCL \codeinline{device} class are listed in Tables~\ref{table.constructors.device}, \ref{table.members.device} and \ref{table.staticmembers.device} respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 % Interface of the device class
 \lstinputlisting{headers/device.h}

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1728,7 +1728,7 @@ kernel object. The kernel information descriptor interface is described in%
 ~\ref{appendix.kernel.descriptors} and the description is in the
 Table~\ref{table.kernel.info}.
 
-The constructors and member functions of the SYCL \codeinline{kernel} class are listed in Tables~\ref{table.constructors.kernel} and \ref{table.members.kernel}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{kernel} class are listed in Tables~\ref{table.constructors.kernel} and \ref{table.members.kernel}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: kernel
 \lstinputlisting{headers/kernelWIP.h}
@@ -1923,7 +1923,7 @@ The SYCL \codeinline{program} class provides the common reference semantics
 \subsubsection{Program interface}
 
 A synopsis of the SYCL \codeinline{program} class is provided below. The constructors and member functions of the SYCL \codeinline{program} class are listed in Tables~\ref{table.constructors.program} and \ref{table.members.program} respectively. The additional common special member functions and common member functions are listed in
-\ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+\ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: program
 \lstinputlisting{headers/programWIP.h}

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -113,8 +113,16 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
     {
         Return the size of the range computed as dimension0*...*dimensionN.
     }
-  \addRow
-    { range<dimensions> operatorOP(const range<dimensions> \&rhs) const }
+
+\completeTable
+%-------------------------------------------------------------------------------
+
+%-------------------------------------------------------------------------------
+\startTable{Hidden friend function}
+\addFootNotes {Hidden friend functions of the SYCL \codeinline{range} class
+  template}{table.functions.range}
+    \addRow
+    { range operatorOP(const range \&lhs, const range \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
@@ -123,15 +131,15 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{range} class
-      template with the same dimensionality as this SYCL \codeinline{range},
+      template with the same dimensionality as \codeinline{lhs} \codeinline{range},
       where each element of the new SYCL \codeinline{range} instance is the
       result of an element-wise \codeinline{OP} operator between each element of
-      this SYCL \codeinline{range} and each element of the \codeinline{rhs}
+      \codeinline{lhs} \codeinline{range} and each element of the \codeinline{rhs}
       \codeinline{range}. If the operator returns a \codeinline{bool} the result
       is the cast to \codeinline{size_t}.
     }
   \addRow
-    { range<dimensions> operatorOP(const size_t \&rhs) const }
+    { range operatorOP(const range \&lhs, const size_t \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
@@ -140,7 +148,7 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{range} class
-      template with the same dimensionality as this SYCL \codeinline{range},
+      template with the same dimensionality as \codeinline{lhs} \codeinline{range},
       where each element of the new SYCL \codeinline{range} instance is the result
       of an element-wise \codeinline{OP} operator between each element of this
       SYCL \codeinline{range} and the \codeinline{rhs} \codeinline{size_t}. If
@@ -148,44 +156,35 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       \codeinline{size_t}.
     }
   \addRow
-    { range<dimensions> \&operatorOP(const range<dimensions> \&rhs) }
+    { range \&operatorOP(range \&lhs, const range \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=},\codeinline{
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
       >>=}, \codeinline{\&=}, \codeinline{|=}, \codeinline{^=}.
       \newline
-      Assigns each element of this SYCL \codeinline{range} instance with the
+      Assigns each element of \codeinline{lhs} \codeinline{range} instance with the
       result of an element-wise \codeinline{OP} operator between each element
-      of this SYCL \codeinline{range} and each element of the \codeinline{rhs}
-      \codeinline{range} and returns a reference to this SYCL \codeinline{
+      of \codeinline{lhs} \codeinline{range} and each element of the \codeinline{rhs}
+      \codeinline{range} and returns \codeinline{lhs} \codeinline{
       range}. If the operator returns a \codeinline{bool} the result is the cast
       to \codeinline{size_t}.
     }
   \addRow
-    { range<dimensions> \&operatorOP(const size_t \&rhs) }
+    { range \&operatorOP(range \&lhs, const size_t \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=},\codeinline{
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
       >>=}, \codeinline{\&=}, \codeinline{|=}, \codeinline{^=}.
       \newline
-      Assigns each element of this SYCL \codeinline{range} instance with the
+      Assigns each element of \codeinline{lhs} \codeinline{range} instance with the
       result of an element-wise \codeinline{OP} operator between each element
-      of this SYCL \codeinline{range} and the \codeinline{rhs} \codeinline{
-      size_t} and returns a reference to this SYCL \codeinline{range}. If the
+      of \codeinline{lhs} \codeinline{range} and the \codeinline{rhs} \codeinline{
+      size_t} and returns \codeinline{lhs} \codeinline{range}. If the
       operator returns a \codeinline{bool} the result is the cast to
       \codeinline{size_t}.
     }
-\completeTable
-%-------------------------------------------------------------------------------
-
-%-------------------------------------------------------------------------------
-\startTable{Non-member function}
-\addFootNotes {Non-member functions of the SYCL \codeinline{range} class
-  template}{table.functions.range}
-  \addRowThreeL
-    { template <int dimensions> }
-    { range<dimensions> operatorOP(const size_t \&lhs, }
-    { const range<dimensions> \&rhs) }
+  \addRow
+    { range operatorOP(const size_t \&lhs, const range \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -372,9 +372,9 @@ tables of other classes. No actual interface change.}
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{id} class
-      template with the same dimensionality as this SYCL \codeinline{id}, where
+      template with the same dimensionality as \codeinline{lhs} \codeinline{id}, where
       each element of the new SYCL \codeinline{id} instance is the result of an
-      element-wise \codeinline{OP} operator between each element of this SYCL
+      element-wise \codeinline{OP} operator between each element of \codeinline{lhs}
       \codeinline{id} and each element of the \codeinline{rhs} \codeinline{id}.
       If the operator returns a \codeinline{bool} the result is the cast to
       \codeinline{size_t}.
@@ -389,9 +389,9 @@ tables of other classes. No actual interface change.}
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{id} class
-      template with the same dimensionality as this SYCL \codeinline{id}, where
+      template with the same dimensionality as \codeinline{lhs} \codeinline{id}, where
       each element of the new SYCL \codeinline{id} instance is the result of an
-      element-wise \codeinline{OP} operator between each element of this SYCL
+      element-wise \codeinline{OP} operator between each element of \codeinline{lhs}
       \codeinline{id} and the \codeinline{rhs} \codeinline{size_t}. If the
       operator returns a \codeinline{bool} the result is the cast to
       \codeinline{size_t}.
@@ -403,10 +403,10 @@ tables of other classes. No actual interface change.}
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
       >>=}, \codeinline{\&=}, \codeinline{|=}, \codeinline{^=}.
       \newline
-      Assigns each element of this SYCL \codeinline{id} instance with the
+      Assigns each element of \codeinline{lhs} \codeinline{id} instance with the
       result of an element-wise \codeinline{OP} operator between each element
-      of this SYCL \codeinline{id} and each element of the \codeinline{rhs}
-      \codeinline{id} and returns a reference to this SYCL \codeinline{id}. If
+      of \codeinline{lhs} \codeinline{id} and each element of the \codeinline{rhs}
+      \codeinline{id} and returns \codeinline{lhs} \codeinline{id}. If
       the operator returns a \codeinline{bool} the result is the cast to
       \codeinline{size_t}.
     }
@@ -417,10 +417,10 @@ tables of other classes. No actual interface change.}
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
       >>=}, \codeinline{\&=}, \codeinline{|=}, \codeinline{^=}.
       \newline
-      Assigns each element of this SYCL \codeinline{id} instance with the
+      Assigns each element of \codeinline{lhs} \codeinline{id} instance with the
       result of an element-wise \codeinline{OP} operator between each element
-      of this SYCL \codeinline{id} and the \codeinline{rhs} \codeinline{size_t}
-      and returns a reference to this SYCL \codeinline{id}. If the operator
+      of \codeinline{lhs} \codeinline{id} and the \codeinline{rhs} \codeinline{size_t}
+      and returns \codeinline{lhs} \codeinline{id}. If the operator
       returns a \codeinline{bool} the result is the cast to \codeinline{size_t}.
     }
 

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -355,8 +355,15 @@ tables of other classes. No actual interface change.}
         Return the value of the requested dimension of the \codeinline{id}
         object.
     }
+\completeTable
+%-------------------------------------------------------------------------------
+
+%-------------------------------------------------------------------------------
+\startTable{Hidden friend function}
+\addFootNotes{Hidden friend functions of the \codeinline{id} class template}
+{table.functions.id}
   \addRow
-    { id<dimensions> operatorOP(const id<dimensions> \&rhs) const }
+    { id operatorOP(const id \&lhs, const id \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
@@ -373,7 +380,7 @@ tables of other classes. No actual interface change.}
       \codeinline{size_t}.
     }
   \addRow
-    { id<dimensions> operatorOP(const size_t \&rhs) const }
+    { id operatorOP(const id \&lhs, const size_t \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
@@ -390,7 +397,7 @@ tables of other classes. No actual interface change.}
       \codeinline{size_t}.
     }
   \addRow
-    { id<dimensions> \&operatorOP(const id<dimensions> \&rhs) }
+    { id \&operatorOP(id \&lhs, const id \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=},\codeinline{
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
@@ -404,7 +411,7 @@ tables of other classes. No actual interface change.}
       \codeinline{size_t}.
     }
   \addRow
-    { id<dimensions> \&operatorOP(const size_t \&rhs) }
+    { id \&operatorOP(id \&lhs, const size_t \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=},\codeinline{
       *=}, \codeinline{/=}, \codeinline{\%=}, \codeinline{<<=}, \codeinline{
@@ -416,17 +423,9 @@ tables of other classes. No actual interface change.}
       and returns a reference to this SYCL \codeinline{id}. If the operator
       returns a \codeinline{bool} the result is the cast to \codeinline{size_t}.
     }
-\completeTable
-%-------------------------------------------------------------------------------
 
-%-------------------------------------------------------------------------------
-\startTable{Non-member function}
-\addFootNotes{Non-member functions of the \codeinline{id} class template}
-{table.functions.id}
-  \addRowThreeL
-    { template <int dimensions> }
-    { id<dimensions> operatorOP(const size_t \&lhs, }
-    { const id<dimensions> \&rhs }
+  \addRow
+    { id operatorOP(const size_t \&lhs, const id \&rhs) }
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -53,7 +53,7 @@ constructed from integers.
 The SYCL \codeinline{range} class template provides the common by-value
 semantics (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{range} class is provided below. The constructors, member functions and non-member functions of the SYCL \codeinline{range} class are listed in Tables~\ref{table.constructors.id}, \ref{table.members.range} and \ref{table.functions.range} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{range} class is provided below. The constructors, member functions and non-member functions of the SYCL \codeinline{range} class are listed in Tables~\ref{table.constructors.id}, \ref{table.members.range} and \ref{table.functions.range} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \lstinputlisting{headers/range.h}
 
@@ -221,7 +221,7 @@ group.
 The SYCL \codeinline{nd_range} class template provides the common by-value
 semantics (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{nd_range} class is provided below. The constructors and member functions of the SYCL \codeinline{nd_range} class are listed in Tables~\ref{table.constructors.ndrange} and \ref{table.members.ndrange} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{nd_range} class is provided below. The constructors and member functions of the SYCL \codeinline{nd_range} class are listed in Tables~\ref{table.constructors.ndrange} and \ref{table.members.ndrange} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \fixme{UPDATE: change parameter naming to match interface}
 %------------------------------------------------------------------------------------------------------
@@ -285,7 +285,7 @@ same rank. The \tf{[n]} operator returns the component \tf{n} as an
 The SYCL \codeinline{id} class template provides the common by-value semantics
 (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{id} class is provided below. The constructors, member functions and non-member functions of the SYCL \codeinline{id} class are listed in Tables~\ref{table.constructors.id}, \ref{table.members.id} and \ref{table.functions.id} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{id} class is provided below. The constructors, member functions and non-member functions of the SYCL \codeinline{id} class are listed in Tables~\ref{table.constructors.id}, \ref{table.members.id} and \ref{table.functions.id} respectively. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \lstinputlisting{headers/id.h}
 
@@ -465,7 +465,7 @@ The SYCL \codeinline{item} class template provides the common by-value semantics
 
 \subsubsection{Item interface}
 
-A synopsis of the SYCL \codeinline{item} class is provided below. The member functions of the SYCL \codeinline{item} class are listed in Table~\ref{table.members.id}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{item} class is provided below. The member functions of the SYCL \codeinline{item} class are listed in Table~\ref{table.members.id}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 %Interface for class: item
 \lstinputlisting{headers/item.h}
@@ -553,7 +553,7 @@ function object.
 The SYCL \codeinline{nd_item} class template provides the common by-value
 semantics (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{nd_item} class is provided below. The member functions of the SYCL \codeinline{nd_item} class are listed in Table~\ref{table.members.nditem}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{nd_item} class is provided below. The member functions of the SYCL \codeinline{nd_item} class are listed in Table~\ref{table.members.nditem}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 %interface for nd_item class
 \lstinputlisting{headers/nditem.h}
@@ -786,7 +786,7 @@ function object.
 The SYCL \codeinline{h_item} class template provides the common by-value
 semantics (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{h_item} class is provided below. The member functions of the SYCL \codeinline{h_item} class are listed in Table~\ref{table.members.hitem}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{h_item} class is provided below. The member functions of the SYCL \codeinline{h_item} class are listed in Table~\ref{table.members.hitem}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \lstinputlisting{headers/hitem.h}
 
@@ -934,7 +934,7 @@ executing work-group, even through the abstracted iteration range of the
 The SYCL \codeinline{group} class template provides the common by-value
 semantics (see Section~\ref{sec:byval-semantics}).
 
-A synopsis of the SYCL \codeinline{group} class is provided below. The member functions of the SYCL \codeinline{group} class are listed in Table~\ref{table.members.group}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+A synopsis of the SYCL \codeinline{group} class is provided below. The member functions of the SYCL \codeinline{group} class are listed in Table~\ref{table.members.group}. The additional common special member functions and common member functions are listed in \ref{sec:byval-semantics} in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 The \codeinline{group} class also provides the \codeinline{
 mem_fence} member function for performing a \gls{work-group-mem-fence}

--- a/latex/headers/common-byval.h
+++ b/latex/headers/common-byval.h
@@ -15,9 +15,11 @@ class T {
 
   ~T() = default;
 
-  bool operator==(const T &rhs) const;
+  ...
 
-  bool operator!=(const T &rhs) const;
+  friend bool operator==(const T &lhs, const T &rhs) { /* ... */ }
+
+  friend bool operator!=(const T &lhs, const T &rhs) { /* ... */ }
 
   ...
 };

--- a/latex/headers/common-reference.h
+++ b/latex/headers/common-reference.h
@@ -14,10 +14,12 @@ class T {
   T &operator=(T &&rhs);
 
   ~T();
+    
+  ...
 
-  bool operator==(const T &rhs) const;
+  friend bool operator==(const T &lhs, const T &rhs) { /* ... */ }
 
-  bool operator!=(const T &rhs) const;
+  friend bool operator!=(const T &lhs, const T &rhs) { /* ... */ }
 
   ...
 };

--- a/latex/headers/id.h
+++ b/latex/headers/id.h
@@ -25,16 +25,17 @@ public:
   size_t operator[](int dimension) const;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  id<dimensions> operatorOP(const id<dimensions> &rhs) const;
-  id<dimensions> operatorOP(const size_t &rhs) const;
+    friend id operatorOP(const id &lhs, const id &rhs) { /* ... */ }
+    friend id operatorOP(const id &lhs, const size_t &rhs) { /* ... */ }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-  id<dimensions> &operatorOP(const id<dimensions> &rhs);
-  id<dimensions> &operatorOP(const size_t &rhs);
+    friend id &operatorOP(id &lhs, const id &rhs) { /* ... */ }
+    friend id &operatorOP(id &lhs, const size_t &rhs) { /* ... */ }
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^
+    friend id operatorOP(const size_t &lhs, const id &rhs) { /* ... */ }
+
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^
-template <int dimensions>
-id<dimensions> operatorOP(const size_t &lhs, const id<dimensions> &rhs);
 }  // namespace sycl
 }  // namespace cl

--- a/latex/headers/multipointer.h
+++ b/latex/headers/multipointer.h
@@ -39,7 +39,7 @@ class multi_ptr {
   multi_ptr &operator=(pointer_t);
   multi_ptr &operator=(ElementType*);
   multi_ptr &operator=(std::nullptr_t);
-  ElementType& operator*() const;
+  friend ElementType& operator*(const multi_ptr& mp) { /* ... */ }
   ElementType* operator->() const;
 
   // Only if Space == global_space
@@ -72,12 +72,12 @@ class multi_ptr {
   operator multi_ptr<const ElementType, Space>() const;
 
   // Arithmetic operators
-  multi_ptr& operator++();
-  multi_ptr operator++(int);
-  multi_ptr& operator--();
-  multi_ptr operator--(int);
-  multi_ptr& operator+=(difference_type r);
-  multi_ptr& operator-=(difference_type r);
+  friend multi_ptr& operator++(multi_ptr& mp) { /* ... */ }
+  friend multi_ptr operator++(multi_ptr& mp, int) { /* ... */ }
+  friend multi_ptr& operator--(multi_ptr& mp) { /* ... */ }
+  friend multi_ptr operator--(multi_ptr& mp, int) { /* ... */ }
+  friend multi_ptr& operator+=(multi_ptr& lhs, difference_type r) { /* ... */ }
+  friend multi_ptr& operator-=(multi_ptr& lhs, difference_type r) { /* ... */ }
   friend multi_ptr operator+(const multi_ptr& lhs, difference_type r) { /* ... */ }
   friend multi_ptr operator-(const multi_ptr& lhs, difference_type r) { /* ... */ }
 

--- a/latex/headers/multipointer.h
+++ b/latex/headers/multipointer.h
@@ -78,10 +78,32 @@ class multi_ptr {
   multi_ptr operator--(int);
   multi_ptr& operator+=(difference_type r);
   multi_ptr& operator-=(difference_type r);
-  multi_ptr operator+(difference_type r) const;
-  multi_ptr operator-(difference_type r) const;
+  friend multi_ptr operator+(const multi_ptr& lhs, difference_type r) { /* ... */ }
+  friend multi_ptr operator-(const multi_ptr& lhs, difference_type r) { /* ... */ }
 
   void prefetch(size_t numElements) const;
+    
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+
 };
 
 // Specialization of multi_ptr for void and const void
@@ -140,6 +162,28 @@ class multi_ptr<VoidType, Space> {
 
   // Implicit conversion to multi_ptr<const void, Space>
   operator multi_ptr<const void, Space>() const;
+    
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
+
 };
 
 template <typename ElementType, access::address_space Space>
@@ -147,49 +191,6 @@ multi_ptr<ElementType, Space> make_ptr(multi_ptr<ElementType, Space>::pointer_t)
 
 template <typename ElementType, access::address_space Space>
 multi_ptr<ElementType, Space> make_ptr(ElementType*);
-
-template <typename ElementType, access::address_space Space>
-bool operator==(const multi_ptr<ElementType, Space>& lhs,
-                const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator!=(const multi_ptr<ElementType, Space>& lhs,
-                const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<(const multi_ptr<ElementType, Space>& lhs,
-               const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>(const multi_ptr<ElementType, Space>& lhs,
-               const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<=(const multi_ptr<ElementType, Space>& lhs,
-                const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>=(const multi_ptr<ElementType, Space>& lhs,
-                const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator!=(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator!=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator==(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator==(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>=(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator>=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<=(const multi_ptr<ElementType, Space>& lhs, std::nullptr_t rhs);
-template <typename ElementType, access::address_space Space>
-bool operator<=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>& rhs);
 
 }  // namespace sycl
 }  // namespace cl

--- a/latex/headers/range.h
+++ b/latex/headers/range.h
@@ -19,16 +19,17 @@ public:
   size_t size() const;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  range<dimensions> operatorOP(const range<dimensions> &rhs) const;
-  range<dimensions> operatorOP(const size_t &rhs) const;
+  friend range operatorOP(const range &lhs, const range &rhs) { /* ... */ }
+  friend range operatorOP(const range &lhs, const size_t &rhs) { /* ... */ }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-  range<dimensions> &operatorOP(const range<dimensions> &rhs);
-  range<dimensions> &operatorOP(const size_t &rhs);
+  friend range & operatorOP(const range &lhs, const range &rhs) { /* ... */ }
+  friend range & operatorOP(const range &lhs, const size_t &rhs) { /* ... */ }
+    
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^
+  friend range operatorOP(const size_t &lhs, const range &rhs) { /* ... */ }
+
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^
-template <int dimensions>
-range<dimensions> operatorOP(const size_t &lhs, const range<dimensions> &rhs);
 }  // sycl
 }  // cl

--- a/latex/headers/vec.h
+++ b/latex/headers/vec.h
@@ -115,90 +115,82 @@ class vec {
   // OP is: +, -, *, /, %
   /* When OP is % available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> operatorOP(const vec<dataT, numElements> &rhs) const;
-  vec<dataT, numElements> operatorOP(const dataT &rhs) const;
+  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec operatorOP(const vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: +=, -=, *=, /=, %=
   /* When OP is %= available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> &operatorOP(const vec<dataT, numElements> &rhs);
-  vec<dataT, numElements> &operatorOP(const dataT &rhs);
+  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec &operatorOP(vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: ++, --
-  vec<dataT, numElements> &operatorOP();
-  vec<dataT, numElements> operatorOP(int);
+  friend vec &operatorOP(vec &lhs) { /* ... */ }
+  friend vec operatorOP(vec& lhs, int) { /* ... */ }
 
   // OP is: &, |, ^
   /* Available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> operatorOP(const vec<dataT, numElements> &rhs) const;
-  vec<dataT, numElements> operatorOP(const dataT &rhs) const;
+  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec operatorOP(const vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: &=, |=, ^=
   /* Available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> &operatorOP(const vec<dataT, numElements> &rhs);
-  vec<dataT, numElements> &operatorOP(const dataT &rhs);
+  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec &operatorOP(vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: &&, ||
-  vec<RET, numElements> operatorOP(const vec<dataT, numElements> &rhs) const;
-  vec<RET, numElements> operatorOP(const dataT &rhs) const;
+  friend vec<RET, numElements> operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec<RET, numElements> operatorOP(const vec& lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: <<, >>
   /* Available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> operatorOP(const vec<dataT, numElements> &rhs) const;
-  vec<dataT, numElements> operatorOP(const dataT &rhs) const;
+  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec operatorOP(const vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: <<=, >>=
   /* Available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> &operatorOP(const vec<dataT, numElements> &rhs);
-  vec<dataT, numElements> &operatorOP(const dataT &rhs);
+  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec &operatorOP(vec &lhs, const dataT &rhs) { /* ... */ }
 
   // OP is: ==, !=, <, >, <=, >=
-  vec<RET, numElements> operatorOP(const vec<dataT, numElements> &rhs) const;
-  vec<RET, numElements> operatorOP(const dataT &rhs) const;
+  friend vec<RET, numElements> operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
+  friend vec<RET, numElements> operatorOP(const vec &lhs, const dataT &rhs) { /* ... */ }
 
   vec<dataT, numElements> &operator=(const vec<dataT, numElements> &rhs);
   vec<dataT, numElements> &operator=(const dataT &rhs);
 
   /* Available only when: dataT != cl_float && dataT != cl_double
   && dataT != cl_half. */
-  vec<dataT, numElements> operator~() const;
+  friend vec operator~(const vec &v) { /* ... */ }
+  friend vec<RET, numElements> operator!(const vec &v) { /* ... */ }
+  
+    
+  // OP is: +, -, *, /, %
+  /* operator% is only available when: dataT != cl_float && dataT != cl_double &&
+  dataT != cl_half. */
+  friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
 
-  vec<RET, numElements> operator!() const;
+  // OP is: &, |, ^
+  /* Available only when: dataT != cl_float && dataT != cl_double
+  && dataT != cl_half. */
+  friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
+    
+  // OP is: &&, ||
+  friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
+    
+  // OP is: <<, >>
+  /* Available only when: dataT != cl_float && dataT != cl_double
+  && dataT != cl_half. */
+  friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
+    
+  // OP is: ==, !=, <, >, <=, >=
+  friend vec<RET, numElements> operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
+
 };
 
-// OP is: +, -, *, /, %
-/* operator% is only available when: dataT != cl_float && dataT != cl_double &&
-dataT != cl_half. */
-template <typename dataT, int numElements>
-vec<dataT, numElements> operatorOP(const dataT &lhs,
-  const vec<dataT, numElements> &rhs);
-
-// OP is: &, |, ^
-/* Available only when: dataT != cl_float && dataT != cl_double
-  && dataT != cl_half. */
-template <typename dataT, int numElements>
-vec<dataT, numElements> operatorOP(const dataT &lhs,
-  const vec<dataT, numElements> &rhs);
-
-// OP is: &&, ||
-template <typename dataT, int numElements>
-vec<RET, numElements> operatorOP(const dataT &lhs,
-  const vec<dataT, numElements> &rhs);
-
-// OP is: <<, >>
-/* Available only when: dataT != cl_float && dataT != cl_double
-  && dataT != cl_half. */
-template <typename dataT, int numElements>
-vec<dataT, numElements> operatorOP(const dataT &lhs,
-    const vec<dataT, numElements> &rhs);
-
-// OP is: ==, !=, <, >, <=, >=
-template <typename dataT, int numElements>
-vec<RET, numElements> operatorOP(const dataT &lhs,
-    const vec<dataT, numElements> &rhs);
 }  // namespace sycl
 }  // namespace cl

--- a/latex/headers/vec.h
+++ b/latex/headers/vec.h
@@ -168,7 +168,6 @@ class vec {
   friend vec operator~(const vec &v) { /* ... */ }
   friend vec<RET, numElements> operator!(const vec &v) { /* ... */ }
   
-    
   // OP is: +, -, *, /, %
   /* operator% is only available when: dataT != cl_float && dataT != cl_double &&
   dataT != cl_half. */
@@ -180,7 +179,7 @@ class vec {
   friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
     
   // OP is: &&, ||
-  friend vec operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
+  friend vec<RET, numElements> operatorOP(const dataT &lhs, const vec &rhs) { /* ... */ }
     
   // OP is: <<, >>
   /* Available only when: dataT != cl_float && dataT != cl_double

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -152,12 +152,12 @@ These common special member functions and hidden friend functions are described 
 \addFootNotes{Common hidden friend functions for reference semantics}
 {table.hiddenfriends.common.reference}
    \addRow
-   {friend bool operator==(const T \&lhs, const T \&rhs)}
+   {bool operator==(const T \&lhs, const T \&rhs)}
    {
      Returns true if this LHS SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
    \addRow
-   {friend bool operator==(const T \&lhs, const T \&rhs)}
+   {bool operator==(const T \&lhs, const T \&rhs)}
    {
      Returns true if this LHS SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
@@ -222,12 +222,12 @@ These common special member functions and hidden friend functions are described 
 \addFootNotes{Common hidden friend functions for by-value semantics}
 {table.hiddenfriends.common.byval}
    \addRow
-   {friend bool operator==(const T \&lhs, const T \&rhs)}
+   {bool operator==(const T \&lhs, const T \&rhs)}
    {
      Returns true if this LHS SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
    \addRow
-   {friend bool operator!=(const T \&lhs, const T \&rhs)}
+   {bool operator!=(const T \&lhs, const T \&rhs)}
    {
      Returns true if this LHS SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -1,3 +1,4 @@
+
 % !TEX root = sycl-1.2.1.tex
 \def \debugging{false}
 
@@ -110,9 +111,9 @@ Some \gls{sycl-runtime} classes will have additional behavior associated with co
 
 Each of the runtime classes mentioned above must provide a common interface of special member functions in order to fulfil the copy, move, destruction requirements and hidden friend functions in order to fulfil the equality requirements.
 
-A hidden friend function is a function first declared via a friend declaration with no additional out of class or namespace scope declarations, because such functions are only visible to ADL (Argument Dependent Lookup) and are hidden from qualified and unqualified lookup.  (Hidden friend functions have the benefits of avoiding accidental implicit conversions and faster compilation.)
+A hidden friend function is a function first declared via a \codeinline{friend} declaration with no additional out of class or namespace scope declarations.  Hidden friend functions are only visible to ADL (Argument Dependent Lookup) and are hidden from qualified and unqualified lookup.  Hidden friend functions have the benefits of avoiding accidental implicit conversions and faster compilation.
 
-These common special member functions and member functions are described in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference} respectively.
+These common special member functions and hidden friend functions are described in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference} respectively.
 
 \lstinputlisting{headers/common-reference.h}
 
@@ -147,8 +148,8 @@ These common special member functions and member functions are described in Tabl
    }
 \completeTable
 
-\startTable{Hidden friend functions}
-\addFootNotes{Hidden friend functions for reference semantics}
+\startTable{Hidden friend function}
+\addFootNotes{Common hidden friend functions for reference semantics}
 {table.hiddenfriends.common.reference}
    \addRow
    {friend bool operator==(const T \&lhs, const T \&rhs)}
@@ -181,9 +182,9 @@ Each of the following \gls{sycl-runtime} classes: \codeinline{id}, \codeinline{r
 
 Some \gls{sycl-runtime} classes will have additional behavior associated with copy, movement, assignment or destruction semantics. If these are specified they are in addition to those specified above unless stated otherwise.
 
-Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements.
+Each of the runtime classes mentioned above must provide a common interface of special member functions in order to fulfil the copy, move, destruction requirements and hidden friend functions to satisfy the equality requirements.
 
-These common special member functions and member functions are described in Tables~\ref{table.specialmembers.common.byval} and \ref{table.members.common.byval} respectively.
+These common special member functions and hidden friend functions are described in Tables~\ref{table.specialmembers.common.byval} and \ref{table.hiddenfriends.common.byval} respectively.
 
 \lstinputlisting{headers/common-byval.h}
 
@@ -217,18 +218,18 @@ These common special member functions and member functions are described in Tabl
    }
 \completeTable
 
-\startTable{Member function}
-\addFootNotes{Common member functions for by-value semantics}
-{table.members.common.byval}
+\startTable{Hidden friend function}
+\addFootNotes{Common hidden friend functions for by-value semantics}
+{table.hiddenfriends.common.byval}
    \addRow
-   {bool operator==(const T \&rhs) const}
+   {friend bool operator==(const T \&lhs, const T \&rhs)}
    {
-     Returns true if this SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
+     Returns true if this LHS SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
    \addRow
-   {bool operator!=(const T \&rhs) const}
+   {friend bool operator!=(const T \&lhs, const T \&rhs)}
    {
-     Returns true if this SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
+     Returns true if this LHS SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
 \completeTable
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -2575,106 +2575,73 @@ compared to \codeinline{*this}.}
 \startTable{Non-member function}
 \addFootNotes{Non-member functions of the \codeinline{multi_ptr} class}
 {table.multipointer.nonmemberfunctions}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator==(const multi_ptr<ElementType, Space>\& lhs,}
-{                const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator==(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{==} for \codeinline{multi_ptr} class.}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator!=(const multi_ptr<ElementType, Space>\& lhs,}
-{                const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator!=(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{!=} for \codeinline{multi_ptr} class.}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<(const multi_ptr<ElementType, Space>\& lhs,}
-{               const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator<(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{<} for \codeinline{multi_ptr} class.}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>(const multi_ptr<ElementType, Space>\& lhs,}
-               {const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator>(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{>} for \codeinline{multi_ptr} class.}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<=(const multi_ptr<ElementType, Space>\& lhs,}
-{                const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator<=(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{<=} for \codeinline{multi_ptr} class.}
-\addRowThreeL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>=(const multi_ptr<ElementType, Space>\& lhs,}
-                {const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator>-=(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{>=} for \codeinline{multi_ptr} class.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator!=(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
-{Comparison operator \codeinline{!=} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
 
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator!=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
-{Comparison operator \codeinline{!=} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator==(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
+\addRow
+{bool operator==(const multi_ptr\& lhs, std::nullptr_t)}
 {Comparison operator \codeinline{==} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator==(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
-{Comparison operator \codeinline{==} for \codeinline{multi_ptr} class with a
+\addRow
+{bool operator!=(const multi_ptr\& lhs, std::nullptr_t)}
+{Comparison operator \codeinline{!=} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
-{Comparison operator \codeinline{>} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
-{Comparison operator \codeinline{>} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
+\addRow
+{bool operator<(const multi_ptr\& lhs, std::nullptr_t)}
 {Comparison operator \codeinline{<} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
-{Comparison operator \codeinline{<} for \codeinline{multi_ptr} class with a
+\addRow
+{bool operator>(const multi_ptr\& lhs, std::nullptr_t)}
+{Comparison operator \codeinline{>} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>=(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
+\addRow
+{bool operator<=(const multi_ptr\& lhs, std::nullptr_t)}
+{Comparison operator \codeinline{<=} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator>=(const multi_ptr\& lhs, std::nullptr_t)}
 {Comparison operator \codeinline{>=} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
 
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator>=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
+\addRow
+{bool operator==(std::nullptr_t, const multi_ptr\& rhs)}
+{Comparison operator \codeinline{==} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator!=(std::nullptr_t, const multi_ptr\& rhs)}
+{Comparison operator \codeinline{!=} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator<(std::nullptr_t, const multi_ptr\& rhs)}
+{Comparison operator \codeinline{<} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator>(std::nullptr_t, const multi_ptr\& rhs)}
+{Comparison operator \codeinline{>} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator<=(std::nullptr_t, const multi_ptr\& rhs)}
+{Comparison operator \codeinline{<=} for \codeinline{multi_ptr} class with a
+\codeinline{std::nullptr_t}.}
+\addRow
+{bool operator>=(std::nullptr_t, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{>=} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<=(const multi_ptr<ElementType, Space>\& lhs, std::nullptr_t rhs)}
-{Comparison operator \codeinline{<=} for \codeinline{multi_ptr} class with a
-\codeinline{std::nullptr_t}.}
-
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{bool operator<=(std::nullptr_t lhs, const multi_ptr<ElementType, Space>\& rhs)}
-{Comparison operator \codeinline{<=} for \codeinline{multi_ptr} class with a
 \codeinline{std::nullptr_t}.}
 
 \completeTable

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -108,9 +108,11 @@ Each of the following \gls{sycl-runtime} classes: \codeinline{device}, \codeinli
 
 Some \gls{sycl-runtime} classes will have additional behavior associated with copy, movement, assignment or destruction semantics. If these are specified they are in addition to those specified above unless stated otherwise.
 
-Each of the runtime classes mentioned above must provide a common interface of special member functions and member functions in order to fulfil the copy, move, destruction and equality requirements.
+Each of the runtime classes mentioned above must provide a common interface of special member functions in order to fulfil the copy, move, destruction requirements and hidden friend functions in order to fulfil the equality requirements.
 
-These common special member functions and member functions are described in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference} respectively.
+A hidden friend function is a function first declared via a friend declaration with no additional out of class or namespace scope declarations, because such functions are only visible to ADL (Argument Dependent Lookup) and are hidden from qualified and unqualified lookup.  (Hidden friend functions have the benefits of avoiding accidental implicit conversions and faster compilation.)
+
+These common special member functions and member functions are described in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference} respectively.
 
 \lstinputlisting{headers/common-reference.h}
 
@@ -145,18 +147,18 @@ These common special member functions and member functions are described in Tabl
    }
 \completeTable
 
-\startTable{Member function}
-\addFootNotes{Common member functions for reference semantics}
-{table.members.common.reference}
+\startTable{Hidden friend functions}
+\addFootNotes{Hidden friend functions for reference semantics}
+{table.hiddenfriends.common.reference}
    \addRow
-   {bool operator==(const T \&rhs) const}
+   {friend bool operator==(const T \&lhs, const T \&rhs)}
    {
-     Returns true if this SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
+     Returns true if this LHS SYCL \codeinline{T} is equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
    \addRow
-   {bool operator!=(const T \&rhs) const}
+   {friend bool operator==(const T \&lhs, const T \&rhs)}
    {
-     Returns true if this SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
+     Returns true if this LHS SYCL \codeinline{T} is not equal to the RHS SYCL \codeinline{T} in accordance with the requirements set out above, otherwise returns false.
    }
 \completeTable
 
@@ -491,7 +493,7 @@ The SYCL \codeinline{platform} class provides the common reference semantics
 
 \subsubsection{Platform interface}
 
-A synopsis of the SYCL \codeinline{platform} class is provided below. The constructors, member functions and static member functions of the SYCL \codeinline{platform} class are listed in Tables~\ref{table.constructors.platform}, \ref{table.members.platform} and \ref{table.staticmembers.platform} respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference} respectively.
+A synopsis of the SYCL \codeinline{platform} class is provided below. The constructors, member functions and static member functions of the SYCL \codeinline{platform} class are listed in Tables~\ref{table.constructors.platform}, \ref{table.members.platform} and \ref{table.staticmembers.platform} respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference} respectively.
 
 %Interface of platform class
 \lstinputlisting{headers/platform.h}
@@ -631,7 +633,7 @@ The SYCL \codeinline{context} class provides the common reference semantics
 
 \subsubsection{Context interface}
 
-The constructors and member functions of the SYCL \codeinline{context} class are listed in Tables~\ref{table.constructors.context} and \ref{table.members.context}, respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{context} class are listed in Tables~\ref{table.constructors.context} and \ref{table.members.context}, respectively. The additional common special member functions and common member functions are listed in \ref{sec:reference-semantics} in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 All member functions of the \gls{context} class are synchronous and errors are handled by throwing synchronous SYCL exceptions.
 
@@ -800,7 +802,7 @@ execution.
 The SYCL \codeinline{event} class provides the common reference semantics
 (see Section~\ref{sec:reference-semantics}).
 
-The constructors and member functions of the SYCL \codeinline{event} class are listed in Tables~\ref{table.constructors.event} and \ref{table.members.event}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{event} class are listed in Tables~\ref{table.constructors.event} and \ref{table.members.event}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: event.h
 \lstinputlisting{headers/event.h}
@@ -1118,7 +1120,7 @@ semantics (see Section~\ref{sec:reference-semantics}).
 
 \subsubsection{Buffer Interface}
 
-The constructors and member functions of the SYCL \codeinline{buffer} class template are listed in Tables~\ref{table.constructors.buffer} and \ref{table.members.buffer}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{buffer} class template are listed in Tables~\ref{table.constructors.buffer} and \ref{table.members.buffer}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 Each constructor excluding the interoperability constructor takes as the last parameter an optional SYCL \codeinline{property_list} to provide properties to the SYCL \codeinline{buffer}.
 
@@ -1598,7 +1600,7 @@ The class \tclass{image}{\tf{int} dimensions}
 two or three dimensions, that can be used by kernels in queues and has to
 be accessed using \gls{accessor} classes with image accessor modes.
 
-The constructors and member functions of the SYCL \codeinline{image} class template are listed in Tables~\ref{table.constructors.image} and \ref{table.members.image}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{image} class template are listed in Tables~\ref{table.constructors.image} and \ref{table.members.image}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 Where relevant, it is the
 responsibility of the user to ensure that the format of the data
@@ -2699,7 +2701,7 @@ aliases is provided below.
 
 The SYCL \codeinline{sampler} class encapsulates a configuration for sampling an image \codeinline{accessor}. A SYCL \codeinline{sampler} may be an OpenCL sampler, in which case it must encapsulate a valid underlying OpenCL \codeinline{cl_sampler}, or it may be a host sampler, in which case it must not.
 
-The constructors and member functions of the SYCL \codeinline{sampler} class are listed in Tables~\ref{table.constructors.sampler} and \ref{table.members.sampler}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{sampler} class are listed in Tables~\ref{table.constructors.sampler} and \ref{table.members.sampler}, respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 The members of the \codeinline{sampler} class that provide information on the sampler (\codeinline{get_addressing_mode()}, \codeinline{get_filtering_mode()}, \codeinline{get_coordinate_normalization_mode()}) are callable from host code.  Invoking these queries within device kernel code produces undefined results.
 
@@ -3555,7 +3557,7 @@ The SYCL \codeinline{stream} class provides the common reference semantics
 %***********************************************************************************
 \subsection{Stream class interface}
 
-The constructors and member functions of the SYCL \codeinline{stream} class are listed in Tables~\ref{table.constructors.stream}, \ref{table.members.stream}, and \ref{table.globals.stream} respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.members.common.reference}, respectively.
+The constructors and member functions of the SYCL \codeinline{stream} class are listed in Tables~\ref{table.constructors.stream}, \ref{table.members.stream}, and \ref{table.globals.stream} respectively. The additional common special member functions and common member functions are listed in Tables~\ref{table.specialmembers.common.reference} and \ref{table.hiddenfriends.common.reference}, respectively.
 
 The operand types that are supported by the SYCL \codeinline{stream} class \codeinline{operator<<()} operator are listed in Table~\ref{table.operands.stream}.
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -2513,9 +2513,9 @@ The conversion must retain the \codeinline{const} qualifier.
 %-------------------------------------------------------------------------------
 
 %-------------------------------------------------------------------------------
-\startTable{Non-member function}
-\addFootNotes{Non-member functions of the \codeinline{multi_ptr} class}
-{table.multipointer.nonmemberfunctions}
+\startTable{Hidden friend function}
+\addFootNotes{Hidden friend functions of the \codeinline{multi_ptr} class}
+{table.multipointer.hiddenfriendfunctions}
 
 \addRow
 {ElementType\& operator*(const multi_ptr\& mp)}

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -2456,13 +2456,6 @@ An implementation should reject an argument if the deduced address space is not 
 {Assigns \codeinline{nullptr} to the \codeinline{multi_ptr}.}
 \addRowTwoL
 {template <typename ElementType, access::address_space Space>}
-{ElementType\& operator*() const}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Operator that returns a reference to the \codeinline{ElementType}
-of the \codeinline{multi_ptr} class.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
 {ElementType* operator->() const}
 {Available only when: \codeinline{!std::is_void<ElementType>::value}.
 \newline
@@ -2505,59 +2498,7 @@ Explicit conversion of a \codeinline{multi_ptr<void>}
 or \codeinline{multi_ptr<const void>} pointer object to a
 \codeinline{multi_ptr} of type \codeinline{ElementType}.}
 The conversion must retain the \codeinline{const} qualifier.
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr\& operator++()}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Increments the pointer by 1.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr operator++(int)}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Increments the pointer by 1 and returns a new \codeinline{multi_ptr}
-with the value of the previous pointer.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr\& operator--()}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Decrements the pointer by 1.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr operator--(int)}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Decrements the pointer by 1 and returns a new \codeinline{multi_ptr}
-with the value of the previous pointer.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr\& operator+=(difference_type r)}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Moves the pointer forward by \codeinline{r}.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr\& operator-=(difference_type r)}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Moves the pointer backward by \codeinline{r}.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr operator+(difference_type r) const}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Creates a new \codeinline{multi_ptr} that points \codeinline{r} forward
-compared to \codeinline{*this}.}
-\addRowTwoL
-{template <typename ElementType, access::address_space Space>}
-{multi_ptr operator-(difference_type r) const}
-{Available only when: \codeinline{!std::is_void<ElementType>::value}.
-\newline
-Creates a new \codeinline{multi_ptr} that points \codeinline{r} backward
-compared to \codeinline{*this}.}
-  \addRow
+ \addRow
     { void prefetch(size_t numElements) const }
     {
       Available only when: \codeinline{Space ==
@@ -2575,6 +2516,59 @@ compared to \codeinline{*this}.}
 \startTable{Non-member function}
 \addFootNotes{Non-member functions of the \codeinline{multi_ptr} class}
 {table.multipointer.nonmemberfunctions}
+
+\addRow
+{ElementType\& operator*(const multi_ptr\& mp)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Operator that returns a reference to the \codeinline{ElementType}
+of  \codeinline{mp}.}
+
+\addRow
+{multi_ptr\& operator++(multi_ptr\& mp)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Increments \codeinline{mp} by \codeinline{1} and returns  \codeinline{mp}.}
+\addRow
+{multi_ptr operator++(multi_ptr\& mp, int)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Increments \codeinline{mp} by \codeinline{1} and returns a new \codeinline{multi_ptr}
+with the value of the original \codeinline{mp}.}
+\addRow
+{multi_ptr\& operator--(multi_ptr\& mp)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Decrements \codeinline{mp} by \codeinline{1} and returns \codeinline{mp}.}
+\addRow
+{multi_ptr operator--(multi_ptr\& mp, int)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Decrements \codeinline{mp} by \codeinline{1} and returns a new \codeinline{multi_ptr}
+with the value of the original \codeinline{mp}.}
+\addRow
+{multi_ptr\& operator+=(multi_ptr\& lhs, difference_type r)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Moves \codeinline{mp} forward by \codeinline{r} and returns  \codeinline{lhs}.}
+\addRow
+{multi_ptr\& operator-=(multi_ptr\& lhs, difference_type r)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Moves \codeinline{mp} backward by \codeinline{r} and returns  \codeinline{lhs}.}
+\addRow
+{multi_ptr operator+(const multi_ptr\& lhs, difference_type r)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Creates a new \codeinline{multi_ptr} that points \codeinline{r} forward
+compared to \codeinline{lhs}.}
+\addRow
+{multi_ptr operator-(const multi_ptr\& lhs, difference_type r)}
+{Available only when: \codeinline{!std::is_void<ElementType>::value}.
+\newline
+Creates a new \codeinline{multi_ptr} that points \codeinline{r} backward
+compared to \codeinline{lhs}.}
+
 \addRow
 {bool operator==(const multi_ptr\& lhs, const multi_ptr\& rhs)}
 {Comparison operator \codeinline{==} for \codeinline{multi_ptr} class.}

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -55,7 +55,7 @@ listed in Tables~\ref{table.constructors.queue} and \ref{table.members.queue}
 respectively. The additional common special member functions and common member
 functions are listed in \ref{sec:reference-semantics} in
 Tables~\ref{table.specialmembers.common.reference} and
-\ref{table.members.common.reference}, respectively.
+\ref{table.hiddenfriends.common.reference}, respectively.
 
 %Interface for class: queue
 \lstinputlisting{headers/queue.h}

--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -208,6 +208,42 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
   {
     Stores the components of this SYCL \codeinline{vec} into the values at the address of \codeinline{ptr} offset in elements of type \codeinline{dataT} by \codeinline{numElements * offset}.
   }
+
+  \addRowTwoL
+    {vec<dataT, numElements> \&operator=(}
+    {  const vec<dataT, numElements> \&rhs)}
+    {
+      Assign each element of the \codeinline{rhs} SYCL \codeinline{vec} to each element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
+    }
+  \addRowTwoL
+    {vec<dataT, numElements> \&operator=(}
+    {  const dataT \&rhs)}
+    {
+      Assign each element of the \codeinline{rhs} scalar to each element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
+    }
+  \addRow
+  {vec<dataT, numElements> operator~()}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation on each element of this SYCL \codeinline{vec}.
+  }
+  \addRow
+  {vec<RET, numElements> operator!()}
+  {
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation on each element of this SYCL \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or this SYCL \codeinline{vec} is a NaN.
+      \newline \newline
+      The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
+  }
+\completeTable
+%-------------------------------------------------------------------------------
+
+%-------------------------------------------------------------------------------
+\startTable{Hidden friend function}
+\addFootNotes{Hidden friend functions of the \codeinline{vec} class template}
+{table.functions.vec}
+
+
   \addRowTwoL
   {vec<dataT, numElements> operatorOP(}
   {  const vec<dataT, numElements> \&rhs) const}
@@ -381,39 +417,9 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
       \newline \newline
       Where \codeinline{OP} is: \codeinline{==}, \codeinline{!=}, \codeinline{<}, \codeinline{>}, \codeinline{<=}, \codeinline{>=}. 
     }
-  \addRowTwoL
-    {vec<dataT, numElements> \&operator=(}
-    {  const vec<dataT, numElements> \&rhs)}
-    {
-      Assign each element of the \codeinline{rhs} SYCL \codeinline{vec} to each element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
-    }
-  \addRowTwoL
-    {vec<dataT, numElements> \&operator=(}
-    {  const dataT \&rhs)}
-    {
-      Assign each element of the \codeinline{rhs} scalar to each element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
-    }
-  \addRow
-  {vec<dataT, numElements> operator~()}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation on each element of this SYCL \codeinline{vec}.
-  }
-  \addRow
-  {vec<RET, numElements> operator!()}
-  {
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation on each element of this SYCL \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or this SYCL \codeinline{vec} is a NaN.
-      \newline \newline
-      The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
-  }
-\completeTable
-%-------------------------------------------------------------------------------
 
-%-------------------------------------------------------------------------------
-\startTable{Non-member function}
-\addFootNotes{Non-member functions of the \codeinline{vec} class template}
-{table.functions.vec}
+
+
   \addRowThreeL
   { vec<dataT, numElements> operatorOP( }
   { const dataT \&lhs, }

--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -221,21 +221,7 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     {
       Assign each element of the \codeinline{rhs} scalar to each element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
     }
-  \addRow
-  {vec<dataT, numElements> operator~()}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation on each element of this SYCL \codeinline{vec}.
-  }
-  \addRow
-  {vec<RET, numElements> operator!()}
-  {
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation on each element of this SYCL \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or this SYCL \codeinline{vec} is a NaN.
-      \newline \newline
-      The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
-  }
-\completeTable
+ \completeTable
 %-------------------------------------------------------------------------------
 
 %-------------------------------------------------------------------------------
@@ -243,187 +229,184 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
 \addFootNotes{Hidden friend functions of the \codeinline{vec} class template}
 {table.functions.vec}
 
-
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const vec<dataT, numElements> \&rhs) const}
-  {
-    When \codeinline{OP} is \codeinline{\%} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} arithmetic operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*}, \codeinline{/}, \codeinline{\%}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const dataT \&rhs) const}
-  {
-    When \codeinline{OP} is \codeinline{\%} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} arithmetic operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*}, \codeinline{/}, \codeinline{\%}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const vec<dataT, numElements> \&rhs)}
-  {
-    When \codeinline{OP} is \codeinline{\%=} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Perform an in-place element-wise \codeinline{OP} arithmetic operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const dataT \&rhs)}
-  {
-    When \codeinline{OP} is \codeinline{\%=} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Perform an in-place element-wise \codeinline{OP} arithmetic operation between each element of this SYCL \codeinline{vec} and \codeinline{rhs} scalar and return a reference to this SYCL \codeinline{vec}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
-  }
   \addRow
-  {vec<dataT, numElements> \&operatorOP()}
+  {vec operatorOP(const vec \&lhs, const vec \&rhs)}
   {
-    Perform an in-place element-wise \codeinline{OP} prefix arithmetic operation on each element of this SYCL \codeinline{vec}, assigning the result of each element to the corresponding element of this SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
+    When \codeinline{OP} is \codeinline{\%} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} arithmetic operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*}, \codeinline{/}, \codeinline{\%}.
+  }
+
+  \addRow
+  {vec operatorOP(const vec \&lhs, const dataT \&rhs)}
+  {
+    When \codeinline{OP} is \codeinline{\%} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} arithmetic operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*}, \codeinline{/}, \codeinline{\%}.
+  }
+
+  \addRow
+  {vec \&operatorOP(vec \&lhs, const vec \&rhs)}
+  {
+    When \codeinline{OP} is \codeinline{\%=} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Perform an in-place element-wise \codeinline{OP} arithmetic operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec} and return \codeinline{lhs} \codeinline{vec}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
+  }
+
+   \addRow
+  {vec \&operatorOP(vec \&lhs, const dataT \&rhs)}
+  {
+    When \codeinline{OP} is \codeinline{\%=} available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Perform an in-place element-wise \codeinline{OP} arithmetic operation between each element of \codeinline{lhs} \codeinline{vec} and \codeinline{rhs} scalar and return \codeinline{lhs} \codeinline{vec}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{+=}, \codeinline{-=}, \codeinline{*=}, \codeinline{/=}, \codeinline{\%=}.
+  }
+
+  \addRow
+  {vec \&operatorOP(vec \&v)}
+  {
+    Perform an in-place element-wise \codeinline{OP} prefix arithmetic operation on each element of \codeinline{lhs} \codeinline{vec}, assigning the result of each element to the corresponding element of \codeinline{lhs} \codeinline{vec} and return \codeinline{lhs} \codeinline{vec}.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{++}, \codeinline{--}. 
   }
-  
+
   \addRow
-  {vec<dataT, numElements> operatorOP(int)}
+  {vec operatorOP(vec \&v, int)}
   {
-    Perform an in-place element-wise \codeinline{OP} post-fix arithmetic operation on each element of this SYCL \codeinline{vec}, assigning the result of each element to the corresponding element of this SYCL \codeinline{vec} and returns a copy of this SYCL \codeinline{vec} before the operation is performed.
+    Perform an in-place element-wise \codeinline{OP} post-fix arithmetic operation on each element of \codeinline{lhs} \codeinline{vec}, assigning the result of each element to the corresponding element of \codeinline{lhs} \codeinline{vec} and returns a copy of \codeinline{lhs} \codeinline{vec} before the operation is performed.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{++}, \codeinline{--}.
   }
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const vec<dataT, numElements> \&rhs) const}
+  
+  \addRow
+  {vec operatorOP(const vec \&lhs, const vec \&rhs)}
   {
     Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
     \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&}, \codeinline{\|}, \codeinline{\^}.
   }
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const dataT \&rhs) const}
+
+  \addRow
+  {vec operatorOP(const vec \&lhs, const dataT \&rhs)}
   {
     Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
     \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar.
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&}, \codeinline{\|}, \codeinline{\^}.
   }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const vec<dataT, numElements> \&rhs)}
+
+  \addRow
+  {vec \&operatorOP(vec \&lhs, const vec \&rhs)}
   {
     Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
     \newline
-    Perform an in-place element-wise \codeinline{OP} bitwise operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} SYCL \codeinline{vec} and return a reference to this SYCL \codeinline{vec}.
+    Perform an in-place element-wise \codeinline{OP} bitwise operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} SYCL \codeinline{vec} and return \codeinline{lhs} \codeinline{vec}.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&=}, \codeinline{\|=}, \codeinline{\^=}.
   }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const dataT \&rhs)}
+
+  \addRow
+  {vec \&operatorOP(vec \&lhs, const dataT \&rhs)}
   {
     Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
     \newline
-    Perform an in-place element-wise \codeinline{OP} bitwise operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar and return a reference to this SYCL \codeinline{vec}.
+    Perform an in-place element-wise \codeinline{OP} bitwise operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar and return a \codeinline{lhs} \codeinline{vec}.
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&=}, \codeinline{\|=}, \codeinline{\^=}. 
   }
-  \addRowTwoL
-  {vec<RET, numElements> operatorOP(}
-  {  const vec<dataT, numElements> \&rhs) const}
-  {
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
-    \newline \newline
-    The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{\&\&}, \codeinline{\|\|}.
-  }
-  \addRowTwoL
-  {vec<RET, numElements> operatorOP(}
-  {  const dataT \&rhs) const}
-  {
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar.
-    \newline \newline
-    The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{\&\&}, \codeinline{\|\|}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const vec<dataT, numElements> \&rhs) const}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitshift operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}. If \codeinline{OP} is \codeinline{>>}, \codeinline{dataT} is a signed type and this SYCL \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{<<}, \codeinline{>>}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> operatorOP(}
-  {  const dataT \&rhs) const}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitshift operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar. If \codeinline{OP} is \codeinline{>>}, \codeinline{dataT} is a signed type and this SYCL \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{<<}, \codeinline{>>}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const vec<dataT, numElements> \&rhs)}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Perform an in-place element-wise \codeinline{OP} bitshift operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} SYCL \codeinline{vec} and returns a reference to this SYCL \codeinline{vec}. If \codeinline{OP} is \codeinline{>>\=}, \codeinline{dataT} is a signed type and this SYCL \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{<<\=}, \codeinline{>>\=}.
-  }
-  \addRowTwoL
-  {vec<dataT, numElements> \&operatorOP(}
-  {  const dataT \&rhs)}
-  {
-    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
-    \newline
-    Perform an in-place element-wise \codeinline{OP} bitshift operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar and returns a reference to this SYCL \codeinline{vec}. If \codeinline{OP} is \codeinline{>>\=}, \codeinline{dataT} is a signed type and this SYCL \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
-    \newline \newline
-    Where \codeinline{OP} is: \codeinline{<<\=}, \codeinline{>>\=}.
-  }
+
   \addRow
-    {vec<RET, numElements> operatorOP(const vec<dataT, numElements> \&rhs) const}
+  {vec<RET, numElements> operatorOP(const vec \&lhs, const vec \&rhs)}
+  {
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}.
+    \newline \newline
+    The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{\&\&}, \codeinline{\|\|}.
+  }
+
+  \addRow
+  {vec<RET, numElements> operatorOP(const vec \&lhs, const dataT \&rhs)}
+  {
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as this SYCL \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar.
+    \newline \newline
+    The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{\&\&}, \codeinline{\|\|}.
+  }
+
+  \addRow
+  {vec operatorOP(const vec \&lhs, const vec \&rhs)}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitshift operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}. If \codeinline{OP} is \codeinline{>>}, \codeinline{dataT} is a signed type and \codeinline{lhs} \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{<<}, \codeinline{>>}.
+  }
+
+   \addRow
+  {vec operatorOP(const vec \&lhs, const dataT \&rhs)}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{lhs} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitshift operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar. If \codeinline{OP} is \codeinline{>>}, \codeinline{dataT} is a signed type and \codeinline{lhs} \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{<<}, \codeinline{>>}.
+  }
+  
+  \addRow
+  {vec \&operatorOP(vec \&lhs, const vec \&rhs)}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Perform an in-place element-wise \codeinline{OP} bitshift operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} SYCL \codeinline{vec} and returns \codeinline{lhs} \codeinline{vec}. If \codeinline{OP} is \codeinline{>>\=}, \codeinline{dataT} is a signed type and \codeinline{lhs} \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{<<\=}, \codeinline{>>\=}.
+  }
+
+  \addRow
+  {vec \&operatorOP(vec \&lhs, const dataT \&rhs)}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Perform an in-place element-wise \codeinline{OP} bitshift operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar and returns a reference to this SYCL \codeinline{vec}. If \codeinline{OP} is \codeinline{>>\=}, \codeinline{dataT} is a signed type and \codeinline{lhs} \codeinline{vec} has a negative value any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{1}, otherwise any vacated bits viewed as an unsigned integer must be assigned the value \codeinline{0}.
+    \newline \newline
+    Where \codeinline{OP} is: \codeinline{<<\=}, \codeinline{>>\=}.
+  }
+
+  \addRow
+    {vec<RET, numElements> operatorOP(const vec\& lhs, const vec \&rhs)}
     {
-      Construct a new instance of the SYCL \codeinline{vec} class template with the element type \codeinline{RET} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} relational operation between each element of this SYCL \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or either this SYCL \codeinline{vec} or the \codeinline{rhs} SYCL \codeinline{vec} is a NaN.
+      Construct a new instance of the SYCL \codeinline{vec} class template with the element type \codeinline{RET} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} relational operation between each element of \codeinline{lhs} \codeinline{vec} and each element of the \codeinline{rhs} SYCL \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or either this SYCL \codeinline{vec} or the \codeinline{rhs} SYCL \codeinline{vec} is a NaN.
       \newline \newline
       The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
       \newline \newline
       Where \codeinline{OP} is: \codeinline{==}, \codeinline{!=}, \codeinline{<}, \codeinline{>}, \codeinline{<=}, \codeinline{>=}.
     }
+    
   \addRow
-    {vec<RET, numElements> operatorOP(const dataT \&rhs) const}
+    {vec<RET, numElements> operatorOP(const vec \&lhs, const dataT \&rhs)}
     {
-      Construct a new instance of the SYCL \codeinline{vec} class template with the \codeinline{dataT} parameter of \codeinline{RET} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} relational operation between each element of this SYCL \codeinline{vec} and the \codeinline{rhs} scalar. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or either this SYCL \codeinline{vec} or the \codeinline{rhs} SYCL \codeinline{vec} is a NaN.
+      Construct a new instance of the SYCL \codeinline{vec} class template with the \codeinline{dataT} parameter of \codeinline{RET} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} relational operation between each element of \codeinline{lhs} \codeinline{vec} and the \codeinline{rhs} scalar. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or either \codeinline{lhs} \codeinline{vec} or the \codeinline{rhs} SYCL \codeinline{vec} is a NaN.
       \newline \newline
       The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
       \newline \newline
       Where \codeinline{OP} is: \codeinline{==}, \codeinline{!=}, \codeinline{<}, \codeinline{>}, \codeinline{<=}, \codeinline{>=}. 
     }
 
-
-
-  \addRowThreeL
-  { vec<dataT, numElements> operatorOP( }
-  { const dataT \&lhs, }
-  { const vec<dataT, numElements> \&rhs) }
+  \addRow
+  { vec operatorOP(const dataT \&lhs, const vec \&rhs) }
   {
     When \codeinline{OP} is \codeinline{\%} available only when: \codeinline{
     dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
@@ -438,10 +421,9 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
     \codeinline{/}, \codeinline{\%}.
   }
-  \addRowThreeL
-  { vec<dataT, numElements> operatorOP( }
-  { const dataT \&lhs, }
-  { const vec<dataT, numElements> \&rhs) }
+
+  \addRow
+  {vec operatorOP(const dataT \&lhs, const vec \&rhs)}
   {
     Available only when: \codeinline{
     dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
@@ -454,10 +436,9 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&}, \codeinline{|}, \codeinline{^}.
   }
-  \addRowThreeL
-  { vec<RET, numElements> operatorOP( }
-  { const dataT \&lhs, }
-  { const vec<dataT, numElements> \&rhs) }
+
+   \addRow
+  {vec<RET, numElements> operatorOP(const dataT \&lhs, const vec \&rhs)}
   {
     Available only when: \codeinline{
     dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
@@ -472,10 +453,9 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     \newline \newline
     Where \codeinline{OP} is: \codeinline{\&\&}, \codeinline{||}.
   }
-  \addRowThreeL
-  { vec<dataT, numElements> operatorOP( }
-  { const dataT \&lhs, }
-  { const vec<dataT, numElements> \&rhs) }
+
+  \addRow
+  {vec operatorOP(const dataT \&lhs, const vec \&rhs)}
   {
     Construct a new instance of the SYCL \codeinline{vec} class template with
     the same template parameters as the \codeinline{rhs} SYCL \codeinline{vec}
@@ -490,10 +470,9 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     \newline \newline
     Where \codeinline{OP} is: \codeinline{<<}, \codeinline{>>}.
   }
-  \addRowThreeL
-    { vec<RET, numElements> operatorOP( }
-    { const dataT \&lhs, }
-    { const vec<dataT, numElements> \&rhs) }
+
+  \addRow
+    {vec<RET, numElements> operatorOP(const dataT \&lhs, const vec \&rhs)}
     {
       Available only when: \codeinline{
       dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
@@ -524,6 +503,23 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
       \newline \newline
       Where \codeinline{OP} is: \codeinline{==}, \codeinline{!=}, \codeinline{<}, \codeinline{>}, \codeinline{<=}, \codeinline{>=}.
     }
+    
+     \addRow
+  { vec \&operator~(const vec \&v)}
+  {
+    Available only when: \codeinline{dataT != cl_float \&\& dataT != cl_double \&\& dataT != cl_half}.
+    \newline
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{v} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} bitwise operation on each element of \codeinline{v} \codeinline{vec}.
+  }
+  
+  \addRow
+  {vec<RET, numElements> operator!(const vec \&v)}
+  {
+    Construct a new instance of the SYCL \codeinline{vec} class template with the same template parameters as \codeinline{v} \codeinline{vec} with each element of the new SYCL \codeinline{vec} instance the result of an element-wise \codeinline{OP} logical operation on each element of \codeinline{v} \codeinline{vec}. Each element of the SYCL \codeinline{vec} that is returned must be \codeinline{-1} if the operation results in \codeinline{true} and \codeinline{0} if the operation results in \codeinline{false} or this SYCL \codeinline{vec} is a NaN.
+      \newline \newline
+      The \codeinline{dataT} template parameter of the constructed SYCL \codeinline{vec}, \codeinline{RET}, varies depending on the \codeinline{dataT} template parameter of this SYCL \codeinline{vec}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_char} or \codeinline{cl_uchar} \codeinline{RET} must be \codeinline{cl_char}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_short}, \codeinline{cl_ushort} or \codeinline{cl_half} \codeinline{RET} must be \codeinline{cl_short}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_int}, \codeinline{cl_uint} or \codeinline{cl_float} \codeinline{RET} must be \codeinline{cl_int}. For a SYCL \codeinline{vec} with \codeinline{dataT} of type \codeinline{cl_long}, \codeinline{cl_ulong} or \codeinline{cl_double} \codeinline{RET} must be \codeinline{cl_long}.
+  }
+
 \completeTable
 %-------------------------------------------------------------------------------
 


### PR DESCRIPTION
There is a definition of "hidden friend functions" in section 4.3.2.  I wasn't sure where else to put it.  

The definition is:

> A hidden friend function is a function first declared via a `friend` declaration with no additional out of class or namespace scope declarations. Hidden friend functions are only visible to ADL (Argument Dependent Lookup) and are hidden from qualified and unqualified lookup. Hidden friend functions have the benefits of avoiding accidental implicit conversions and faster compilation.

In the class synopses, I declared hidden friends in the form

```
friend ret operatorOP(const type& lhs, const type& rhs) { /* ... */ }
```

to indicate that the body of the function must be present (even if all that body does is call another function).  This is a requirement for hidden friends to work.

Anthony Williams does a great job explaining [The Power of Hidden Friends in C++](https://www.justsoftwaresolutions.co.uk/cplusplus/hidden-friends.html), including using them for unary operators.

With the exception of those operators that cannot be non-member functions, I changed all the operators to use hidden friends.  This affected reference semantics, by-value semantics, `multi_ptr`, `range`, `id` and `vec`.