### PR TITLE
Move description of "half" to the right table

### DIFF
--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -336,17 +336,6 @@ Table~\ref{table.types.fundamental}.
   A 64-bit floating-point. The double data type must conform to the IEEE 754
   double precision storage format.
 }
-\addRow
-{
-  half
-}
-{
-  A 16-bit floating-point. The half data type must conform to the IEEE 754-2008
-  half precision storage format. A SYCL \codeinline{feature_not_supported}
-  exception must be thrown if the \codeinline{half} type is used in a SYCL
-  kernel function which executes on a SYCL \codeinline{device} that does not
-  support the extension \codeinline{khr_fp16}.
-}
 \completeTable
 %-------------------------------------------------------------------------------
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3153,8 +3153,19 @@ cl::sycl} namespace are described in Table~\ref{table.types.additional}.
 {
   byte
 }
-{
+{%
   A signed or unsigned 8-bit integer, as defined by the C++11 ISO Standard.
+}
+\addRow
+{
+  half
+}
+{%
+  A 16-bit floating-point. The half data type must conform to the IEEE 754-2008
+  half precision storage format. A SYCL \codeinline{feature_not_supported}
+  exception must be thrown if the \codeinline{half} type is used in a SYCL
+  kernel function which executes on a SYCL \codeinline{device} that does not
+  support the extension \codeinline{khr_fp16}.
 }
 \completeTable
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
half is not a C++ native type but an additional SYCL scalar data type.

This should close https://github.com/KhronosGroup/SYCL-Docs/issues/40