### PR TITLE
cl::sycl::event::get() method is supposed to be a constant.

### DIFF
--- a/latex/headers/event.h
+++ b/latex/headers/event.h
@@ -23,7 +23,7 @@ class event {
 
   /* -- common interface members -- */
 
-  cl_event get();
+  cl_event get() const;
 
   bool is_host() const;
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -897,7 +897,7 @@ The constructors and member functions of the SYCL \codeinline{event} class are l
 \startTable{Member function}
 \addFootNotes{Member functions for the \codeinline{event} class}{table.members.event}
   \addRow
-    {cl_event get()}
+    {cl_event get() const}
     {  
       Returns a valid \codeinline{cl_event} instance in accordance with the requirements described in \ref{sec:opencl-interoperability}.      
     }


### PR DESCRIPTION
get() method is not supported from constant cl::sycl::event object, but it is supported from constant cl::sycl::context, cl::sycl::device, cl::sycl::kernel, cl::sycl::platform, and cl::sycl::program.