### PR TITLE
Further clarify stream class, and align better with C++ ostream in the process

### DIFF
--- a/latex/headers/stream.h
+++ b/latex/headers/stream.h
@@ -60,7 +60,8 @@ class stream {
   size_t get_work_item_buffer_size() const;
 
   /* get_max_statement_size() has the same functionality as get_work_item_buffer_size(),
-     and is provided for backward compatibility */
+     and is provided for backward compatibility.  get_max_statement_size() is a deprecated
+     query. */
   size_t get_max_statement_size() const;
 };
 

--- a/latex/headers/stream.h
+++ b/latex/headers/stream.h
@@ -59,8 +59,8 @@ class stream {
 
   size_t get_work_item_buffer_size() const;
 
-  /* get_max_statement_size() is an alias for get_work_item_buffer_size(), and
-     is provided for backward compatibility */
+  /* get_max_statement_size() has the same functionality as get_work_item_buffer_size(),
+     and is provided for backward compatibility */
   size_t get_max_statement_size() const;
 };
 

--- a/latex/headers/stream.h
+++ b/latex/headers/stream.h
@@ -2,6 +2,7 @@ namespace cl {
 namespace sycl {
 
 enum class stream_manipulator {
+  flush,
   dec,
   hex,
   oct,
@@ -15,6 +16,9 @@ enum class stream_manipulator {
   hexfloat,
   defaultfloat
 };
+
+
+const stream_manipulator flush = stream_manipulator::flush;
 
 const stream_manipulator dec = stream_manipulator::dec;
 
@@ -47,12 +51,16 @@ __width_manipulator__ setw(int width);
 class stream {
  public:
 
-  stream(size_t bufferSize, size_t maxStatementSize, handler& cgh);
+  stream(size_t totalBufferSize, size_t workItemBufferSize, handler& cgh);
 
   /* -- common interface members -- */
 
   size_t get_size() const;
 
+  size_t get_work_item_buffer_size() const;
+
+  /* get_max_statement_size() is an alias for get_work_item_buffer_size(), and
+     is provided for backward compatibility */
   size_t get_max_statement_size() const;
 };
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3565,6 +3565,8 @@ The way in which values are output by an instance of the SYCL \codeinline{stream
 
 An instance of the SYCL \codeinline{stream} class has a maximum buffer size (\codeinline{totalBufferSize}) that specifies maximum size of the overall character stream that can be output in characters (a character is of size \codeinline{sizeof(char)} bytes) during a kernel invocation, and a maximum stream size (\codeinline{workItemBufferSize}) that specifies the maximum size of the character stream (number of characters) that can be output within a work item before a flush must be performed (a character is of size \codeinline{sizeof(char)} bytes).  \codeinline{totalBufferSize} must be sufficient to contain the characters output by all stream statements during execution of a kernel invocation (the aggregate of outputs from all work items), and \codeinline{workItemBufferSize} must be sufficient to contain the characters output within a work item between stream flush operations.
 
+A stream flush operation is defined that synchronizes the work item stream buffer with the global stream buffer, and then empties the work item stream buffer.  A flush can be explicitly triggered using the \codeinline{flush} stream manipulator, or implicitly triggered by the \codeinline{endl} stream manipulator or by kernel completion (from the perspective of each completing work item).
+
 If the \codeinline{totalBufferSize} or \codeinline{workItemBufferSize} limits are exceeded, it is implementation defined whether the streamed characters exceeding the limit are output, or silently ignored/discarded, and if output it is implementation defined whether those extra characters exceeding the \codeinline{workItemBufferSize} limit count toward the \codeinline{totalBufferSize} limit.  Regardless of this implementations defined behavior of output exceeding the limits, no undefined or erroneous behavior is permitted of an implementation when the limits are exceeded.  Unused characters within \codeinline{workItemBufferSize} (any portion of the \codeinline{workItemBufferSize} capacity that has not been used at the time of a stream flush) do not count toward the \codeinline{totalBufferSize} limit, in that only characters flushed count toward the \codeinline{totalBufferSize} limit.
 
 The SYCL \codeinline{stream} class provides the common reference semantics
@@ -3640,8 +3642,8 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   flush
 }
 {
-  Triggers a flush operation, that synchronizes the work item stream buffer with the global
-  stream buffer, and that empties the work item stream buffer.  After a flush, the full
+  Triggers a flush operation, which synchronizes the work item stream buffer with the global
+  stream buffer, and then empties the work item stream buffer.  After a flush, the full
   \codeinline{workItemBufferSize} is available again for subsequent streaming within the work item.
 }
 \addRow
@@ -3649,7 +3651,7 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   endl
 }
 {
-  Outputs a new-line character and then generates a flush.
+  Outputs a new-line character and then triggers a flush operation.
 }
 \addRow
 {
@@ -3769,6 +3771,12 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
     {
       Returns the buffer size per work item, in characters.
     }
+  \addRow
+    {size_t get_max_statement_size() const}
+    {
+      Same functionality as \codeinline{get_work_item_buffer_size()}.  Provided for
+      backward compatibility of code using an older (deprecated) name for the query.
+    }
 \completeTable
 %-------------------------------------------------------------------------------------------
 
@@ -3786,7 +3794,7 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 
 \subsection{Synchronization}
 
-An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator (that doesn't exceed the \codeinline{workItemBufferSize} or \codeinline{totalBufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
+An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator before a flush operation (that doesn't exceed the \codeinline{workItemBufferSize} or \codeinline{totalBufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
 
 The SYCL \codeinline{stream} class is required to output the content of each stream, between flushes (up to \codeinline{workItemBufferSize}), without mixing with content from the same stream in other work items.  There are no other output order guarantees between work items or between streams.  The stream flush operation therefore delimits the unit of output that is guaranteed to be displayed without mixing with other work items, with respect to a single stream.
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -69,7 +69,7 @@ defaulted as 1 in most cases.
 Many of the \gls{sycl-runtime} classes encapsulate an associated OpenCL opaque type and provide facilities for interoperating between the SYCL classes and the OpenCL opaque types they encapsulate in order to allow interoperability between SYCL and OpenCL applications.
 
 Each of the following \gls{sycl-runtime} classes: \codeinline{platform},
-\codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler} and \codeinline{stream} must obey the following statements, where \codeinline{T} is the runtime class type:
+\codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image} and \codeinline{sampler} must obey the following statements, where \codeinline{T} is the runtime class type:
 
 \begin{itemize}
 
@@ -3559,13 +3559,13 @@ work-item to make progress if the code is to be portable.
 \section{Stream class}
 \label{subsection:stream}
 
-The SYCL \codeinline{stream} class is a buffered output stream that allows outputting the values of built-in, vector and SYCL types to the console. The implementation of how values are streamed is left as an implementation detail.
+The SYCL \codeinline{stream} class is a buffered output stream that allows outputting the values of built-in, vector and SYCL types to the console. The implementation of how values are streamed to the console is left as an implementation detail.
 
 The way in which values are output by an instance of the SYCL \codeinline{stream} class can also be altered using a range of manipulators.
 
-An instance of the SYCL \codeinline{stream} class has a maximum buffer size (\codeinline{bufferSize}) that specifies maximum size of the character stream that can be output by any single work item in characters (a character is of size \codeinline{sizeof(char)} bytes) during a kernel invocation, and a maximum statement size (\codeinline{maxStatementSize}) that specifies the maximum size of the character stream that can be output in a single statement in characters (a character is of size \codeinline{sizeof(char)} bytes).  \codeinline{bufferSize} must be sufficient to contain the characters output by statements during execution of a work item, and \codeinline{maxStatementSize} must be sufficient to contain the characters output by any specific statement, otherwise behavior is undefined.  Unused characters within \codeinline{maxStatementSize} (any portion of the \codeinline{maxStatementSize} that is not used/output by a statement) do not count toward the \codeinline{bufferSize} limit of a work item.
+An instance of the SYCL \codeinline{stream} class has a maximum buffer size (\codeinline{totalBufferSize}) that specifies maximum size of the overall character stream that can be output in characters (a character is of size \codeinline{sizeof(char)} bytes) during a kernel invocation, and a maximum stream size (\codeinline{workItemBufferSize}) that specifies the maximum size of the character stream (number of characters) that can be output within a work item before a flush must be performed (a character is of size \codeinline{sizeof(char)} bytes).  \codeinline{totalBufferSize} must be sufficient to contain the characters output by all stream statements during execution of a kernel invocation (the aggregate of outputs from all work items), and \codeinline{workItemBufferSize} must be sufficient to contain the characters output within a work item between stream flush operations.
 
-All member functions of the \codeinline{stream} class are synchronous and errors are handled by throwing synchronous SYCL exceptions.
+If the \codeinline{totalBufferSize} or \codeinline{workItemBufferSize} limits are exceeded, it is implementation defined whether the streamed characters exceeding the limit are output, or silently ignored/discarded, and if output it is implementation defined whether those extra characters exceeding the \codeinline{workItemBufferSize} limit count toward the \codeinline{totalBufferSize} limit.  Regardless of this implementations defined behavior of output exceeding the limits, no undefined or erroneous behavior is permitted of an implementation when the limits are exceeded.  Unused characters within \codeinline{workItemBufferSize} (any portion of the \codeinline{workItemBufferSize} capacity that has not been used at the time of a stream flush) do not count toward the \codeinline{totalBufferSize} limit, in that only characters flushed count toward the \codeinline{totalBufferSize} limit.
 
 The SYCL \codeinline{stream} class provides the common reference semantics
 (see Section~\ref{sec:reference-semantics}).
@@ -3637,10 +3637,19 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 \addFootNotes{Manipulators supported by the \codeinline{stream} class}{table.manipulators.stream}
 \addRow
 {
+  flush
+}
+{
+  Triggers a flush operation, that synchronizes the work item stream buffer with the global
+  stream buffer, and that empties the work item stream buffer.  After a flush, the full
+  \codeinline{workItemBufferSize} is available again for subsequent streaming within the work item.
+}
+\addRow
+{
   endl
 }
 {
-  Outputs a new-line character.
+  Outputs a new-line character and then generates a flush.
 }
 \addRow
 {
@@ -3740,9 +3749,9 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 \startTable{Constructor}
     \addFootNotes{Constructors of the \codeinline{stream} class}{table.constructors.stream}
   \addRow
-    {stream(size_t bufferSize, size_t maxStatementSize, handler\& cgh)}
+    {stream(size_t totalBufferSize, size_t workItemBufferSize, handler\& cgh)}
     {
-      Constructs a SYCL \codeinline{stream} instance associated with the command group specified by \codeinline{cgh}, with a maximum buffer size per work item specified by the parameter \codeinline{bufferSize} and a maximum statement size specified by the parameter \codeinline{maxStatementSize}.  \codeinline{bufferSize} and \codeinline{maxStatementSize} relate to memory storage size in that they are the term \codeinline{n} in \codeinline{alloc_size = n*sizeof(char)}.
+      Constructs a SYCL \codeinline{stream} instance associated with the command group specified by \codeinline{cgh}, with a maximum buffer size in characters per kernel invocation specified by the parameter \codeinline{totalBufferSize}, and a maximum stream size that can be buffered by a work item between stream flushes specified by the parameter \codeinline{workItemBufferSize}.  \codeinline{totalBufferSize} and \codeinline{workItemBufferSize} relate to memory storage size in that they are the term \codeinline{n} in \codeinline{alloc_size = n*sizeof(char)}.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -3753,12 +3762,12 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   \addRow
     {size_t get_size() const}
     {
-      Returns the maximum buffer size.
+      Returns the total buffer size, in characters.
     }
   \addRow
-    {size_t get_max_statement_size() const}
+    {size_t get_work_item_buffer_size() const}
     {
-      Returns the maximum statement size.
+      Returns the buffer size per work item, in characters.
     }
 \completeTable
 %-------------------------------------------------------------------------------------------
@@ -3770,16 +3779,19 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   \addRow
     {template <typename T> const stream\& operator<<(const stream\& os, const T \&rhs)}
     {
-      Outputs any valid values (see~\ref{table.operands.stream}) as a stream of characters and applies any valid manipulator (see~\ref{table.manipulators.stream}) to the current statements.
+      Outputs any valid values (see~\ref{table.operands.stream}) as a stream of characters and applies any valid manipulator (see~\ref{table.manipulators.stream}) to the current stream.
     }
 \completeTable
 %-------------------------------------------------------------------------------------------
 
 \subsection{Synchronization}
 
-An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator (that doesn't exceed the \codeinline{maxStatementSize} or \codeinline{bufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
+An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator (that doesn't exceed the \codeinline{workItemBufferSize} or \codeinline{totalBufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
 
-The SYCL \codeinline{stream} class is required to output each statement (up to \codeinline{maxStatementSize}) without mixing with statements of other work items.  There are no other output order guarantees between work items.  It is undefined behavor if a statement exceeds \codeinline{maxStatementSize}, or if the sum of outputs from all statements within execution of a work item exceed \codeinline{bufferSize}.
+The SYCL \codeinline{stream} class is required to output the content of each stream, between flushes (up to \codeinline{workItemBufferSize}), without mixing with content from the same stream in other work items.  There are no other output order guarantees between work items or between streams.  The stream flush operation therefore delimits the unit of output that is guaranteed to be displayed without mixing with other work items, with respect to a single stream.
+
+\subsection{Implicit flush}
+There is guaranteed to be an implicit flush of each stream used by a kernel, at the end of kernel execution, from the perspective of each work item.  There is also an implicit flush when the endl stream manipulator is executed.  No other implicit flushes are permitted in an implementation. 
 
 \subsection{Performance note}
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3774,8 +3774,7 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   \addRow
     {size_t get_max_statement_size() const}
     {
-      Same functionality as \codeinline{get_work_item_buffer_size()}.  Provided for
-      backward compatibility of code using an older (deprecated) name for the query.
+      Deprecated query with same functionality as \codeinline{get_work_item_buffer_size()}.
     }
 \completeTable
 %-------------------------------------------------------------------------------------------


### PR DESCRIPTION
- rename constructor members to be more descriptive
- use flush instead of statement-based descriptions.  Flush is the C++ approach to describe/define
- endl implicitly flushes, like C++ convention
- no OpenCL interop on stream, since no appropriate object to map
- clarify synchronization and cross-WI guarantees
- improve wording