### PR TITLE
Replaced std::nullptr typos with nullptr

### DIFF
--- a/latex/headers/buffer.h
+++ b/latex/headers/buffer.h
@@ -116,7 +116,7 @@ class buffer {
     range<dimensions> accessRange, id<dimensions> accessOffset = {});
 
   template <typename Destination = std::nullptr_t>
-  void set_final_data(Destination finalData = std::nullptr);
+  void set_final_data(Destination finalData = nullptr);
 
   void set_write_back(bool flag = true);
 

--- a/latex/headers/image.h
+++ b/latex/headers/image.h
@@ -167,7 +167,7 @@ class image {
   get_access();
 
   template <typename Destination = std::nullptr_t>
-  void set_final_data(Destination finalData = std::nullptr);
+  void set_final_data(Destination finalData = nullptr);
 
   void set_write_back(bool flag = true);
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -1459,7 +1459,7 @@ The SYCL \codeinline{buffer} class template takes a template parameter \codeinli
 
    \addRowTwoL
     {template <typename Destination = std::nullptr_t>}
-    {void set_final_data(Destination finalData = std::nullptr)}
+    {void set_final_data(Destination finalData = nullptr)}
     {
       The \codeinline{finalData} points to where the outcome of all
       the buffer processing is going to be copied to at destruction
@@ -2080,7 +2080,7 @@ The SYCL \codeinline{image} class template takes a template parameter \codeinlin
     }
    \addRowTwoL
     {template <typename Destination = std::nullptr_t>}
-    {void set_final_data(Destination finalData = std::nullptr)}
+    {void set_final_data(Destination finalData = nullptr)}
     {
 
       The \codeinline{finalData} points to where the output of all
@@ -2327,7 +2327,7 @@ This behavior can be overiden using the \codeinline{set_final_data()} method of
 the buffer class, which will by any means force the buffer destructor to
 wait until the data is copied to wherever the \codeinline{set_final_data()} method has
 put the data (or not wait nor copy if set final data is
-\codeinline{std::nullptr}).
+\codeinline{nullptr}).
 
 \begin{code}
 {


### PR DESCRIPTION
There are a few examples of `std::nullptr` written in the spec. This PR fixes this by replacing these typos with `nullptr`. Closes #52.