### PR TITLE
Fix for sub-buffer constructor

### DIFF
--- a/latex/headers/buffer.h
+++ b/latex/headers/buffer.h
@@ -80,7 +80,7 @@ class buffer {
   buffer<T, 1>(InputIterator first, InputIterator last,
                const property_list &propList = {});
 
-  buffer(buffer<T, dimensions, AllocatorT> b, const id<dimensions> &baseIndex,
+  buffer(buffer &b, const id<dimensions> &baseIndex,
          const range<dimensions> &subRange);
 
   /* Available only when: dimensions == 1. */

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -1352,9 +1352,8 @@ The SYCL \codeinline{buffer} class template takes a template parameter \codeinli
       The constructed SYCL \codeinline{buffer} will use the \codeinline{allocator} parameter provided when allocating memory on the host.
       Zero or more properties can be provided to the constructed SYCL \codeinline{buffer} via an instance of \codeinline{property_list}.
     }
-  \addRowThreeSL
-    { buffer(buffer<T, dimensions, AllocatorT> \&b, }
-    { const id<dimensions> \& baseIndex, }
+  \addRowTwoSL
+    { buffer(buffer \& b, const id<dimensions> \& baseIndex, }
     { const range<dimensions> \& subRange) }
     {
       Create a new sub-buffer without allocation to have separate


### PR DESCRIPTION
Ensure buffer reference is used.

Also removes redundant template parameters.

Fixes #96 