### PR TITLE
Update the copyright lines

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2019 The Khronos Group Inc.
+Copyright (c) 2011-2020 The Khronos Group, Inc.
 
 This specification is protected by copyright laws and contains material proprietary
 to Khronos. Except as described by these terms, it or any components
@@ -27,7 +27,7 @@ otherwise, arising from or in connection with these materials.
 Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL,
 WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput,
 OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
-trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
+trademarks of The Khronos Group, Inc. ASTC is a trademark of ARM Holdings PLC,
 OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
 and the OpenGL ES and OpenGL SC logos are trademarks of Hewlett Packard Enterprise
 all used under license by Khronos. All other product names, trademarks,

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2020 The Khronos Group Inc.
+Copyright (c) 2011-2020 The Khronos Group, Inc.
 
 The files in, and generated output documents from this SYCL-Docs project are
 under a mix of copyright and license statements. Refer to the individual files

--- a/latex/Makefile
+++ b/latex/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2019 The Khronos Group Inc.
+# Copyright (c) 2012-2019 The Khronos Group, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/acknowledgements.tex
+++ b/latex/acknowledgements.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/builtin_functions.tex
+++ b/latex/builtin_functions.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/code/anatomy.cpp
+++ b/latex/code/anatomy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/basicParallelForItem.cpp
+++ b/latex/code/basicParallelForItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/basicparallelfor.cpp
+++ b/latex/code/basicparallelfor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/explicitcopy.cpp
+++ b/latex/code/explicitcopy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/largesample.cpp
+++ b/latex/code/largesample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/myfunctor.cpp
+++ b/latex/code/myfunctor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/mykernel.cpp
+++ b/latex/code/mykernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/myprogram.cpp
+++ b/latex/code/myprogram.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/myprogramlink.cpp
+++ b/latex/code/myprogramlink.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/parallelfor.cpp
+++ b/latex/code/parallelfor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/parallelforbarrier.cpp
+++ b/latex/code/parallelforbarrier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/parallelforworkgroup.cpp
+++ b/latex/code/parallelforworkgroup.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/parallelforworkgroup2.cpp
+++ b/latex/code/parallelforworkgroup2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/propertyExample.cpp
+++ b/latex/code/propertyExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/singletask.cpp
+++ b/latex/code/singletask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/code/syclkernel.cpp
+++ b/latex/code/syclkernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/conf.tex
+++ b/latex/conf.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/descriptors.tex
+++ b/latex/descriptors.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/device_to_device.tex
+++ b/latex/device_to_device.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/extensions.tex
+++ b/latex/extensions.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/glossary.tex
+++ b/latex/glossary.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/headers/accessMode.h
+++ b/latex/headers/accessMode.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/accessTarget.h
+++ b/latex/headers/accessTarget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/accessorBuffer.h
+++ b/latex/headers/accessorBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/accessorImage.h
+++ b/latex/headers/accessorImage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/accessorLocal.h
+++ b/latex/headers/accessorLocal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/atomic.h
+++ b/latex/headers/atomic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/atomicoperations.h
+++ b/latex/headers/atomicoperations.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/buffer.h
+++ b/latex/headers/buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/commandGroup.h
+++ b/latex/headers/commandGroup.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/commandGroupHandler.h
+++ b/latex/headers/commandGroupHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/common-byval.h
+++ b/latex/headers/common-byval.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/common-reference.h
+++ b/latex/headers/common-reference.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/context.h
+++ b/latex/headers/context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/contextInfo.h
+++ b/latex/headers/contextInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/device.h
+++ b/latex/headers/device.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/deviceEvent.h
+++ b/latex/headers/deviceEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/deviceInfo.h
+++ b/latex/headers/deviceInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/deviceSelector.h
+++ b/latex/headers/deviceSelector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/deviceSelectorInterface.h
+++ b/latex/headers/deviceSelectorInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/event.h
+++ b/latex/headers/event.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/eventInfo.h
+++ b/latex/headers/eventInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/exception.h
+++ b/latex/headers/exception.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/group.h
+++ b/latex/headers/group.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/hitem.h
+++ b/latex/headers/hitem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/id.h
+++ b/latex/headers/id.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/image.h
+++ b/latex/headers/image.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/item.h
+++ b/latex/headers/item.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/kernelInfo.h
+++ b/latex/headers/kernelInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/kernelWIP.h
+++ b/latex/headers/kernelWIP.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/multipointer.h
+++ b/latex/headers/multipointer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/ndRange.h
+++ b/latex/headers/ndRange.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/nditem.h
+++ b/latex/headers/nditem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/openclcInterop.h
+++ b/latex/headers/openclcInterop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/parallelFor.h
+++ b/latex/headers/parallelFor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/paramTraits.h
+++ b/latex/headers/paramTraits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/platform.h
+++ b/latex/headers/platform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/platformInfo.h
+++ b/latex/headers/platformInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/pointer.h
+++ b/latex/headers/pointer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/priv.h
+++ b/latex/headers/priv.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/programInfo.h
+++ b/latex/headers/programInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/programWIP.h
+++ b/latex/headers/programWIP.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/properties.h
+++ b/latex/headers/properties.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/queue.h
+++ b/latex/headers/queue.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/queueInfo.h
+++ b/latex/headers/queueInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/range.h
+++ b/latex/headers/range.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/sampler.h
+++ b/latex/headers/sampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/stlclasses.h
+++ b/latex/headers/stlclasses.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/stream.h
+++ b/latex/headers/stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/synchronization.h
+++ b/latex/headers/synchronization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/headers/vec.h
+++ b/latex/headers/vec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2020 The Khronos Group Inc.
+// Copyright (c) 2011-2020 The Khronos Group, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.

