### PR TITLE
SYCL is an independent Khronos working group since September 20, 2019

### DIFF
--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -13,7 +13,7 @@
 
 
 %The purpose of this glossary is to define the key concepts involved in
-%specifying OpenCL SYCL. This section includes definitions of terminology used
+%specifying SYCL. This section includes definitions of terminology used
 %throughout the specification document.
 \makenoidxglossaries
 \glstoctrue

--- a/latex/sycl-1.2.1.tex
+++ b/latex/sycl-1.2.1.tex
@@ -79,8 +79,8 @@ idx)
 }
 
 \vskip 1cm
-{Khronos\textsuperscript{\textregistered} OpenCL\texttrademark{}
-  Working Group --- SYCL\texttrademark{} subgroup}
+{Khronos\textsuperscript{\textregistered} SYCL\texttrademark{}
+  Working Group}
 \vskip 0.2cm
 {Editors: Ronan Keryell, Maria Rovatsou \& Lee Howes}
 


### PR DESCRIPTION
It is no longer a subgroup of the OpenCL working group.