### PR TITLE
Minor fixes to spec constant API

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13778,7 +13778,7 @@ another invocation of the same <<command-group-function-object>>.
 ----
 template<auto& SpecName>
 void set_specialization_constant(
-    typename std::remove_reference_t<decltype(SpecName)>::type value);
+    typename std::remove_reference_t<decltype(SpecName)>::value_type value);
 ----
 
 _Effects:_ Sets the value of the specialization constant whose address is
@@ -13799,7 +13799,7 @@ _Throws:_
 [source]
 ----
 template<auto& SpecName>
-typename std::remove_reference_t<decltype(SpecName)>::type get_specialization_constant();
+typename std::remove_reference_t<decltype(SpecName)>::value_type get_specialization_constant();
 ----
 
 _Returns:_ The value of the specialization constant whose address is
@@ -13834,7 +13834,8 @@ include::{header_dir}/expressingParallelism/classKernelHandler.h[lines=4..-1]
 [source,,linenums]
 ----
 template<auto& SpecName>
-typename std::remove_reference_t<decltype(SpecName)>::type get_specialization_constant();
+typename std::remove_reference_t<decltype(SpecName)>::value_type
+get_specialization_constant();
 ----
 
 _Returns:_ The value of the <<specialization-constant>> whose address is
@@ -15020,7 +15021,7 @@ specialization constant whose address is [code]#SpecName#.
 ----
 template<auto& SpecName>
 void set_specialization_constant(
-  typename std::remove_reference_t<decltype(S)>::type value);
+  typename std::remove_reference_t<decltype(SpecName)>::value_type value);
 ----
 
 _Preconditions:_ This member function is only available if the kernel bundle's
@@ -15037,7 +15038,8 @@ uses it; doing so has no effect on the execution of kernels from that bundle.
 [source]
 ----
 template<auto& SpecName>
-typename std::remove_reference_t<decltype(S)>::type get_specialization_constant() const;
+typename std::remove_reference_t<decltype(SpecName)>::value_type
+get_specialization_constant() const;
 ----
 
 _Returns:_ The value of the <<specialization-constant>> whose address is

--- a/adoc/headers/bundle/kernelBundleClass.h
+++ b/adoc/headers/bundle/kernelBundleClass.h
@@ -33,16 +33,17 @@ class kernel_bundle {
 
   bool native_specialization_constant() const noexcept;
 
-  template<auto& S>
+  template<auto& SpecName>
   bool has_specialization_constant() const noexcept;
 
   /* Available only when: (State == bundle_state::input) */
-  template<auto& S>
+  template<auto& SpecName>
   void set_specialization_constant(
-    typename std::remove_reference_t<decltype(S)>::type value);
+    typename std::remove_reference_t<decltype(SpecName)>::value_type value);
 
-  template<auto& S>
-  typename std::remove_reference_t<decltype(S)>::type get_specialization_constant() const;
+  template<auto& SpecName>
+  typename std::remove_reference_t<decltype(SpecName)>::value_type
+  get_specialization_constant() const;
 
   device_image_iterator begin() const;
 

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -123,8 +123,13 @@ class handler {
 
   void use_kernel_bundle(const kernel_bundle<bundle_state::executable> &execBundle);
 
-  template<auto& S>
-  typename std::remove_reference_t<decltype(S)>::type get_specialization_constant();
+  template<auto& SpecName>
+  void set_specialization_constant(
+      typename std::remove_reference_t<decltype(SpecName)>::value_type value);
+
+  template<auto& SpecName>
+  typename std::remove_reference_t<decltype(SpecName)>::value_type
+  get_specialization_constant();
 
 };
 }  // namespace sycl

--- a/adoc/headers/expressingParallelism/classKernelHandler.h
+++ b/adoc/headers/expressingParallelism/classKernelHandler.h
@@ -5,8 +5,9 @@ namespace sycl {
 
 class kernel_handler {
  public:
-  template<auto& S>
-  typename std::remove_reference_t<decltype(S)>::type get_specialization_constant();
+  template<auto& SpecName>
+  typename std::remove_reference_t<decltype(SpecName)>::value_type
+  get_specialization_constant();
 };
 
 }  // namespace sycl

--- a/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
+++ b/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
@@ -10,11 +10,9 @@ class kernel_handler {
 
  public:
 
-  template<auto& S>
-  bool has_specialization_constant() const noexcept;
-
-  template<auto& S>
-  typename std::remove_reference_t<decltype(S)>::type get_specialization_constant();
+  template<auto& SpecName>
+  typename std::remove_reference_t<decltype(SpecName)>::value_type
+  get_specialization_constant();
 
 };
 


### PR DESCRIPTION
* The declaration of `specialization_id` defines a class type named
  `value_type` for the underlying type of the specialization constant.
  However, all the declarations for `get_specialization_constant()` and
  `set_specialization_constant()` referred to the type name as just
  `type`.  We need to use the same name in both places.  This commit
  uses the name `value_type` consistently, but I'm happy to use `type`
  instead of we prefer.

* During a previous update to the specialization constant API I removed
  the method `kernel_handler::has_specialization_constant()` because I
  did not think it could be implemented in a useful way.  However, I
  forgot to remove the declaration from the synopsis.  Do that now.

* The synopsis for the `handler` class was missing the declaration of
  `set_specialization_constant()` even though we described it later in
  the specification.  Add this missing declaration.

* Some of the member function declaration for specialization constants
  used the template parameter name `SpecName` while others used the
  template parameter name `S`.  Consistently use the name `SpecName` to
  make it clear that all these template parameters mean the same thing.