### PR TITLE
Clarify mapping of unit stride dimension between SYCL and OpenCL

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -243,17 +243,17 @@ elements of a SYCL \codeinline{buffer}. Firstly by passing a SYCL \codeinline{
 id} instance of the same dimensionality as the SYCL \codeinline{accessor}
 subscript operator. Secondly by passing a single \codeinline{size_t} value to
 multiple consecutive subscript operators (one for each dimension of the SYCL
-\codeinline{accessor}, for example \codeinline{acc[id1][id2][id3]}). Finally, in the
+\codeinline{accessor}, for example \codeinline{acc[id0][id1][id2]}). Finally, in the
 case of the SYCL \codeinline{accessor} being \codeinline{0} dimensions, by
 triggering the implicit conversion operator. Whenever a multi-dimensional index
 is passed to a SYCL \codeinline{accessor} the linear index is calculated based
-on the index \codeinline{\{id1, id2, id3\}} provided and the range of the SYCL
-\codeinline{accessor} \codeinline{\{r1, r2, r3\}} according to row-major
+on the index \codeinline{\{id0, id1, id2\}} provided and the range of the SYCL
+\codeinline{accessor} \codeinline{\{r0, r1, r2\}} according to row-major
 ordering as follows:
 
 \begin{equation}
 \label{row-major-equation-buffer}
- id3 + (id2 \cdot r3) + (id1 \cdot r3 \cdot r2)
+ id2 + (id1 \cdot r2) + (id0 \cdot r2 \cdot r1)
 \end{equation}
 
 A buffer accessor can optionally provide access to a sub range of a SYCL
