### PR TITLE
Fix operations on id & range

### DIFF
--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -119,6 +119,7 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
@@ -136,6 +137,7 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
@@ -190,6 +192,7 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
@@ -364,6 +367,7 @@ tables of other classes. No actual interface change.}
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
@@ -381,6 +385,7 @@ tables of other classes. No actual interface change.}
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
@@ -434,6 +439,7 @@ tables of other classes. No actual interface change.}
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
       \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{\&\&}, \codeinline{||},
       \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -118,8 +118,8 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}, \codeinline{\&\&},
-      \codeinline{||}, \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{range} class
@@ -135,8 +135,8 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}, \codeinline{\&\&},
-      \codeinline{||}, \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{range} class
@@ -361,8 +361,8 @@ tables of other classes. No actual interface change.}
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}, \codeinline{\&\&},
-      \codeinline{||}, \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{id} class
@@ -378,8 +378,8 @@ tables of other classes. No actual interface change.}
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}, \codeinline{\&\&},
-      \codeinline{||}, \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
       \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{id} class

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -189,7 +189,9 @@ A synopsis of the SYCL \codeinline{range} class is provided below. The construct
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}.
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{range} class
       template with the same dimensionality as the \codeinline{rhs} SYCL
@@ -431,7 +433,9 @@ tables of other classes. No actual interface change.}
     {
       Where \codeinline{OP} is: \codeinline{+}, \codeinline{-}, \codeinline{*},
       \codeinline{/}, \codeinline{\%}, \codeinline{<<}, \codeinline{>>},
-      \codeinline{\&}, \codeinline{|}, \codeinline{^}.
+      \codeinline{\&}, \codeinline{|}, \codeinline{^},
+      \codeinline{<}, \codeinline{>}, \codeinline{<=},
+      \codeinline{>=}.
       \newline
       Constructs and returns a new instance of the SYCL \codeinline{id} class
       template with the same dimensionality as the \codeinline{rhs} SYCL

--- a/latex/headers/id.h
+++ b/latex/headers/id.h
@@ -24,7 +24,7 @@ public:
   size_t &operator[](int dimension);
   size_t operator[](int dimension) const;
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
   id<dimensions> operatorOP(const id<dimensions> &rhs) const;
   id<dimensions> operatorOP(const size_t &rhs) const;
 

--- a/latex/headers/id.h
+++ b/latex/headers/id.h
@@ -24,7 +24,7 @@ public:
   size_t &operator[](int dimension);
   size_t operator[](int dimension) const;
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   id<dimensions> operatorOP(const id<dimensions> &rhs) const;
   id<dimensions> operatorOP(const size_t &rhs) const;
 
@@ -33,7 +33,7 @@ public:
   id<dimensions> &operatorOP(const size_t &rhs);
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
+// OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 template <int dimensions>
 id<dimensions> operatorOP(const size_t &lhs, const id<dimensions> &rhs);
 }  // namespace sycl

--- a/latex/headers/id.h
+++ b/latex/headers/id.h
@@ -33,7 +33,7 @@ public:
   id<dimensions> &operatorOP(const size_t &rhs);
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^
+// OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
 template <int dimensions>
 id<dimensions> operatorOP(const size_t &lhs, const id<dimensions> &rhs);
 }  // namespace sycl

--- a/latex/headers/range.h
+++ b/latex/headers/range.h
@@ -18,7 +18,7 @@ public:
 
   size_t size() const;
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   range<dimensions> operatorOP(const range<dimensions> &rhs) const;
   range<dimensions> operatorOP(const size_t &rhs) const;
 
@@ -27,7 +27,7 @@ public:
   range<dimensions> &operatorOP(const size_t &rhs);
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
+// OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 template <int dimensions>
 range<dimensions> operatorOP(const size_t &lhs, const range<dimensions> &rhs);
 }  // sycl

--- a/latex/headers/range.h
+++ b/latex/headers/range.h
@@ -18,7 +18,7 @@ public:
 
   size_t size() const;
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
   range<dimensions> operatorOP(const range<dimensions> &rhs) const;
   range<dimensions> operatorOP(const size_t &rhs) const;
 

--- a/latex/headers/range.h
+++ b/latex/headers/range.h
@@ -27,7 +27,7 @@ public:
   range<dimensions> &operatorOP(const size_t &rhs);
 };
 
-// OP is: +, -, *, /, %, <<, >>, &, |, ^
+// OP is: +, -, *, /, %, <<, >>, &, |, ^, <, >, <=, >=
 template <int dimensions>
 range<dimensions> operatorOP(const size_t &lhs, const range<dimensions> &rhs);
 }  // sycl


### PR DESCRIPTION
Add <, >, <=, >= for id and range.
Add some missing || and &&.

This solve the non controversial part of internal discussion https://gitlab.khronos.org/sycl/Specification/issues/148 and https://gitlab.khronos.org/sycl/Specification/merge_requests/326