### PR TITLE
Fix explicit memory operations.

### DIFF
--- a/latex/headers/commandGroupHandler.h
+++ b/latex/headers/commandGroupHandler.h
@@ -65,26 +65,36 @@ class handler {
 
   //------ Explicit memory operation APIs
   //
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void copy(accessor<T, dim, mode, tgt> src, shared_ptr_class<T> dest);
+  template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, access::placeholder isPlaceholder,
+            typename T_dest>
+  void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder> src,
+            shared_ptr_class<T_dest> dest);
 
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void copy(shared_ptr_class<T> src, accessor<T, dim, mode, tgt> dest);
+  template <typename T_src,
+            typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder>
+  void copy(shared_ptr_class<T_src> src,
+            accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder> dest);
 
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void copy(accessor<T, dim, mode, tgt> src, T * dest);
+  template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, access::placeholder isPlaceholder,
+            typename T_dest>
+  void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder> src,
+            T_dest *dest);
 
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void copy(const T * src, accessor<T, dim, mode, tgt> dest);
+  template <typename T_src,
+            typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder>
+  void copy(const T_src *src,
+            accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder> dest);
 
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void copy(accessor<T, dim, mode, tgt> src, accessor<T, dim, mode, tgt> dest);
+  template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, access::placeholder isPlaceholder_src,
+            typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder_dest>
+  void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder_src> src,
+            accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder_dest> dest);
 
-  template <typename T, int dim, access::mode mode, access::target tgt>
-  void update_host(accessor<T, dim, mode, tgt> acc);
+  template <typename T, int dim, access::mode mode, access::target tgt, access::placeholder isPlaceholder>
+  void update_host(accessor<T, dim, mode, tgt, isPlaceholder> acc);
 
-  template<typename T, int dim, access::mode mode, access::target tgt>
-  void fill(accessor<T, dim, mode, tgt> dest, const T& src);
+  template <typename T, int dim, access::mode mode, access::target tgt, access::placeholder isPlaceholder>
+  void fill(accessor<T, dim, mode, tgt, isPlaceholder> dest, const T& src);
 
 };
 }  // namespace sycl

--- a/latex/sycl_explicit_memory.tex
+++ b/latex/sycl_explicit_memory.tex
@@ -53,59 +53,54 @@ explicit copy operations.
 \startTable{Member function}
 \addFootNotes{Member functions of the \codeinline{handler} class}
 {table.members.handler.copy}
-  \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void copy(accessor<T, dim, mode, tgt> src,}
-    { shared_ptr_class<T> dest)}
+  \addRowTwoL
+    {template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, typename T_dest, access::placeholder isPlaceholder>}
+    {void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder> src, shared_ptr_class<T_dest> dest)}
     { Copies the contents of the memory object accessed by
       \codeinline{src} into the memory pointed to by \codeinline{dest}.
       \codeinline{dest} must have at least as many bytes as the
       range accessed by \codeinline{src}.}
-  \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void copy(shared_ptr_class<T> src}
-    { accessor<T, dim, mode, tgt> dest)}
+  \addRowTwoL
+    {template <typename T_src, typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder>}
+    {void copy(shared_ptr_class<T_src> src, accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder> dest)}
     { Copies the contents of the memory pointed to by \codeinline{src}
       into the memory object accessed by \codeinline{dest}.
       \codeinline{src} must have at least as many bytes as the
       range accessed by \codeinline{dest}.}
-  \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void copy(accessor<T, dim, mode, tgt> src,}
-    { T * dest)}
+  \addRowTwoL
+    {template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, typename T_dest, access::placeholder isPlaceholder>}
+    {void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder> src, T_dest * dest)}
     { Copies the contents of the memory object accessed by
       \codeinline{src} into the memory pointed to by \codeinline{dest}.
       \codeinline{dest} must have at least as many bytes as the
       range accessed by \codeinline{src}.}
-  \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void copy(const T * src}
-    { accessor<T, dim, mode, tgt> dest)}
+  \addRowTwoL
+    {template <typename T_src, typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder>}
+    {void copy(const T_src * src, accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder> dest)}
     { Copies the contents of the memory pointed to by \codeinline{src}
       into the memory object accessed by \codeinline{dest}.
       \codeinline{src} must have at least as many bytes as the
       range accessed by \codeinline{dest}.}
-  \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void copy(accessor<T, dim, mode, tgt> src}
-    { accessor<T, dim, mode, tgt> dest)}
+  \addRowTwoL
+    {template <typename T_src, int dim_src, access::mode mode_src, access::target tgt_src, access::placeholder isPlaceholder_src, typename T_dest, int dim_dest, access::mode mode_dest, access::target tgt_dest, access::placeholder isPlaceholder_dest>}
+    {void copy(accessor<T_src, dim_src, mode_src, tgt_src, isPlaceholder_src> src, accessor<T_dest, dim_dest, mode_dest, tgt_dest, isPlaceholder_dest> dest)}
     { Copies the contents of the memory object accessed by \codeinline{src}
       into the memory object accessed by \codeinline{dest}.
       \codeinline{src} must have at least as many bytes as the
       range accessed by \codeinline{dest}.}
   \addRowTwoL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void update_host(accessor<T, dim, mode, tgt> acc)}
+    {template <typename T, int dim, access::mode mode, access::target tgt, access::placeholder isPlaceholder>}
+    {void update_host(accessor<T, dim, mode, tgt, isPlaceholder> acc)}
     { The contents of the memory object accessed via \codeinline{acc}
       on the host are guaranteed to be up-to-date after this
       \gls{command-group} object execution is complete.}
   \addRowThreeL
-    {template <typename T, int dim, access::mode mode, access::target tgt>}
-    {void fill(accessor<T, dim, mode, tgt> dest,}
+    {template <typename T, int dim, access::mode mode, access::target tgt, access::placeholder isPlaceholder>}
+    {void fill(accessor<T, dim, mode, tgt, isPlaceholder> dest,}
     {          const T\& src)}
     {Replicates the value of \codeinline{src} into the
       memory object accessed by \codeinline{dest}.
-      T must be an integral scalar value or a SYCL vector type.
+      T must be a scalar value or a SYCL vector type.
     }
 
 \completeTable


### PR DESCRIPTION
 - Specify that `access::target::local` access target is not supported
 - Enable placeholder accessors parameters
 - Allow floating point values as `fill` method template parameter

(synchronization with internal GitLab)
(cherry picked from commit 029bac7d0f91802755373cc512e38c9092629d37)