### PR TITLE
Fix SYCL definition of preferred_work_group_size_multiple

### DIFF
--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1868,8 +1868,10 @@ descriptor.}
 {info::kernel_work_group::preferred_work_group_size_multiple}
 {size_t}
 {
-  Returns the preferred work-group size for executing a kernel on a particular
-  device.
+  Returns a value, of which work-group size is preferred to be a multiple,
+  for executing a kernel on a particular device.  This is a performance
+  hint.  The value must be less than or equal to that returned by
+  \codeinline{info::kernel_work_group::work_group_size}.
 }
 
 \addInfoRow


### PR DESCRIPTION
Fix SYCL definition of preferred_work_group_size_multiple so that "multiple" is in the definition.  That word was accidentally missed in the definition, relative to the query name and also the equivalent OpenCL definition.  Also state that it shouldn't be more than the max legal size.