### PR TITLE
Clarify range of zero dimension accessors

### DIFF
--- a/latex/accessors.tex
+++ b/latex/accessors.tex
@@ -371,7 +371,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       access::target::constant_buffer))) \&\& dimensions == 0}.
       \newline
       If \codeinline{isPlaceholder == access::placeholder::false_t}, constructs
-      a SYCL \codeinline{accessor} instance for accessing a single element of a
+      a SYCL \codeinline{accessor} instance for accessing the first element of a
       SYCL \codeinline{buffer} immediately on the host. If \codeinline{
       isPlaceholder == access::placeholder::true_t}, constructs a SYCL
       placeholder \codeinline{accessor}.
@@ -388,7 +388,7 @@ Tables~\ref{table.specialmembers.common.reference} and
       access::target::global_buffer || accessTarget ==
       access::target::constant_buffer)) \&\& dimensions == 0}.
       \newline
-      Constructs a SYCL \codeinline{accessor} instance for accessing a single
+      Constructs a SYCL \codeinline{accessor} instance for accessing the first
       element of a SYCL \codeinline{buffer} within a SYCL kernel function on
       the SYCL \codeinline{queue} associated with \codeinline{
       commandGroupHandlerRef}.


### PR DESCRIPTION
Clarify that zero dimension accessors to a buffer, access the first
element of the buffer.  Previously, it just said "a single element" of
the buffer.