### PR TITLE
Generalized use of property list

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -539,14 +539,27 @@ Tables~\ref{table.specialmembers.common.reference} and
     {
       Available only when: \codeinline{dimensions > 0}.
       \newline
-      Returns the range of this SYCL \codeinline{accessor}.
+      Returns a \codeinline{range} object which represents the number of
+      elements of \codeinline{dataT} per dimension that this
+      \codeinline{accessor} may access.
+      \newline
+      The \codeinline{range} object returned must equal to the
+      \codeinline{range} of the \codeinline{buffer} this \codeinline{accessor}
+      is associated with, unless a range was explicitly specified when this
+      \codeinline{accessor} was constructed.
     }
   \addRow
     { id<dimensions> get_offset() const }
     {
       Available only when: \codeinline{dimensions > 0}.
       \newline
-      Returns the offset of this SYCL \codeinline{accessor}.
+      Returns an \codeinline{id} object which represents the starting point in
+      number of elements of \codeinline{dataT} for the \codeinline{range} that
+      this \codeinline{accessor} may access.
+      \newline
+      The \codeinline{id} object returned must equal to
+      \codeinline{id\{0, 0, 0\}}, unless an offset was explicitly specified
+      when this \codeinline{accessor} was constructed.
     }
   \addRow
     { operator dataT \&() const }
@@ -851,6 +864,15 @@ member functions and common member functions are listed in
     {
       Returns the number of \codeinline{dataT} elements in the local memory allocation, per work-group,
       that this SYCL \codeinline{accessor} is accessing.
+    }
+  \addRow
+    { range<dimensions> get_range() const }
+    {
+      Available only when: \codeinline{dimensions > 0}.
+      \newline
+      Returns a \codeinline{range} object which represents the number of
+      elements of \codeinline{dataT} per dimension that this
+      \codeinline{accessor} may access, per work-group.
     }
   \addRow
     { operator dataT \&() const }

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -709,8 +709,7 @@ Tables~\ref{table.specialmembers.common.reference} and
 \subsubsection{Buffer accessor properties}
 \label{sub.section.accessors.buffer.properties}
 
-Construction of the SYCL buffer \codeinline{accessor} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 %*******************************************************************************
 % Local accessor
@@ -972,8 +971,7 @@ member functions and common member functions are listed in
 \subsubsection{Local accessor properties}
 \label{sub.section.accessors.local.properties}
 
-Construction of the SYCL local \codeinline{accessor} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 %******************************************************************************
 % Image accessor
@@ -1218,8 +1216,7 @@ Tables~\ref{table.specialmembers.common.reference} and
 \subsubsection{Image accessor properties}
 \label{sub.section.accessors.image.properties}
 
-Construction of the SYCL image \codeinline{accessor} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 \clearpage
 

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -375,7 +375,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowThreeL
     { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef, }
@@ -391,7 +392,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       element of a SYCL \codeinline{buffer} within a SYCL kernel function on
       the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowTwoL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
@@ -409,7 +411,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       buffer} immediately on the host. If \codeinline{isPlaceholder ==
       access::placeholder::true_t}, constructs a SYCL placeholder \codeinline{
       accessor}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowThreeL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
@@ -424,7 +427,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{buffer} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowThreeL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
@@ -443,7 +447,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowFourL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
@@ -463,7 +468,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowFourL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
@@ -480,13 +486,14 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{buffer} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef},
       specified by \codeinline{accessRange}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowFiveL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
     { handler \&commandGroupHandlerRef, }
     { range<dimensions> accessRange, }
