### PR TITLE
Clarify introduction of atomic class

### DIFF
--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3205,8 +3205,7 @@ The SYCL specification provides atomic operations based on the C++11
 library syntax. The only available ordering, due to constraints of the
 OpenCL 1.2 memory model, is \codeinline{memory_order_relaxed}.
 The SYCL atomic library may map directly to
-the underlying C++11 library in host code, and must interact safely
-with the host C++11 atomic library when used in host code. The SYCL
+the underlying C++11 library on the host device. The SYCL
 library must be used in device code to ensure that only the limited
 subset of functionality is available. SYCL 1.2.1 device compilers should
 give a compilation error on use of the \codeinline{std::atomic}

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3203,9 +3203,8 @@ A \gls{work-group-barrier} or \gls{work-group-mem-fence} may provide ordering se
 
 The SYCL specification provides atomic operations based on the C++11
 library syntax. The only available ordering, due to constraints of the
-OpenCL 1.2 memory model, is \codeinline{memory_order_relaxed}. No
-default order is supported because a default order would imply
-sequential consistency. The SYCL atomic library may map directly to
+OpenCL 1.2 memory model, is \codeinline{memory_order_relaxed}.
+The SYCL atomic library may map directly to
 the underlying C++11 library in host code, and must interact safely
 with the host C++11 atomic library when used in host code. The SYCL
 library must be used in device code to ensure that only the limited


### PR DESCRIPTION
The introduction to the `atomic` class in 4.11 makes two claims that are contradicted by other parts of the specification:
1. That atomic operations have no default `memory_order`
2. That `atomic` can be used in host code