### PR TITLE
Clarify the size and count queries of an accessor

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -462,13 +462,14 @@ Tables~\ref{table.specialmembers.common.reference} and
   \addRow
     { size_t get_size() const }
     {
-      Returns the size in bytes of the SYCL \codeinline{buffer} this SYCL
-      \codeinline{accessor} is accessing.
+      Returns the size in bytes of the region of a SYCL \codeinline{buffer}
+      that this SYCL \codeinline{accessor} is accessing.
     }
   \addRow
     { size_t get_count() const }
     {
-      Returns the number of elements of the SYCL \codeinline{buffer} this SYCL \codeinline{accessor} is accessing.
+      Returns the number of elements in the region of a SYCL \codeinline{buffer}
+      that this SYCL \codeinline{accessor} is accessing.
     }
   \addRow
     { range<dimensions> get_range() const }


### PR DESCRIPTION
Clarify that the size and count queries of an accessor apply to the accessor, which may be ranged, and not the underlying unranged buffer.