-    { id<dimensions> accessOffset = \{\}, }
+    { id<dimensions> accessOffset, }
     { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{(isPlaceholder ==
@@ -498,7 +505,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{buffer} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef},
       specified by \codeinline{accessRange} and \codeinline{accessOffset}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -804,7 +812,8 @@ member functions and common member functions are listed in
       allocated shared local memory of a single element (of type \codeinline{dataT}) within
       a SYCL kernel function on the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.  The allocation is per work-group.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowThreeL
     { accessor(range<dimensions> allocationSize, }
@@ -812,7 +821,7 @@ member functions and common member functions are listed in
     { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{dimensions > 0}.
-      \newline      
+      \newline
       Constructs a SYCL \codeinline{accessor} instance for accessing runtime
       allocated shared local memory of size specified by \codeinline{
       allocationSize} within a SYCL kernel function on the SYCL \codeinline{
@@ -821,7 +830,7 @@ member functions and common member functions are listed in
       is per work-group, and if multiple work-groups execute simultaneously in an
       implementation, each work-group will receive its own functionally independent
       allocation of size \codeinline{allocationSize} elements of type \codeinline{dataT}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -1067,7 +1076,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       \newline
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{image} immediately on the host.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowFourL
     { template <typename AllocatorT> }
@@ -1081,7 +1091,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{image} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
   \addRowFourL
     { template <typename AllocatorT> }
@@ -1096,7 +1107,8 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{image} as an array of images, within a SYCL kernel function on
       the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1139,15 +1139,37 @@ Tables~\ref{table.specialmembers.common.reference} and
     image specialization}
   {table.members.accessor.image}
   \addRow
-    { size_t get_size() const }
-    {
-      Returns the size in bytes of the SYCL \codeinline{image} this SYCL
-      \codeinline{accessor} is accessing.
-    }
-  \addRow
     { size_t get_count() const }
     {
       Returns the number of elements of the SYCL \codeinline{image} this SYCL \codeinline{accessor} is accessing.
+    }
+  \addRow
+    { range<dimensions+1> get_range() const }
+    {
+      Available only when:
+      \codeinline{accessTarget == access::target::image_array)}.
+      \newline
+      Returns a \codeinline{range} object which represents the number of
+      elements of \codeinline{dataT} per dimension that this
+      \codeinline{accessor} may access.
+      \newline
+      The \codeinline{range} object returned must equal to the
+      \codeinline{range} of the \codeinline{image} this \codeinline{accessor}
+      is associated with.
+    }
+  \addRow
+    { range<dimensions> get_range() const }
+    {
+      Available only when:
+      \codeinline{accessTarget != access::target::image_array)}.
+      \newline
+      Returns a \codeinline{range} object which represents the number of
+      elements of \codeinline{dataT} per dimension that this
+      \codeinline{accessor} may access.
+      \newline
+      The \codeinline{range} object returned must equal to the
+      \codeinline{range} of the \codeinline{image} this \codeinline{accessor}
+      is associated with.
     }
   \addRowTwoSL
     { template <typename coordT> }
@@ -1178,11 +1200,11 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{dimensions == 3}.
     }
   \addRowTwoSL
-    { template <typename coordT> }    
+    { template <typename coordT> }
     { void write(const coordT \&coords, const dataT \&color) const }
     {
       Available only when: \codeinline{(accessTarget == access::target::image \&\&
-      (accessMode == access::mode::write || accessMode == access::mode::discard_write)) || 
+      (accessMode == access::mode::write || accessMode == access::mode::discard_write)) ||
       (accessTarget == access::target::host_image \&\& (accessMode ==
       access::mode::write || accessMode == access::mode::discard_write ||
       accessMode == access::mode::read_write))}.

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -359,8 +359,9 @@ Tables~\ref{table.specialmembers.common.reference} and
 \addFootNotes{Constructors of the \codeinline{accessor} class template buffer
   specialization}
 {table.constructors.accessor.buffer}
-  \addRow
-    { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef) }
+  \addRowTwoL
+    { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{((isPlaceholder ==
       access::placeholder::false_t \&\& accessTarget ==
@@ -374,10 +375,12 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRowTwoL
+  \addRowThreeL
     { accessor(buffer<dataT, 1, AllocatorT> \&bufferRef, }
-    { handler \&commandGroupHandlerRef) }
+    { handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{(isPlaceholder ==
       access::placeholder::false_t \&\& (accessTarget ==
@@ -388,9 +391,11 @@ Tables~\ref{table.specialmembers.common.reference} and
       element of a SYCL \codeinline{buffer} within a SYCL kernel function on
       the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRow
-    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef) }
+  \addRowTwoL
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{((isPlaceholder ==
       access::placeholder::false_t \&\& accessTarget ==
@@ -404,10 +409,12 @@ Tables~\ref{table.specialmembers.common.reference} and
       buffer} immediately on the host. If \codeinline{isPlaceholder ==
       access::placeholder::true_t}, constructs a SYCL placeholder \codeinline{
       accessor}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRowTwoL
+  \addRowThreeL
     { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
-    { handler \&commandGroupHandlerRef) }
+    { handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{(isPlaceholder ==
       access::placeholder::false_t \&\& (accessTarget ==
@@ -417,11 +424,12 @@ Tables~\ref{table.specialmembers.common.reference} and
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{buffer} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
   \addRowThreeL
-    { accessor( buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
-    { range<dimensions> accessRange, id<dimensions> }
-    { accessOffset = \{\}) }
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
+    { range<dimensions> accessRange, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{(isPlaceholder ==
       access::placeholder::false_t \&\& accessTarget ==
@@ -435,12 +443,51 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
   \addRowFourL
-    { accessor( buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
+    { range<dimensions> accessRange, }
+    { id<dimensions> accessOffset, }
+    { const property_list \&propList = \{\}) }
+    {
+      Available only when: \codeinline{(isPlaceholder ==
+      access::placeholder::false_t \&\& accessTarget ==
+      access::target::host_buffer) ||  (isPlaceholder ==
+      access::placeholder::true_t \&\& (accessTarget ==
+      access::target::global_buffer || accessTarget ==
+      access::target::constant_buffer)) \&\& dimensions > 0}.
+      \newline
+      If \codeinline{isPlaceholder == access::placeholder::false_t}, constructs
+      a SYCL \codeinline{accessor} instance for accessing a range of a SYCL
+      \codeinline{buffer} immediately on the host. If \codeinline{
+      isPlaceholder == access::placeholder::true_t}, constructs a SYCL
+      placeholder \codeinline{accessor}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+    }
+  \addRowFourL
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
     { handler \&commandGroupHandlerRef, }
     { range<dimensions> accessRange, }
-    { id<dimensions> accessOffset = \{\}) }
+    { const property_list \&propList = \{\}) }
+    {
+      Available only when: \codeinline{(isPlaceholder ==
+      access::placeholder::false_t \&\& (accessTarget ==
+      access::target::global_buffer || accessTarget ==
+      access::target::constant_buffer)) \&\& dimensions > 0}.
+      \newline
+      Constructs a SYCL \codeinline{accessor} instance for accessing a range of
+      SYCL \codeinline{buffer} within a SYCL kernel function on the SYCL
+      \codeinline{queue} associated with \codeinline{commandGroupHandlerRef},
+      specified by \codeinline{accessRange}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
+    }
+  \addRowFiveL
+    { accessor(buffer<dataT, dimensions, AllocatorT> \&bufferRef, }
+    { handler \&commandGroupHandlerRef, }
+    { range<dimensions> accessRange, }
+    { id<dimensions> accessOffset = \{\}, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{(isPlaceholder ==
       access::placeholder::false_t \&\& (accessTarget ==
@@ -451,6 +498,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{buffer} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef},
       specified by \codeinline{accessRange} and \codeinline{accessOffset}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -483,27 +531,14 @@ Tables~\ref{table.specialmembers.common.reference} and
     {
       Available only when: \codeinline{dimensions > 0}.
       \newline
-      Returns a \codeinline{range} object which represents the number of
-      elements of \codeinline{dataT} per dimension that this
-      \codeinline{accessor} may access.
-      \newline
-      The \codeinline{range} object returned must equal to the
-      \codeinline{range} of the \codeinline{buffer} this \codeinline{accessor}
-      is associated with, unless a range was explicitly specified when this
-      \codeinline{accessor} was constructed.
+      Returns the range of this SYCL \codeinline{accessor}.
     }
   \addRow
     { id<dimensions> get_offset() const }
     {
       Available only when: \codeinline{dimensions > 0}.
       \newline
-      Returns an \codeinline{id} object which represents the starting point in
-      number of elements of \codeinline{dataT} for the \codeinline{range} that
-      this \codeinline{accessor} may access.
-      \newline
-      The \codeinline{id} object returned must equal to
-      \codeinline{id\{0, 0, 0\}}, unless an offset was explicitly specified
-      when this \codeinline{accessor} was constructed.
+      Returns the offset of this SYCL \codeinline{accessor}.
     }
   \addRow
     { operator dataT \&() const }
@@ -647,6 +682,16 @@ Tables~\ref{table.specialmembers.common.reference} and
 %-------------------------------------------------------------------------------
 
 %*******************************************************************************
+% Buffer accessor Properties
+%*******************************************************************************
+
+\subsubsection{Buffer accessor properties}
+\label{sub.section.accessors.buffer.properties}
+
+Construction of the SYCL buffer \codeinline{accessor} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
+
+%*******************************************************************************
 % Local accessor
 %*******************************************************************************
 
@@ -749,8 +794,9 @@ member functions and common member functions are listed in
 \addFootNotes {Constructors of the \codeinline{accessor} class template local
   specialization}
 {table.constructors.accessor.local}
-  \addRow
-    { accessor(handler \&commandGroupHandlerRef) }
+  \addRowTwoL
+    { accessor(handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{dimensions == 0}.
       \newline
@@ -758,10 +804,12 @@ member functions and common member functions are listed in
       allocated shared local memory of a single element (of type \codeinline{dataT}) within
       a SYCL kernel function on the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.  The allocation is per work-group.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRowTwoL
+  \addRowThreeL
     { accessor(range<dimensions> allocationSize, }
-    { handler \&commandGroupHandlerRef) }
+    { handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{dimensions > 0}.
       \newline      
@@ -773,6 +821,7 @@ member functions and common member functions are listed in
       is per work-group, and if multiple work-groups execute simultaneously in an
       implementation, each work-group will receive its own functionally independent
       allocation of size \codeinline{allocationSize} elements of type \codeinline{dataT}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -793,15 +842,6 @@ member functions and common member functions are listed in
     {
       Returns the number of \codeinline{dataT} elements in the local memory allocation, per work-group,
       that this SYCL \codeinline{accessor} is accessing.
-    }
-  \addRow
-    { range<dimensions> get_range() const }
-    {
-      Available only when: \codeinline{dimensions > 0}.
-      \newline
-      Returns a \codeinline{range} object which represents the number of
-      elements of \codeinline{dataT} per dimension that this
-      \codeinline{accessor} may access, per work-group.
     }
   \addRow
     { operator dataT \&() const }
@@ -893,6 +933,16 @@ member functions and common member functions are listed in
     }
 \completeTable
 %------------------------------------------------------------------------------
+
+%*******************************************************************************
+% Local accessor Properties
+%*******************************************************************************
+
+\subsubsection{Local accessor properties}
+\label{sub.section.accessors.local.properties}
+
+Construction of the SYCL local \codeinline{accessor} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
 
 %******************************************************************************
 % Image accessor
@@ -1010,18 +1060,20 @@ Tables~\ref{table.specialmembers.common.reference} and
   \addRowThreeL
     { template <typename AllocatorT> }
     { accessor(image<dimensions, AllocatorT> }
-    { \&imageRef) }
+    { \&imageRef, const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{accessTarget ==
       access::target::host_image}.
       \newline
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{image} immediately on the host.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRowThreeL
+  \addRowFourL
     { template <typename AllocatorT> }
     { accessor(image<dimensions, AllocatorT> }
-    { \&imageRef, handler \&commandGroupHandlerRef) }
+    { \&imageRef, handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{accessTarget ==
       access::target::image}.
@@ -1029,11 +1081,13 @@ Tables~\ref{table.specialmembers.common.reference} and
       Constructs a SYCL \codeinline{accessor} instance for accessing a SYCL
       \codeinline{image} within a SYCL kernel function on the SYCL
       \codeinline{queue} associated with \codeinline{commandGroupHandlerRef}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
-  \addRowThreeL
+  \addRowFourL
     { template <typename AllocatorT> }
     { accessor(image<dimensions + 1, AllocatorT> }
-    { \&imageRef, handler \&commandGroupHandlerRef) }
+    { \&imageRef, handler \&commandGroupHandlerRef, }
+    { const property_list \&propList = \{\}) }
     {
       Available only when: \codeinline{accessTarget ==
       access::target::image_array \&\& dimensions < 3}.
@@ -1042,6 +1096,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{image} as an array of images, within a SYCL kernel function on
       the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{accessor} object.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -1052,37 +1107,15 @@ Tables~\ref{table.specialmembers.common.reference} and
     image specialization}
   {table.members.accessor.image}
   \addRow
+    { size_t get_size() const }
+    {
+      Returns the size in bytes of the SYCL \codeinline{image} this SYCL
+      \codeinline{accessor} is accessing.
+    }
+  \addRow
     { size_t get_count() const }
     {
       Returns the number of elements of the SYCL \codeinline{image} this SYCL \codeinline{accessor} is accessing.
-    }
-  \addRow
-    { range<dimensions+1> get_range() const }
-    {
-      Available only when:
-      \codeinline{accessTarget == access::target::image_array)}.
-      \newline
-      Returns a \codeinline{range} object which represents the number of
-      elements of \codeinline{dataT} per dimension that this
-      \codeinline{accessor} may access.
-      \newline
-      The \codeinline{range} object returned must equal to the
-      \codeinline{range} of the \codeinline{image} this \codeinline{accessor}
-      is associated with.
-    }
-  \addRow
-    { range<dimensions> get_range() const }
-    {
-      Available only when:
-      \codeinline{accessTarget != access::target::image_array)}.
-      \newline
-      Returns a \codeinline{range} object which represents the number of
-      elements of \codeinline{dataT} per dimension that this
-      \codeinline{accessor} may access.
-      \newline
-      The \codeinline{range} object returned must equal to the
-      \codeinline{range} of the \codeinline{image} this \codeinline{accessor}
-      is associated with.
     }
   \addRowTwoSL
     { template <typename coordT> }
@@ -1142,6 +1175,17 @@ Tables~\ref{table.specialmembers.common.reference} and
       by \codeinline{index}.
     }
 \completeTable
+%-------------------------------------------------------------------------------
+
+%*******************************************************************************
+% Image accessor Properties
+%*******************************************************************************
+
+\subsubsection{Image accessor properties}
+\label{sub.section.accessors.image.properties}
+
+Construction of the SYCL image \codeinline{accessor} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
 
 \clearpage
 

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -2140,8 +2140,7 @@ A SYCL \codeinline{program} can be queried for all of the following information 
 \subsubsection{Program properties}
 \label{sec:interfaces.program.properties}
 
-Construction of the SYCL \codeinline{program} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 %*******************************************************************************
 % Defining kernels

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1956,26 +1956,68 @@ A synopsis of the SYCL \codeinline{program} class is provided below. The constru
     {
       Default constructor is deleted.
     }
-  \addRowTwoL
-    {explicit program (}
-    {const context \&context)}
-    {
-      Constructs an instance of SYCL \codeinline{program} in the \codeinline{program_state::none} state, associated with the \codeinline{context} provides and the SYCL \codeinline{device}s that are associated with the \codeinline{context}.
-    }
   \addRowThreeL
+    {explicit program (}
+    {const context \&context,}
+    {const property_list \&propList = \{\})}
+    {
+      Constructs an instance of SYCL \codeinline{program} in the
+      \codeinline{program_state::none} state, associated with the
+      \codeinline{context} provides and the SYCL \codeinline{device}s that are
+      associated with the \codeinline{context}.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{program} object.
+    }
+  \addRowFourL
     {program (}
     {const context \&context,}
-    {vector_class<device> deviceList)}
+    {vector_class<device> deviceList,}
+    {const property_list \&propList = \{\})}
     {
-      Constructs an instance of SYCL \codeinline{program} in the \codeinline{program_state::none} state, associated with the \codeinline{context} provides and \codeinline{deviceList}.
+      Constructs an instance of SYCL \codeinline{program} in the
+      \codeinline{program_state::none} state, associated with the
+      \codeinline{context} provides and \codeinline{deviceList}.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{program} object.
     }
   \addRowThreeL
     {program (}
     {vector_class<program> programList,}
-    {string_class linkOptions = "")}
+    {const property_list \&propList = \{\})}
     {
-      Constructs an instance of SYCL \codeinline{program} in the \codeinline{program_state::linked} by linking together each SYCL \codeinline{program} instance in \codeinline{programList}. Each SYCL \codeinline{program} in \codeinline{programList} must be in the \codeinline{program_state::compiled} state and must be associated with the same SYCL \codeinline{context}. Otherwise must throw an \codeinline{invalid_object_error} SYCL exception.  Must throw a \codeinline{feature_not_supported} SYCL exception if any device that the program is to be linked for returns \codeinline{false} for the device information query \codeinline{info::device::is_linker_available}.
-
+      Constructs an instance of SYCL \codeinline{program} in the
+      \codeinline{program_state::linked} by linking together each SYCL
+      \codeinline{program} instance in \codeinline{programList}. Each SYCL
+      \codeinline{program} in \codeinline{programList} must be in the
+      \codeinline{program_state::compiled} state and must be associated with the
+      same SYCL \codeinline{context}. Otherwise must throw an
+      \codeinline{invalid_object_error} SYCL exception.  Must throw a
+      \codeinline{feature_not_supported} SYCL exception if any device that the
+      program is to be linked for returns \codeinline{false} for the device
+      information query \codeinline{info::device::is_linker_available}.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{program} object.
+    }
+  \addRowFourL
+    {program (}
+    {vector_class<program> programList,}
+    {string_class linkOptions,}
+    {const property_list \&propList = \{\})}
+    {
+      Constructs an instance of SYCL \codeinline{program} in the
+      \codeinline{program_state::linked} by linking together each SYCL
+      \codeinline{program} instance in \codeinline{programList} with the
+      compiler options specified by \codeinline{linkOptions}. Each SYCL
+      \codeinline{program} in \codeinline{programList} must be in the
+      \codeinline{program_state::compiled} state and must be associated with the
+      same SYCL \codeinline{context}. Otherwise must throw an
+      \codeinline{invalid_object_error} SYCL exception.
+      Must throw a \codeinline{feature_not_supported} SYCL exception if any
+      device that the program is to be linked for returns \codeinline{false} for
+      the device information query
+      \codeinline{info::device::is_linker_available}.
+      The optional \codeinline{property_list} provides properties for the
+      constructed SYCL \codeinline{program} object.
     }
   \addRowThreeL
     {program (}

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1930,6 +1930,10 @@ This constructor links them together into a new SYCL \codeinline{program}.
 
 The encapsulated \codeinline{cl_program} of an OpenCL program can contain either SYCL kernel functions or OpenCL C kernel functions. When a \codeinline{program} instance is constructed using a non-OpenCL interoperability constructor, it is in the \codeinline{program_state::none} state and should then be compiled or built by specifying the SYCL kernel name (either the type of the function object or the explicit kernel name type specified when defining the SYCL kernel function). When a \codeinline{program} instance is constructed using an OpenCL interoperability constructor, it can be in either the \codeinline{program_state::compiled} or \codeinline{program_state::linked} state  and should not be compiled or built, only linked.
 
+With the exception of the interoperability constructor, each constructor takes as the last
+parameter an optional SYCL \codeinline{property_list} to provide properties to
+the SYCL \codeinline{program}.
+
 The compiler options that can be provided are described in the OpenCL specification \cite[p.~145, \S~5.6.4]{opencl12} and the linker options that can be provided are described in \cite[p.~148,\S~5.6.5]{opencl12}.
 
 The SYCL \codeinline{program} class provides the common reference semantics
@@ -2127,6 +2131,17 @@ A SYCL \codeinline{program} can be queried for all of the following information 
       Returns a \codeinline{vector_class} containing the SYCL \codeinline{device}s that this \codeinline{program} has been compiled for.
     }
 \completeInfoTable
+%-------------------------------------------------------------------------------
+
+%*******************************************************************************
+% Program Properties
+%*******************************************************************************
+
+\subsubsection{Program properties}
+\label{sec:interfaces.program.properties}
+
+Construction of the SYCL \codeinline{program} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
 
 %*******************************************************************************
 % Defining kernels

--- a/latex/headers/accessorBuffer.h
+++ b/latex/headers/accessorBuffer.h
@@ -29,14 +29,14 @@ class accessor {
   || accessTarget == access::target::constant_buffer))) && dimensions == 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
-      const property_list &propList = {});
+           const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions == 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
-      handler &commandGroupHandlerRef, const property_list &propList = {});
+           handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: ((isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
@@ -44,14 +44,14 @@ class accessor {
   || accessTarget == access::target::constant_buffer))) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      const property_list &propList = {});
+           const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      handler &commandGroupHandlerRef, const property_list &propList = {});
+           handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
@@ -59,7 +59,7 @@ class accessor {
   || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      range<dimensions> accessRange, const property_list &propList = {});
+           range<dimensions> accessRange, const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
@@ -67,24 +67,24 @@ class accessor {
   || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      range<dimensions> accessRange, id<dimensions> accessOffset,
-      const property_list &propList = {});
+           range<dimensions> accessRange, id<dimensions> accessOffset,
+           const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      handler &commandGroupHandlerRef, range<dimensions> accessRange,
-      const property_list &propList = {});
+           handler &commandGroupHandlerRef, range<dimensions> accessRange,
+           const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-      handler &commandGroupHandlerRef, range<dimensions> accessRange,
-      id<dimensions> accessOffset, const property_list &propList = {});
+           handler &commandGroupHandlerRef, range<dimensions> accessRange,
+           id<dimensions> accessOffset, const property_list &propList = {});
 
   /* -- common interface members -- */
 

--- a/latex/headers/accessorBuffer.h
+++ b/latex/headers/accessorBuffer.h
@@ -28,45 +28,67 @@ class accessor {
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer))) && dimensions == 0 */
   template <typename AllocatorT>
-  accessor(buffer<dataT, 1, AllocatorT> &bufferRef);
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
+      const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions == 0 */
   template <typename AllocatorT>
-  accessor(buffer<dataT, 1, AllocatorT> &bufferRef, handler &commandGroupHandlerRef);
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
+      handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: ((isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer))) && dimensions > 0 */
   template <typename AllocatorT>
-  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef);
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+      const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef);
+      handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   accessTarget == access::target::host_buffer) || (isPlaceholder ==
   access::placeholder::true_t && (accessTarget == access::target::global_buffer
   || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
-  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef, range<dimensions> accessRange,
-    id<dimensions> accessOffset = {});
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+      range<dimensions> accessRange, const property_list &propList = {});
+
+  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
+  accessTarget == access::target::host_buffer) || (isPlaceholder ==
+  access::placeholder::true_t && (accessTarget == access::target::global_buffer
+  || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+      range<dimensions> accessRange, id<dimensions> accessOffset,
+      const property_list &propList = {});
 
   /* Available only when: (isPlaceholder == access::placeholder::false_t &&
   (accessTarget == access::target::global_buffer || accessTarget ==
   access::target::constant_buffer)) && dimensions > 0 */
   template <typename AllocatorT>
   accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef, range<dimensions> accessRange,
-    id<dimensions> accessOffset = {});
+      handler &commandGroupHandlerRef, range<dimensions> accessRange,
+      const property_list &propList = {});
+
+  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
+  (accessTarget == access::target::global_buffer || accessTarget ==
+  access::target::constant_buffer)) && dimensions > 0 */
+  template <typename AllocatorT>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+      handler &commandGroupHandlerRef, range<dimensions> accessRange,
+      id<dimensions> accessOffset, const property_list &propList = {});
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   constexpr bool is_placeholder() const;
 