--- a/latex/host_acc.tex
+++ b/latex/host_acc.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/introduction.tex
+++ b/latex/introduction.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/overlap.tex
+++ b/latex/overlap.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/references.bib
+++ b/latex/references.bib
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/sycl-1.2.1.tex
+++ b/latex/sycl-1.2.1.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.
@@ -86,7 +86,7 @@ idx)
 
 \vskip 1cm
 \vbox{\hrulefill}
-\vbox{Copyright 2011-2019 The Khronos\textregistered{} Group Inc.\ All
+\vbox{Copyright 2011-2020 The Khronos\textregistered{} Group, Inc.\ All
   Rights Reserved}
 \end{center}
 
@@ -96,8 +96,8 @@ idx)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%% END TITLE PAGE
 
 
-\centerline{\large Copyright\textcopyright{} 2013-2019 The
-  Khronos\textregistered{} Group Inc.  All Rights Reserved.}
+\centerline{\large Copyright\textcopyright{} 2011-2020 The
+  Khronos\textregistered{} Group, Inc.  All Rights Reserved.}
 \vskip 3ex
 
 This specification is protected by copyright laws and contains

--- a/latex/sycl_explicit_memory.tex
+++ b/latex/sycl_explicit_memory.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/three_cg_one_queue.tex
+++ b/latex/three_cg_one_queue.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/three_cg_three_queue.tex
+++ b/latex/three_cg_three_queue.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.

--- a/latex/vec_class.tex
+++ b/latex/vec_class.tex
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2019 Khronos Group.
+% Copyright (c) 2011-2020 Khronos Group, Inc.
 %
 % This work is licensed under a Creative Commons Attribution 4.0
 % International License.


### PR DESCRIPTION
We are now in 2020.
I found some meeting notes on OpenCL HLM/SYCL back from 2011, so
update the start year to 2011.
Update the name to "Khronos Group, Inc."

This was done by running:

function update_copyright() {
  file_name="$1"
  # Update the copyright dates and names
  sed -i -e 's/2012-2019 Khronos Group./2011-2020 Khronos Group, Inc./g' \
    -e 's/The Khronos Group Inc./The Khronos Group, Inc./g' \
    -e 's/2012-2020 The Khronos Group, Inc./2011-2020 The Khronos Group, Inc./g' \
         $file_name
}

for f in `git ls-files`; do
  update_copyright "$f"
done