### PR TITLE
Rounding mode typo fix, and make automatic the default rounding mode in convert template

### DIFF
--- a/latex/headers/vec.h
+++ b/latex/headers/vec.h
@@ -67,7 +67,7 @@ class vec {
 
   size_t get_size() const;
 
-  template <typename convertT, rounding_mode roundingMode>
+  template <typename convertT, rounding_mode roundingMode = rounding_mode::automatic>
   vec<convertT, numElements> convert() const;
 
   template <typename asT>

--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -112,7 +112,7 @@ The constructors, member functions and non-member functions of the SYCL \codeinl
     alignment as described in \ref{memory-layout-and-alignment}.
   }
   \addRowTwoL
-  {template<typename convertT, rounding_mode roundingMode>}
+  {template<typename convertT, rounding_mode roundingMode = rounding_mode::automatic>}
   {vec<convertT, numElements> convert() const}
   {
     Converts this SYCL \codeinline{vec} to a SYCL \codeinline{vec} of a different element type specified by \codeinline{convertT} using the rounding mode specified by \codeinline{roundingMode}. The new SYCL \codeinline{vec} type must have the same number of elements as this SYCL \codeinline{vec}. The different rounding modes are described in Table~\ref{table.vec.roundingmodes}.
@@ -580,7 +580,7 @@ The various rounding modes that can be used in the \codeinline{as} member functi
   \addRow
     {automatic}
     {
-      Default rounding mode for the SYCL \codeinline{vec} class element type element type, \codeinline{rtz} (round toward zero) for integer types and \codeinline{rte} (round to nearest even) for floating-point types.
+      Default rounding mode for the SYCL \codeinline{vec} class element type. \codeinline{rtz} (round toward zero) for integer types and \codeinline{rte} (round to nearest even) for floating-point types.
     }
   \addRow
     {rte}


### PR DESCRIPTION
Fix typo in description of rounding_mode::automatic.  Clearly make automatic the default rounding mode in the convert function.