### PR TITLE
Fix bug in group::get_group_range()

### DIFF
--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -972,6 +972,7 @@ operation.
     {range<dimensions> get_local_range() const}
     {
         Return a SYCL \codeinline{range} representing all dimensions of the local range.
+        This local range may have been provided by the programmer, or chosen by the \gls{sycl-runtime}.
     }
   \addRow
     {size_t get_local_range(int dimension) const}
@@ -981,9 +982,7 @@ operation.
   \addRow
     {range<dimensions> get_group_range() const}
     {
-        Return a \codeinline{range} representing the dimensions of the
-        current group.  This local range may have been provided by the
-        programmer, or chosen by the \gls{sycl-runtime}.
+        Return a \codeinline{range} representing the number of \glspl{work-group} in the \codeinline{nd_range}.
     }
   \addRow
     {size_t get_group_range(int dimension) const}


### PR DESCRIPTION
get_group_range() should return number of work-groups, not their size.

This commit also moves the note that a group's local range can be provided by the programmer or chosen by the run-time to the description of get_local_range().

Resolves internal Khronos issue: https://gitlab.khronos.org/sycl/Specification/issues/270