### PR TITLE
clarified the buffer conversion to C++ pointer types

### DIFF
--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -1124,8 +1124,8 @@ The fundamental differences between a buffer and an image object are:
     \item
         Elements in a buffer are stored in an array of 1, 2 or 3
         dimensions and can be accessed using an accessor by a kernel
-        executing on a device. The accessors for kernels can be
-        converted within a kernel into C++ pointer types, or
+        executing on a device. The accessors for kernels provide a method
+        to get C++ pointer types, or
         the \codeinline{cl::sycl::global_ptr},
         \codeinline{cl::sycl::constant_ptr} classes.
         Elements of an image are


### PR DESCRIPTION
According to https://github.com/KhronosGroup/SYCL-Docs/pull/44,
we already decided not to support coversion of a buffer to a C++ pointer type.
Now, the user can use the method `get_pointer()` instead.
This patch just clarifies this new decision in the architecture section.

Signed-off-by: Byoungro So <byoungro.so@intel.com>