@@ -661,13 +661,13 @@ multiple consecutive subscript operators (one for each dimension of the SYCL
 case of the SYCL \codeinline{accessor} having \codeinline{0} dimensions, by
 triggering the implicit conversion operator. Whenever a multi-dimensional index
 is passed to a SYCL \codeinline{accessor}, the linear index is calculated based
-on the index \codeinline{\{id1, id2, id3\}} provided and the range of the SYCL 
-\codeinline{accessor} \codeinline{\{r1, r2, r3\}} according to row-major
+on the index \codeinline{\{id0, id1, id2\}} provided and the range of the SYCL 
+\codeinline{accessor} \codeinline{\{r0, r1, r2\}} according to row-major
 ordering as follows:
 
 \begin{equation}
 \label{row-major-equation-local}
- id3 + (id2 \cdot r3) + (id1 \cdot r3 \cdot r2)
+ id2 + (id1 \cdot r2) + (id0 \cdot r2 \cdot r1)
 \end{equation}
 
 A local accessor can optionally provide atomic access to allocated memory,

--- a/latex/conf.tex
+++ b/latex/conf.tex
@@ -553,6 +553,10 @@ Comment [#1\themycomment]:~\newline #2}%
 \newcommand{\labelGenericTable}[1]{\label{#1}}
 \newcommand{\completeGenericTable}[0]{\end{table}\endgroup}
 
+\newcommand{\startGenericThreeColTable}[6]{\begingroup\begin{table}[!h]\setlength{\extrarowheight}{5pt}\small\centering\begin{tabular}[b]{|p{#1} | p{#2} | p{#3} |}\hline\cellcolor{lightgray}\textbf{#4} & \cellcolor{lightgray}\textbf{#5} & \cellcolor{lightgray}\textbf{#6}\\ \hline}
+\newcommand{\genericThreeColRow}[3]{\codeinline{#1} & \codeinline{#2} & #3\\ \hline}
+
+
 \newcommand{\startMethodTable}[0]{\begingroup\scriptsize\centering\begin{tabular}[c]{|p{1.5cm}|p{2cm}|p{3cm}|p{4cm}|p{4cm}|}\hline\cellcolor{gray}\textbf{Access} & \cellcolor{gray}\textbf{Return} & \cellcolor{gray}\textbf{Name} & \cellcolor{gray}\textbf{Parameters} & \cellcolor{gray}\textbf{Description}\\ \hline}
 \newcommand{\methodTableRow}[5]{\lstinline$#1$ & \lstinline$#2$ & \lstinline$#3$ & \lstinline$#4$ & #5\\ \hline}
 \newcommand{\completeMethodTable}[0]{\end{tabular}\endgroup}

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -2257,7 +2257,11 @@ user code should call \codeinline{clReleaseKernel} if the
 
 OpenCL and SYCL use opposite conventions for the unit stride dimension.  SYCL
 aligns with C++ conventions, which is important to understand from a performance
-perspective when porting code to SYCL.
+perspective when porting code to SYCL.  The unit stride dimension, at least for data, is implicit in the
+linearization equations in SYCL (Equation~\ref{row-major-equation-buffer}) and OpenCL.  SYCL aligns with C++ array subscript ordering
+\codeinline{arr[a][b][c]}, in that range constructor dimension ordering used to launch a kernel
+(e.g. \codeinline{range<3> R\{a,b,c\}}) and range and ID queries within a kernel, are ordered in
+the same way as the C++ multi-dimensional subscript operators (unit stride on the right).
 
 When specifying a \codeinline{range} as the global or local size
 in a \codeinline{parallel_for} that invokes an OpenCL interop kernel (through
@@ -2267,7 +2271,7 @@ the highest dimension of the range in SYCL will map to the
 lowest dimension within the OpenCL kernel.  That statement applies to both
 an underlying enqueue operation such as \codeinline{clEnqueueNDRangeKernel}
 in OpenCL, and also ID and size queries within the OpenCL kernel.
-For example, a global range specified in SYCL as:
+For example, a 3D global range specified in SYCL as:
 
 \begin{lstlisting}[style=nonumbers]
 range<3> R{r0,r1,r2};
@@ -2280,33 +2284,49 @@ of:
 size_t cl_interop_range[3] = {r2,r1,r0};
 \end{lstlisting}
 
+Likewise, a 2D global range specified in SYCL as:
+
+\begin{lstlisting}[style=nonumbers]
+range<2> R{r0,r1};
+\end{lstlisting}
+
+maps to an \codeinline{clEnqueueNDRangeKernel} \codeinline{global_work_size} argument
+of:
+
+\begin{lstlisting}[style=nonumbers]
+size_t cl_interop_range[2] = {r1,r0};
+\end{lstlisting}
+
+The mapping of highest dimension in SYCL to lowest dimension in OpenCL applies to all
+operations where a multi-dimensional construct must be mapped, such as when mapping SYCL
+explicit memory operations to OpenCL APIs like \codeinline{clEnqueueCopyBufferRect}.
+
 Work-item and work-group ID and range queries have the same reversed convention for unit
-stride dimension between SYCL and OpenCL.  For example, with a three dimensional SYCL
-global range of \codeinline{range<3> R\{r0,r1,r2\}} specified for a kernel enqueue, OpenCL
-and SYCL kernel code queries relate to the range as:
+stride dimension between SYCL and OpenCL.  For example, with three, two, or one dimensional SYCL
+global ranges, OpenCL and SYCL kernel code queries relate to the range as shown in Table~\ref{table.syclOpenCL.mapping}.
+The ``SYCL kernel query'' column applies for SYCL-defined kernels, and the ``OpenCL kernel query'' column
+applies for kernels defined through OpenCL interop.
 
 \startGenericThreeColTable{8cm}{3cm}{3cm}{SYCL kernel query}{OpenCL kernel query}{Returned Value}
+\multicolumn{3}{|c|}{\cellcolor{Gray}With enqueued 3D SYCL global \codeinline{range} of \codeinline{range<3> R\{r0,r1,r2\}}} \\ \hline
 \genericThreeColRow {nd_item::get_global_range(0) / item::get_range(0)}{get_global_size(2)}{\codeinline{r0}}
 \genericThreeColRow {nd_item::get_global_range(1) / item::get_range(1)}{get_global_size(1)}{\codeinline{r1}}
 \genericThreeColRow {nd_item::get_global_range(2) / item::get_range(2)}{get_global_size(0)}{\codeinline{r2}}
 \genericThreeColRow {nd_item::get_global_id(0) / item::get_id(0)}{get_global_id(2)}{Value in range 0..(\codeinline{r0}-1)}
 \genericThreeColRow {nd_item::get_global_id(1) / item::get_id(1)}{get_global_id(1)}{Value in range 0..(\codeinline{r1}-1)}
 \genericThreeColRow {nd_item::get_global_id(2) / item::get_id(2)}{get_global_id(0)}{Value in range 0..(\codeinline{r2}-1)}
-\completeGenericTabular
-\captionGenericTable{Example range mapping from SYCL enqueued three dimensional global \codeinline{range} to OpenCL and SYCL queries}
-\completeGenericTable
-
-Likewise, for a two dimensional global range \codeinline{range<2> R\{r0,r1\}}, OpenCL and SYCL kernel code queries relate to the range as:
-
-\startGenericThreeColTable{8cm}{3cm}{3cm}{SYCL kernel query}{OpenCL kernel query}{Returned Value}
+\multicolumn{3}{|c|}{\cellcolor{Gray}With enqueued 2D SYCL global \codeinline{range} of \codeinline{range<2> R\{r0,r1\}}} \\ \hline
 \genericThreeColRow {nd_item::get_global_range(0) / item::get_range(0)}{get_global_size(1)}{\codeinline{r0}}
 \genericThreeColRow {nd_item::get_global_range(1) / item::get_range(1)}{get_global_size(0)}{\codeinline{r1}}
 \genericThreeColRow {nd_item::get_global_id(0) / item::get_id(0)}{get_global_id(1)}{Value in range 0..(\codeinline{r0}-1)}
 \genericThreeColRow {nd_item::get_global_id(1) / item::get_id(1)}{get_global_id(0)}{Value in range 0..(\codeinline{r1}-1)}
+\multicolumn{3}{|c|}{\cellcolor{Gray}With enqueued 1D SYCL global \codeinline{range} of \codeinline{range<1> R\{r0\}}} \\ \hline
+\genericThreeColRow {nd_item::get_global_range(0) / item::get_range(0)}{get_global_size(0)}{\codeinline{r0}}
+\genericThreeColRow {nd_item::get_global_id(0) / item::get_id(0)}{get_global_id(0)}{Value in range 0..(\codeinline{r0}-1)}
 \completeGenericTabular
-\captionGenericTable{Example range mapping from SYCL enqueued two dimensional global \codeinline{range} to OpenCL and SYCL queries}
+\captionGenericTable{Example range mapping from SYCL enqueued three dimensional global \codeinline{range} to OpenCL and SYCL queries}
+\label{table.syclOpenCL.mapping}
 \completeGenericTable
-
 
 
 %***********************************************************************************

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -2249,6 +2249,66 @@ user code should call \codeinline{clReleaseKernel} if the
 \codeinline{cl_kernel} is no longer needed in the calling context.
 
 
+%*******************************************************************************
+% OpenCL Kernel Conventions and SYCL
+%*******************************************************************************
+\subsection{OpenCL Kernel Conventions and SYCL}
+\label{sec:opencl_kern_conventions_and_sycl}
+
+OpenCL and SYCL use opposite conventions for the unit stride dimension.  SYCL
+aligns with C++ conventions, which is important to understand from a performance
+perspective when porting code to SYCL.
+
+When specifying a \codeinline{range} as the global or local size
+in a \codeinline{parallel_for} that invokes an OpenCL interop kernel (through
+\codeinline{cl_kernel} interop or \codeinline{compile_with_source}/
+\codeinline{build_with_source}),
+the highest dimension of the range in SYCL will map to the
+lowest dimension within the OpenCL kernel.  That statement applies to both
+an underlying enqueue operation such as \codeinline{clEnqueueNDRangeKernel}
+in OpenCL, and also ID and size queries within the OpenCL kernel.
+For example, a global range specified in SYCL as:
+
+\begin{lstlisting}[style=nonumbers]
+range<3> R{r0,r1,r2};
+\end{lstlisting}
+
+maps to an \codeinline{clEnqueueNDRangeKernel} \codeinline{global_work_size} argument
+of:
+
+\begin{lstlisting}[style=nonumbers]
+size_t cl_interop_range[3] = {r2,r1,r0};
+\end{lstlisting}
+
+Work-item and work-group ID and range queries have the same reversed convention for unit
+stride dimension between SYCL and OpenCL.  For example, with a three dimensional SYCL
+global range of \codeinline{range<3> R\{r0,r1,r2\}} specified for a kernel enqueue, OpenCL
+and SYCL kernel code queries relate to the range as:
+
+\startGenericThreeColTable{8cm}{3cm}{3cm}{SYCL kernel query}{OpenCL kernel query}{Returned Value}
+\genericThreeColRow {nd_item::get_global_range(0) / item::get_range(0)}{get_global_size(2)}{\codeinline{r0}}
+\genericThreeColRow {nd_item::get_global_range(1) / item::get_range(1)}{get_global_size(1)}{\codeinline{r1}}
+\genericThreeColRow {nd_item::get_global_range(2) / item::get_range(2)}{get_global_size(0)}{\codeinline{r2}}
+\genericThreeColRow {nd_item::get_global_id(0) / item::get_id(0)}{get_global_id(2)}{Value in range 0..(\codeinline{r0}-1)}
+\genericThreeColRow {nd_item::get_global_id(1) / item::get_id(1)}{get_global_id(1)}{Value in range 0..(\codeinline{r1}-1)}
+\genericThreeColRow {nd_item::get_global_id(2) / item::get_id(2)}{get_global_id(0)}{Value in range 0..(\codeinline{r2}-1)}
+\completeGenericTabular
+\captionGenericTable{Example range mapping from SYCL enqueued three dimensional global \codeinline{range} to OpenCL and SYCL queries}
+\completeGenericTable
+
+Likewise, for a two dimensional global range \codeinline{range<2> R\{r0,r1\}}, OpenCL and SYCL kernel code queries relate to the range as:
+
+\startGenericThreeColTable{8cm}{3cm}{3cm}{SYCL kernel query}{OpenCL kernel query}{Returned Value}
+\genericThreeColRow {nd_item::get_global_range(0) / item::get_range(0)}{get_global_size(1)}{\codeinline{r0}}
+\genericThreeColRow {nd_item::get_global_range(1) / item::get_range(1)}{get_global_size(0)}{\codeinline{r1}}
+\genericThreeColRow {nd_item::get_global_id(0) / item::get_id(0)}{get_global_id(1)}{Value in range 0..(\codeinline{r0}-1)}
+\genericThreeColRow {nd_item::get_global_id(1) / item::get_id(1)}{get_global_id(0)}{Value in range 0..(\codeinline{r1}-1)}
+\completeGenericTabular
+\captionGenericTable{Example range mapping from SYCL enqueued two dimensional global \codeinline{range} to OpenCL and SYCL queries}
+\completeGenericTable
+
+
+
 %***********************************************************************************
 % Rules for parameter passing to kernels
 %***********************************************************************************


### PR DESCRIPTION
Clarify mapping of unit stride dimension (and dimensions more generally) between SYCL and OpenCL.  Ensures stable mapping between SYCL and OpenCL interop enqueues.

Also change equations to be zero-based instead of one-based.