--- a/latex/headers/accessorImage.h
+++ b/latex/headers/accessorImage.h
@@ -25,20 +25,23 @@ class accessor {
 
   /* Available only when: accessTarget == access::target::host_image */
   template <typename AllocatorT>
-  accessor(image<dimensions, AllocatorT> &imageRef);
+  accessor(image<dimensions, AllocatorT> &imageRef,
+      const property_list &propList = {});
 
   /* Available only when: accessTarget == access::target::image */
   template <typename AllocatorT>
   accessor(image<dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef);
+    handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: accessTarget == access::target::image_array &&
   dimensions < 3 */
   template <typename AllocatorT>
   accessor(image<dimensions + 1, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef);
+    handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   size_t get_count() const;
 

--- a/latex/headers/accessorImage.h
+++ b/latex/headers/accessorImage.h
@@ -26,18 +26,18 @@ class accessor {
   /* Available only when: accessTarget == access::target::host_image */
   template <typename AllocatorT>
   accessor(image<dimensions, AllocatorT> &imageRef,
-      const property_list &propList = {});
+           const property_list &propList = {});
 
   /* Available only when: accessTarget == access::target::image */
   template <typename AllocatorT>
   accessor(image<dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef, const property_list &propList = {});
+           handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* Available only when: accessTarget == access::target::image_array &&
   dimensions < 3 */
   template <typename AllocatorT>
   accessor(image<dimensions + 1, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef, const property_list &propList = {});
+           handler &commandGroupHandlerRef, const property_list &propList = {});
 
   /* -- common interface members -- */
 

