### PR TITLE
Clarification on get_devices

### DIFF
--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -139,7 +139,7 @@ A synopsis of the SYCL \codeinline{device} class is provided below. The construc
    {  info::device_type deviceType = }
    {  info::device_type::all)}
    {
-     Returns a \codeinline{vector_class} containing all SYCL \codeinline{device}s available in the system of the device type specified by the parameter \codeinline{deviceType}. The returned \codeinline{vector_class} must contain a single SYCL \codeinline{device} that is a host device, permitted by the \codeinline{deviceType} parameter.
+     Returns a \codeinline{vector_class} containing all SYCL \codeinline{device}s available in the system of the device type specified by the parameter \codeinline{deviceType}. The returned \codeinline{vector_class} must contain at least a SYCL \codeinline{device} that is a host device if the \codeinline{deviceType} is \codeinline{info::device_type::all}, or a single host device if the \codeinline{deviceType} is \codeinline{info::device_type::host}.
    }
 \completeTable
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
The wording on the table for get_devices static function suggested a host device will appear in all cases. The new wording attempts to clarify the occurrences of the host device in the return value of this function.