### PR TITLE
Add clarification to property_list constructor and supporting traits

### DIFF
--- a/latex/code/propertyExample.cpp
+++ b/latex/code/propertyExample.cpp
@@ -16,9 +16,9 @@
   context myContext;
 
   std::vector<buffer<int, 1>> bufferList {
-    buffer<int, 1>{},
-    buffer<int, 1>{property::use_host_ptr{}},
-    buffer<int, 1>{property::context_bound{myContext}}
+    buffer<int, 1>{ptr, rng},
+    buffer<int, 1>{ptr, rng, property::use_host_ptr{}},
+    buffer<int, 1>{ptr, rng, property::context_bound{myContext}}
   };
 
   for(auto& buf : bufferList) {

--- a/latex/headers/properties.h
+++ b/latex/headers/properties.h
@@ -14,6 +14,13 @@
 
 namespace cl {
 namespace sycl {
+
+template <typename propertyT>
+struct is_property;
+
+template <typename propertyT, typename syclObjectT>
+struct is_property_of;
+
 class T {
   ...
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -268,6 +268,40 @@ A synopsis of the common properties interface, the SYCL \codeinline{property_lis
 \lstinputlistingSkipLicense{headers/properties.h}
 
 %---------------------------------------------------------------------
+\startTable{Traits}
+\addFootNotes{Traits for properties}
+{table.traits.properties}
+\addRowTwoSL
+{ template <typename propertyT> }
+{ struct is_property }
+{
+  An explicit specialization of \codeinline{is_property} that inherits
+  from \codeinline{std::true_type} must be provided for each property,
+  where \codeinline{propertyT} is the class defining the property.
+  This includes both standard properties described in this
+  specification and any additional non-standard properties defined by
+  an implementation. All other specializations of
+  \codeinline{is_property} must inherit from
+  \codeinline{std::false_type}.
+}
+\addRowTwoSL
+{ template <typename propertyT, syclObjectT> }
+{ struct is_property_of }
+{
+  An explicit specialization of \codeinline{is_property_of} that
+  inherits from \codeinline{std::true_type} must be provided for each
+  property that can be used in constructing a given SYCL class, where
+  \codeinline{propertyT} is the class defining the property and
+  \codeinline{syclObjectT} is the SYCL class. This includes both
+  standard properties described in this specification and any
+  additional non-standard properties defined by an implementation. All
+  other specializations of \codeinline{is_property_of} must inherit
+  from \codeinline{std::false_type}.
+}
+\completeTable
+%---------------------------------------------------------------------
+
+%---------------------------------------------------------------------
 \startTable{Member function}
 \addFootNotes{Common member functions of the SYCL property interface}
 {table.members.propertyinterface}
@@ -299,6 +333,10 @@ A synopsis of the common properties interface, the SYCL \codeinline{property_lis
 { template <typename... propertyTN> }
 { property_list(propertyTN... props) }
 {
+  Available only when: \codeinline{is_property<property>::value}
+  evaluates to \codeinline{true} where \codeinline{property} is each
+  property in \codeinline{propertyTN}.
+  \newline
   Construct a SYCL \codeinline{property_list} with zero or more properties.
 }
 \completeTable


### PR DESCRIPTION
This change resolves a potential ambiguity in SYCL class constructors such as those which take an `async_handler` which can occur in some implementations. It also supports another clarification https://github.com/KhronosGroup/SYCL-Docs/pull/73 which extends support for properties to a number of other SYCL classes.

* Add minor fix to the properties example.
* Introduce `is_property` and `is_property_of` traits.
* Add clarification to `property_list` constructor such that it is only
available if all of the variadic parameters passed to it are of types
which are valid properties, evaluated via `is_property`.