### PR TITLE
Add explicit keyword to Queue constructors

### DIFF
--- a/latex/headers/queue.h
+++ b/latex/headers/queue.h
@@ -18,33 +18,33 @@ class queue {
  public:
   explicit queue(const property_list &propList = {});
 
-  queue(const async_handler &asyncHandler,
+  explicit queue(const async_handler &asyncHandler,
     const property_list &propList = {});
 
-  queue(const device_selector &deviceSelector,
+  explicit queue(const device_selector &deviceSelector,
     const property_list &propList = {});
 
-  queue(const device_selector &deviceSelector,
+  explicit queue(const device_selector &deviceSelector,
       const async_handler &asyncHandler, const property_list &propList = {});
 
-  queue(const device &syclDevice, const property_list &propList = {});
+  explicit queue(const device &syclDevice, const property_list &propList = {});
 
-  queue(const device &syclDevice, const async_handler &asyncHandler,
+  explicit queue(const device &syclDevice, const async_handler &asyncHandler,
     const property_list &propList = {});
 
-  queue(const context &syclContext, const device_selector &deviceSelector,
+  explicit queue(const context &syclContext, const device_selector &deviceSelector,
     const property_list &propList = {});
 
-  queue(const context &syclContext, const device_selector &deviceSelector,
+  explicit queue(const context &syclContext, const device_selector &deviceSelector,
     const async_handler &asyncHandler, const property_list &propList = {});
 
-  queue(const context &syclContext, const device &syclDevice,
+  explicit queue(const context &syclContext, const device &syclDevice,
     const property_list &propList = {});
 
-  queue(const context &syclContext, const device &syclDevice,
+  explicit queue(const context &syclContext, const device &syclDevice,
     const async_handler &asyncHandler, const property_list &propList = {});
 
-  queue(cl_command_queue clQueue, const context& syclContext,
+  explicit queue(cl_command_queue clQueue, const context& syclContext,
     const async_handler &asyncHandler = {});
 
   /* -- common interface members -- */

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -79,7 +79,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       \codeinline{property_list}.
     }
   \addRowTwoL
-    { queue(const async_handler \&asyncHandler, }
+    { explicit queue(const async_handler \&asyncHandler, }
     { const property_list \&propList = \{\}) }
     {
       Constructs a SYCL \codeinline{queue} instance with an \codeinline{
@@ -89,7 +89,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       property_list}.
     }
   \addRowTwoL
-    { queue(const device_selector \&deviceSelector, }
+    { explicit queue(const device_selector \&deviceSelector, }
     { const property_list \&propList = \{\}) }
     {
       Constructs a SYCL \codeinline{queue} instance using the device returned by
@@ -108,7 +108,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       SYCL \codeinline{queue} via an instance of \codeinline{property_list}.
     }
   \addRowTwoL
-    { queue(const device \&syclDevice, }
+    { explicit queue(const device \&syclDevice, }
     { const property_list \&propList = \{\}) }
     {
       Constructs a SYCL \codeinline{queue} instance using the \codeinline{
@@ -117,7 +117,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       property_list}.
     }
   \addRowThreeL
-    { queue(const device \&syclDevice, }
+    { explicit queue(const device \&syclDevice, }
     { const async_handler \&asyncHandler, }
     { const property_list \&propList = \{\}) }
     {
@@ -127,7 +127,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       via an instance of \codeinline{property_list}.
     }
   \addRowThreeL
-    { queue(const context \&syclContext, }
+    { explicit queue(const context \&syclContext, }
     { const device_selector \&deviceSelector, }
     { const property_list \&propList = \{\}) }
     {
@@ -141,7 +141,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       via an instance of \codeinline{property_list}.
     }
   \addRowFourL
-    { queue(const context \&syclContext, }
+    { explicit queue(const context \&syclContext, }
     { const device_selector \&deviceSelector, }
     { const async_handler \&asyncHandler, }
     { const property_list \&propList = \{\}) }
@@ -156,7 +156,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       an instance of \codeinline{property_list}.
     }
   \addRowThreeL
-    { queue(const context \&syclContext, }
+    { explicit queue(const context \&syclContext, }
     { const device \&syclDevice, }
     { const property_list \&propList = \{\}) }
     {
@@ -170,7 +170,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       via an instance of \codeinline{property_list}.
     }
   \addRowFourL
-    { queue(const context \&syclContext, }
+    { explicit queue(const context \&syclContext, }
     { const device \&syclDevice, }
     { const async_handler \&asyncHandler, }
     { const property_list \&propList = \{\}) }
@@ -185,7 +185,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       an instance of \codeinline{property_list}.
     }
   \addRowThreeL
-    { queue(cl_command_queue clQueue,}
+    { explicit queue(cl_command_queue clQueue,}
     { const context \&syclContext, }
     { const async_handler \&asyncHandler = \{\}) }
     {


### PR DESCRIPTION
Implicit type conversions were causing conflicts between different
constructors. In particular, it wasn't defined whether a given
argument was a property_list or an async_handler.

This would close Issue #66 .