### PR TITLE
Fix wording for exception_ptr_class

### DIFF
--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -2996,8 +2996,8 @@ relevant to the queue where the kernel has been enqueued.
 
 The SYCL \codeinline{exception_ptr_class}
 class is used to store SYCL \codeinline{exception} objects and allows
-exception objects to be transferred between threads. It is equivalent to the
-\codeinline{exception_ptr_class} class. The SYCL \codeinline{exception_list}
+exception objects to be transferred between threads, serving the same purpose
+as the \codeinline{exception_ptr} class in C++.  The SYCL \codeinline{exception_list}
 class is also available in order to provide a list of synchronous and
 asynchronous exceptions.
 


### PR DESCRIPTION
The description for "exception_ptr_class" was trying to say it is
equivalent to "exception_ptr" in C++, but it mistakenly referred to
this as "exception_ptr_class".  There is no "_class" in the C++ name.