### PR TITLE
fixed a typo

### DIFF
--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -1448,7 +1448,7 @@ Table~\ref{table.members.handler.kernel} lists all the members of the
     \codeinline{parallel_for_work_item} methods representing the
     execution on each work-item. Launches
     \codeinline{num_work_groups} work-groups of
-    \codeinline{work_roup_size} work-items each. Described in
+    \codeinline{work_group_size} work-items each. Described in
     detail in~\ref{subsec:invokingkernels}.
   }
   \addRow


### PR DESCRIPTION
Fixed the typo work_roup_size

Signed-off-by: Byoungro So <byoungro.so@intel.com>