### PR TITLE
Add clarification of supported image formats

### DIFF
--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1044,12 +1044,52 @@ through specialized operations.
 Elements of a buffer object can be a scalar data type (such as an int, float),
 vector data type, or a user-defined structure. In SYCL, a \gls{buffer} object is a
 templated type (\codeinline{cl::sycl::buffer}), parameterized by the element
-type and number of dimensions. An \gls{image} object is stored in one of a limited
-number of formats. The elements of an image object are selected from a list of
-predefined image formats which are provided by an underlying OpenCL
-implementation.  Images are encapsulated in the \codeinline{cl::sycl::image}
-type, which is templated by the number of dimensions in the image. The minimum
-number of elements in a memory object is one.
+type and number of dimensions.
+
+An \gls{image} is represented by the \codeinline{cl::sycl::image} class
+template, parametrized by the dimensionality. The minimum number of elements in
+a memory object is one. Elements of an \gls{image}, are stored in memory
+according one of a limited number of image formats described by a combination of
+\codeinline{cl::sycl::image_channel_order} and
+\codeinline{cl::sycl::image_channel_type}. An \gls{image} can be constructed
+with any one of these image formats, however whether that \gls{image} can be
+passed to a \gls{sycl-kernel-function} is subject to the target \gls{device}
+supporting that image format. The image formats supported by a \gls{device} is
+implementation defined, however if the \gls{device} is reported as supporting
+images it must support the minimum image formats as described below:
+
+\begin{itemize}
+  \item
+    \codeinline{cl::sycl::image_channel_order::rgba}
+    \begin{itemize}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unorm_int8}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unorm_int16}
+      \item
+        \codeinline{cl::sycl::image_channel_type::signed_int8}
+      \item
+        \codeinline{cl::sycl::image_channel_type::signed_int16}
+      \item
+        \codeinline{cl::sycl::image_channel_type::signed_int32}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unsigned_int8}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unsigned_int16}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unsigned_int32}
+      \item
+        \codeinline{cl::sycl::image_channel_type::fp16}
+      \item
+        \codeinline{cl::sycl::image_channel_type::fp32}
+    \end{itemize}
+  \item
+    \codeinline{cl::sycl::image_channel_order::bgra}
+    \begin{itemize}
+      \item
+        \codeinline{cl::sycl::image_channel_type::unorm_int8}
+    \end{itemize}
+\end{itemize}
 
 The fundamental differences between a buffer and an image object are:
 \begin{itemize}
@@ -1300,8 +1340,8 @@ same rules as the OpenCL devices.
 Kernel math library functions on the host must conform to OpenCL math precision
 requirements. The SYCL host device needs to be queried for the capabilities it provides.
 
-The range of image formats supported by the host device is implementation-defined, 
-but must match the minimum requirements of the OpenCL specification.
+The \gls{host-device} must report as supporting images and therefore support
+the minimum image formats.
 
 Some of the OpenCL extensions and optional features may be available on a SYCL
 host device, but since these are optional features and vendor specific

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1048,7 +1048,7 @@ type and number of dimensions.
 
 An \gls{image} is represented by the \codeinline{cl::sycl::image} class
 template, parametrized by the dimensionality. The minimum number of elements in
-a memory object is one. Elements of an \gls{image}, are stored in memory
+a memory object is one. Elements of an \gls{image} are stored in memory
 according to one of a limited number of image formats described by a combination of
 \codeinline{cl::sycl::image_channel_order} and
 \codeinline{cl::sycl::image_channel_type}. An \gls{image} can be constructed

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1083,12 +1083,6 @@ images it must support the minimum image formats as described below:
       \item
         \codeinline{cl::sycl::image_channel_type::fp32}
     \end{itemize}
-  \item
-    \codeinline{cl::sycl::image_channel_order::bgra}
-    \begin{itemize}
-      \item
-        \codeinline{cl::sycl::image_channel_type::unorm_int8}
-    \end{itemize}
 \end{itemize}
 
 The fundamental differences between a buffer and an image object are:

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1049,7 +1049,7 @@ type and number of dimensions.
 An \gls{image} is represented by the \codeinline{cl::sycl::image} class
 template, parametrized by the dimensionality. The minimum number of elements in
 a memory object is one. Elements of an \gls{image}, are stored in memory
-according one of a limited number of image formats described by a combination of
+according to one of a limited number of image formats described by a combination of
 \codeinline{cl::sycl::image_channel_order} and
 \codeinline{cl::sycl::image_channel_type}. An \gls{image} can be constructed
 with any one of these image formats, however whether that \gls{image} can be

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -256,7 +256,8 @@ information descriptors.}
      {
        Returns true if images are supported by this SYCL \codeinline{device} and
        false if they are not. If this SYCL \codeinline{device} is a
-       \gls{host-device}, images must be supported.
+       \gls{host-device}, images must be supported, and therefore this query
+       must always return true.
      }
    \addInfoRow
      {info::device::max_read_image_args}

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -250,12 +250,14 @@ information descriptors.}
      {
       Returns the maximum size of memory object allocation in  bytes. The minimum value is max (1/4th of \codeinline{info::device::global_mem_size},128*1024*1024) if this SYCL \codeinline{device} is not of device type \codeinline{info::device_type::custom}.
      }
-
    \addInfoRow
      {info::device::image_support}
      {bool}
-     {Returns true if images are supported by this SYCL \codeinline{device} and false if they are not. }
-
+     {
+       Returns true if images are supported by this SYCL \codeinline{device} and
+       false if they are not. If this SYCL \codeinline{device} is a
+       \gls{host-device} image must be supported.
+     }
    \addInfoRow
      {info::device::max_read_image_args}
      {cl_uint}

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -256,7 +256,7 @@ information descriptors.}
      {
        Returns true if images are supported by this SYCL \codeinline{device} and
        false if they are not. If this SYCL \codeinline{device} is a
-       \gls{host-device} image must be supported.
+       \gls{host-device}, images must be supported.
      }
    \addInfoRow
      {info::device::max_read_image_args}


### PR DESCRIPTION
Add clarification as to the required image support for the host device. This pull request replaces https://github.com/KhronosGroup/SYCL-Docs/pull/16

* Add general clarification on required image format for images.
* Add description of the minimum image formats.
* Add clarification on requirement for the host device support to
support the minimum image formats.