### PR TITLE
Add missing queue constructor form that takes existing device + context

### DIFF
--- a/latex/headers/queue.h
+++ b/latex/headers/queue.h
@@ -38,6 +38,12 @@ class queue {
   queue(const context &syclContext, const device_selector &deviceSelector,
     const async_handler &asyncHandler, const property_list &propList = {});
 
+  queue(const context &syclContext, const device &syclDevice,
+    const property_list &propList = {});
+
+  queue(const context &syclContext, const device &syclDevice,
+    const async_handler &asyncHandler, const property_list &propList = {});
+
   queue(cl_command_queue clQueue, const context& syclContext,
     const async_handler &asyncHandler = {});
 

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -156,6 +156,35 @@ Tables~\ref{table.specialmembers.common.reference} and
       an instance of \codeinline{property_list}.
     }
   \addRowThreeL
+    { queue(const context \&syclContext, }
+    { const device \&syclDevice, }
+    { const property_list \&propList = \{\}) }
+    {
+      Constructs a SYCL \codeinline{queue} instance using the \codeinline{
+      syclDevice} provided, and associated with the
+      \codeinline{syclContext} provided. Must throw an
+      \codeinline{invalid_object_error} SYCL exception if
+      \codeinline{syclContext} does not encapsulate the SYCL
+      \codeinline{device} \codeinline{syclDevice}. Zero or more
+      properties can be provided to the constructed SYCL \codeinline{queue}
+      via an instance of \codeinline{property_list}.
+    }
+  \addRowFourL
+    { queue(const context \&syclContext, }
+    { const device \&syclDevice, }
+    { const async_handler \&asyncHandler, }
+    { const property_list \&propList = \{\}) }
+    {
+      Constructs a SYCL \codeinline{queue} instance with an \codeinline{
+      async_handler} using the \codeinline{syclDevice} provided, and
+      associated with the \codeinline{syclContext} provided. Must throw an
+      \codeinline{invalid_object_error} SYCL exception if
+      \codeinline{syclContext} does not encapsulate the SYCL
+      \codeinline{device} \codeinline{syclDevice}.  Zero or more
+      properties can be provided to the constructed SYCL \codeinline{queue} via
+      an instance of \codeinline{property_list}.
+    }
+  \addRowThreeL
     { queue(cl_command_queue clQueue,}
     { const context \&syclContext, }
     { const async_handler \&asyncHandler = \{\}) }


### PR DESCRIPTION
Add missing queue constructor form that takes existing device instead of device_selector.

Resolves #71 

Matches [internal Khronos reference](https://gitlab.khronos.org/sycl/Specification/merge_requests/377/diffs?view=inline).