--- a/latex/headers/accessorLocal.h
+++ b/latex/headers/accessorLocal.h
@@ -24,12 +24,16 @@ class accessor {
   using const_reference = const dataT &;
 
   /* Available only when: dimensions == 0 */
-  accessor(handler &commandGroupHandlerRef);
+  accessor(handler &commandGroupHandlerRef,
+      const property_list &propList = {});
 
   /* Available only when: dimensions > 0 */
-  accessor(range<dimensions> allocationSize, handler &commandGroupHandlerRef);
+  accessor(range<dimensions> allocationSize, handler &commandGroupHandlerRef,
+      const property_list &propList = {});
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   size_t get_size() const;
 

--- a/latex/headers/accessorLocal.h
+++ b/latex/headers/accessorLocal.h
@@ -25,11 +25,11 @@ class accessor {
 
   /* Available only when: dimensions == 0 */
   accessor(handler &commandGroupHandlerRef,
-      const property_list &propList = {});
+           const property_list &propList = {});
 
   /* Available only when: dimensions > 0 */
   accessor(range<dimensions> allocationSize, handler &commandGroupHandlerRef,
-      const property_list &propList = {});
+           const property_list &propList = {});
 
   /* -- common interface members -- */
 

--- a/latex/headers/context.h
+++ b/latex/headers/context.h
@@ -16,18 +16,32 @@ namespace cl {
 namespace sycl {
 class context {
  public:
-  explicit context(async_handler asyncHandler = {});
+  explicit context(const property_list &propList = {});
 
-  context(const device &dev, async_handler asyncHandler = {});
+  context(async_handler asyncHandler,
+      const property_list &propList = {});
 
-  context(const platform &plt, async_handler asyncHandler = {});
+  context(const device &dev, const property_list &propList = {});
+
+  context(const device &dev, async_handler asyncHandler,
+      const property_list &propList = {});
+
+  context(const platform &plt, const property_list &propList = {});
+
+  context(const platform &plt, async_handler asyncHandler,
+      const property_list &propList = {});
 
   context(const vector_class<device> &deviceList,
-    async_handler asyncHandler = {});
+      const property_list &propList = {});
+
+  context(const vector_class<device> &deviceList,
+      async_handler asyncHandler, const property_list &propList = {});
 
   context(cl_context clContext, async_handler asyncHandler = {});
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   cl_context get() const;
 

--- a/latex/headers/context.h
+++ b/latex/headers/context.h
@@ -19,23 +19,23 @@ class context {
   explicit context(const property_list &propList = {});
 
   context(async_handler asyncHandler,
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   context(const device &dev, const property_list &propList = {});
 
   context(const device &dev, async_handler asyncHandler,
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   context(const platform &plt, const property_list &propList = {});
 
   context(const platform &plt, async_handler asyncHandler,
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   context(const vector_class<device> &deviceList,
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   context(const vector_class<device> &deviceList,
-      async_handler asyncHandler, const property_list &propList = {});
+          async_handler asyncHandler, const property_list &propList = {});
 
   context(cl_context clContext, async_handler asyncHandler = {});
 

--- a/latex/headers/programWIP.h
+++ b/latex/headers/programWIP.h
@@ -25,13 +25,13 @@ class program {
   program() = delete;
 
   explicit program(const context &context,
-      const property_list &propList = {});
+                   const property_list &propList = {});
 
   program(const context &context, vector_class<device> deviceList,
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   program(vector_class<program> &programList, string_class linkOptions = "",
-      const property_list &propList = {});
+          const property_list &propList = {});
 
   program(const context &context, cl_program clProgram);
 
@@ -46,12 +46,14 @@ class program {
   template <typename kernelT>
   void compile_with_kernel_type(string_class compileOptions = "");
 
-  void compile_with_source(string_class kernelSource, string_class compileOptions = "");
+  void compile_with_source(string_class kernelSource,
+                           string_class compileOptions = "");
 
   template <typename kernelT>
   void build_with_kernel_type(string_class buildOptions = "");
 
-  void build_with_source(string_class kernelSource, string_class buildOptions = "");
+  void build_with_source(string_class kernelSource,
+                         string_class buildOptions = "");
 
   void link(string_class linkOptions = "");
 

--- a/latex/headers/programWIP.h
+++ b/latex/headers/programWIP.h
@@ -30,7 +30,10 @@ class program {
   program(const context &context, vector_class<device> deviceList,
           const property_list &propList = {});
 
-  program(vector_class<program> &programList, string_class linkOptions = "",
+  program(vector_class<program> &programList,
+          const property_list &propList = {});
+
+  program(vector_class<program> &programList, string_class linkOptions,
           const property_list &propList = {});
 
   program(const context &context, cl_program clProgram);

--- a/latex/headers/programWIP.h
+++ b/latex/headers/programWIP.h
@@ -24,15 +24,20 @@ class program {
  public:
   program() = delete;
 
-  explicit program(const context &context);
+  explicit program(const context &context,
+      const property_list &propList = {});
 
-  program(const context &context, vector_class<device> deviceList);
+  program(const context &context, vector_class<device> deviceList,
+      const property_list &propList = {});
 
-  program(vector_class<program> programList, string_class linkOptions = "");
+  program(vector_class<program> &programList, string_class linkOptions = "",
+      const property_list &propList = {});
 
   program(const context &context, cl_program clProgram);
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   cl_program get() const;
 

--- a/latex/headers/sampler.h
+++ b/latex/headers/sampler.h
@@ -35,12 +35,15 @@ enum class coordinate_normalization_mode : unsigned int {
 
 class sampler {
  public:
-  sampler(coordinate_normalization_mode normalizationMode, addressing_mode addressingMode,
-          filtering_mode filteringMode);
+  sampler(coordinate_normalization_mode normalizationMode,
+      addressing_mode addressingMode, filterin_mode filteringMode,
+      const property_list &propList = {});
 
   sampler(cl_sampler clSampler, const context &syclContext);
 
   /* -- common interface members -- */
+
+  /* -- property interface members -- */
 
   addressing_mode get_addressing_mode() const;
 

--- a/latex/headers/sampler.h
+++ b/latex/headers/sampler.h
@@ -36,8 +36,8 @@ enum class coordinate_normalization_mode : unsigned int {
 class sampler {
  public:
   sampler(coordinate_normalization_mode normalizationMode,
-      addressing_mode addressingMode, filtering_mode filteringMode,
-      const property_list &propList = {});
+          addressing_mode addressingMode, filtering_mode filteringMode,
+          const property_list &propList = {});
 
   sampler(cl_sampler clSampler, const context &syclContext);
 

--- a/latex/headers/sampler.h
+++ b/latex/headers/sampler.h
@@ -36,7 +36,7 @@ enum class coordinate_normalization_mode : unsigned int {
 class sampler {
  public:
   sampler(coordinate_normalization_mode normalizationMode,
-      addressing_mode addressingMode, filterin_mode filteringMode,
+      addressing_mode addressingMode, filtering_mode filteringMode,
       const property_list &propList = {});
 
   sampler(cl_sampler clSampler, const context &syclContext);

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -243,7 +243,15 @@ These common special member functions and hidden friend functions are described 
 %*********************************************************************
 \subsection{Properties}
 
-Each of the following \gls{sycl-runtime} classes: \codeinline{buffer}, \codeinline{image} and \codeinline{queue} provide an optional parameter in each of their constructors to provide a \codeinline{property_list} which contains zero or more properties. Each of those properties augments the semantics of the class with a particular feature. Each of those classes must also provide \codeinline{has_property} and \codeinline{get_property} member functions for querying for a particular property.
+Each of the following \gls{sycl-runtime} classes: \codeinline{context},
+\codeinline{queue}, \codeinline{buffer}, \codeinline{image},
+\codeinline{accessor}, \codeinline{sampler}, and \codeinline{program} provide an
+optional parameter in each of their constructors to provide a
+\codeinline{property_list} which contains zero or more properties. Each of those
+properties augments the semantics of the class with a particular feature. Each
+of those classes must also provide \codeinline{has_property} and
+\codeinline{get_property} member functions for querying for a particular
+property.
 
 The listing below illustrates the usage of various buffer properties, described in \ref{sec:buffer-properties}.
 
@@ -647,6 +655,10 @@ All member functions of the \gls{context} class are synchronous and errors are h
 
 All constructors of the SYCL \gls{context} class, excluding the interoperability constructor, will construct either an OpenCL context or a host context, determined by the constructor parameters or, in the case of the default constructor, the SYCL \codeinline{device} produced by the \codeinline{default_selector}. If the SYCL \codeinline{platform} or SYCL \codeinline{device} is a host platform or host device respectively then the constructed SYCL \codeinline{context} is a host context. Subsequently if the constructed SYCL \codeinline{context} is a host context, then the associated SYCL \codeinline{platform} must be a host platform and the constructed SYCL \codeinline{context} must have a single associated SYCL \codeinline{device} that is a host device.
 
+With the exception of the interoperability constructor, each constructor takes as the last
+parameter an optional SYCL \codeinline{property_list} to provide properties to
+the SYCL \codeinline{context}.
+
 A SYCL \codeinline{context} can optionally be constructed with an \codeinline{async_handler} parameter. In this case the \codeinline{async_handler} provided is passed on to a SYCL \codeinline{queue} to be used to report asynchronous SYCL exceptions.
 
 Information about a SYCL \gls{context} may be queried through the \codeinline{get_info()}
@@ -758,6 +770,16 @@ A SYCL \codeinline{context} can be queried for all of the following information 
 \completeInfoTable
 
 %------------------------------------------------------------------------------------------------------
+
+%*******************************************************************************
+% Context Properties
+%*******************************************************************************
+
+\subsubsection{Context properties}
+\label{sec:context-properties}
+
+Construction of the SYCL \codeinline{context} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
 
 %***********************************************************************************
 % Device class
@@ -1424,7 +1446,7 @@ The SYCL \codeinline{buffer} class template takes a template parameter \codeinli
 \completeTable
 %------------------------------------------------------------------------------------------------------
 
-\subsubsection{Buffer Properties}
+\subsubsection{Buffer properties}
 \label{sec:buffer-properties}
 
 The properties that can be provided when constructing the SYCL \codeinline{buffer} class are describe in Table~\ref{table.properties.buffer}.
@@ -2022,7 +2044,7 @@ The SYCL \codeinline{image} class template takes a template parameter \codeinlin
 \completeInfoTable
 %------------------------------------------------------------------------------------------------------
 
-\subsubsection{Image Properties}
+\subsubsection{Image properties}
 \label{sec:image-properties}
 
 The properties that can be provided when constructing the SYCL \codeinline{image} class are describe in Table~\ref{table.properties.image}.
@@ -2773,14 +2795,16 @@ The members of the \codeinline{sampler} class that provide information on the sa
 \startTable{Constructor}
 \addFootNotes {Constructors the \codeinline{sampler} class}
 {table.constructors.sampler}
-  \addRowFourL
+  \addRowFiveL
     {sampler(}
     {  coordinate_normalization_mode normalizationMode,}
     {  addressing_mode addressingMode,}
-    {  filtering_mode filteringMode)}
+    {  filtering_mode filteringMode,}
+    {  const property_list \&propList = \{\})}
     {
       Constructs a SYCL \codeinline{sampler} instance with address mode, filtering mode and coordinate normalization mode specified by the respective parameters.
       It is not valid to construct a SYCL \codeinline{sampler} within a SYCL kernel function.
+      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{sampler} object.
     }
   \addRowTwoL
     { sampler(cl_sampler clSampler, }
@@ -2812,6 +2836,16 @@ The members of the \codeinline{sampler} class that provide information on the sa
     }
 \completeTable
 %------------------------------------------------------------------------------------------------------
+
+%*******************************************************************************
+% Sampler Properties
+%*******************************************************************************
+
+\subsection{Sampler properties}
+\label{sec:sampler-properties}
+
+Construction of the SYCL \codeinline{sampler} class does not accept any properties.
+The \codeinline{property_list} constructor parameters are present for future extensibility.
 
 %***********************************************************************************
 % Expressing parallelism through kernels

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -778,8 +778,7 @@ A SYCL \codeinline{context} can be queried for all of the following information 
 \subsubsection{Context properties}
 \label{sec:context-properties}
 
-Construction of the SYCL \codeinline{context} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 %***********************************************************************************
 % Device class
@@ -2846,8 +2845,7 @@ The members of the \codeinline{sampler} class that provide information on the sa
 \subsection{Sampler properties}
 \label{sec:sampler-properties}
 
-Construction of the SYCL \codeinline{sampler} class does not accept any properties.
-The \codeinline{property_list} constructor parameters are present for future extensibility.
+The \codeinline{property_list} constructor parameters are present for extensibility.
 
 %***********************************************************************************
 % Expressing parallelism through kernels

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -2804,13 +2804,15 @@ The members of the \codeinline{sampler} class that provide information on the sa
     {
       Constructs a SYCL \codeinline{sampler} instance with address mode, filtering mode and coordinate normalization mode specified by the respective parameters.
       It is not valid to construct a SYCL \codeinline{sampler} within a SYCL kernel function.
-      The optional \codeinline{property_list} parameters provides properties for the constructed SYCL \codeinline{sampler} object.
+      The optional \codeinline{property_list} provides properties for the constructed SYCL \codeinline{sampler} object.
     }
   \addRowTwoL
     { sampler(cl_sampler clSampler, }
     { const context \&syclContext) }
     {  
-      Constructs a SYCL \codeinline{sampler} instance from an OpenCL \codeinline{cl_sampler} in accordance with the requirements described in \ref{sec:opencl-interoperability}.
+      Constructs a SYCL \codeinline{sampler} instance from an OpenCL
+      \codeinline{cl_sampler} in accordance with the requirements described in
+      \ref{sec:opencl-interoperability}.
     }
 \completeTable
 %------------------------------------------------------------------------------------------------------

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -301,7 +301,7 @@ in appendix~\ref{appendix.queue.descriptors}.
 {Return the command-queue reference count.}
 \completeTable
 
-\subsubsection{Queue Properties}
+\subsubsection{Queue properties}
 \label{sec:queue-properties}
 
 The properties that can be provided when constructing the SYCL

--- a/latex/sycl-1.2.1.tex
+++ b/latex/sycl-1.2.1.tex
@@ -1,4 +1,3 @@
-
 % Copyright (c) 2012-2019 Khronos Group.
 %
 % This work is licensed under a Creative Commons Attribution 4.0

--- a/latex/sycl-1.2.1.tex
+++ b/latex/sycl-1.2.1.tex
@@ -1,3 +1,4 @@
+
 % Copyright (c) 2012-2019 Khronos Group.
 %
 % This work is licensed under a Creative Commons Attribution 4.0


### PR DESCRIPTION
Adds optional `property_list` parameters to all user-constructible SYCL
object constructors that did not have it before.

This is the wording related [this proposal](https://github.com/codeplaysoftware/standards-proposals/blob/master/general_property_lists/general_property_lists.md) which has been discussed internally.