### PR TITLE
Add Github Actions CI script 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,13 @@
+# Copyright 2021 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # CI to build asciidoctor spec targets, on push or manually
 
 name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or manual dispatch
   push:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,13 +22,17 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Unfortunately, asciidoctor-pdf gets pathname-specific errors
+      # building under the usual $GITHUB_WORKSPACE (/__w). As a workaround,
+      # generate the outputs in /tmp.
+
       - name: Build spec targets
         run: |
           cd adoc
-          make QUIET= html pdf
+          make OUTDIR=/tmp/out QUIET= html pdf
       - name: Archive generated files
         uses: actions/upload-artifact@v2
         with:
           name: spec-outputs
           path: |
-            adoc/out/
+            /tmp/out

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,34 @@
+# CI to build asciidoctor spec targets, on push or manually
+
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Use Khronos container with asciidoctor toolchain preinstalled
+    container: khronosgroup/docker-images:asciidoctor-spec
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Build spec targets
+        run: |
+          cd adoc
+          make QUIET= html pdf
+      - name: Archive generated files
+        uses: actions/upload-artifact@v2
+        with:
+          name: spec-outputs
+          path: |
+            adoc/out/

--- a/README.md
+++ b/README.md
@@ -9,25 +9,18 @@
 
 # SYCL Open Source Specification
 
-This repository contains the source and tool chain used to generate
-the formal SYCL specifications found on [https://www.khronos.org/sycl/](https://www.khronos.org/sycl/).
+This repository contains the source markup used to generate the
+formal SYCL specifications found on
+[https://www.khronos.org/sycl/](https://www.khronos.org/sycl/).
 
-## Reading the latest version of the SYCL specification
-
-The CI pipeline builds the specification HTML and PDF targets on commits
-to the repository.
-
-
-
-The GitLab CI pipeline builds the specification. This is accessible
-from this page, under the green check symbol, on the top right of the
-page or more generally from the rocket symbol on the left side.
-
-Then on the pipeline page, select the *Jobs* tab and click on the
-*download* icon on the bottom right.
+If you are proposing a merge or pull request to the specification, this
+README describes how the specification HTML and PDF targets can be built.
+Proposed changes must successfully build these targets before being
+considered for inclusion by the SYCL Working Group.
 
 
 ## Building the SYCL specification
+
 
 ### Building Using Github CI
 
@@ -79,7 +72,7 @@ docker pull khronosgroup/docker-images:asciidoctor-spec
 ```
 
 The Dockerfile specifying this image can be found at
-`https://github.com/KhronosGroup/DockerContainers` if you need to build a
+https://github.com/KhronosGroup/DockerContainers if you need to build a
 modified or layered image. However, if something is missing or out of date
 in the image, please file an issue on the `DockerContainers` repository
 before trying to build your own image. We will try to keep the image updated
@@ -116,11 +109,14 @@ example, though we do not support this), then you will need to install all
 the same tools in your own environment.
 
 We cannot provide instructions to do this on every possible build
-environment. If you are using Debian/Ubuntu Linux, however, you should be
-able to figure out the required tools by looking at the Dockerfile, at
-`https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile`.
-Note that the Khronos image builds on the official Ruby 2.7 Docker image, so
-you must also install Ruby.
+environment. However, if you are using Debian/Ubuntu Linux, either native or
+via WSL2, you should be able to install the required tools by looking at the
+Dockerfile at
+
+https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile
+
+Note that the Khronos Docker image layers on the official Ruby 2.7 Docker
+image, so you must install Ruby first.
 
 
 ### Building Using GitLab CI

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ considered for inclusion by the SYCL Working Group.
 ## Building the SYCL specification
 
 
-### Building Using Github CI
+### Building using Github CI
 
 When using our github repository, pushing to a branch will trigger the
 Github Actions CI script under `../.github/workflows/CI.yml` to build HTML

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ the formal SYCL specifications found on [https://www.khronos.org/sycl/](https://
 
 ## Reading the latest version of the SYCL specification
 
+The CI pipeline builds the specification HTML and PDF targets on commits
+to the repository.
+
+
+
 The GitLab CI pipeline builds the specification. This is accessible
 from this page, under the green check symbol, on the top right of the
 page or more generally from the rocket symbol on the left side.
@@ -24,139 +29,109 @@ Then on the pipeline page, select the *Jobs* tab and click on the
 
 ## Building the SYCL specification
 
-### Using GitLab CI
+### Building Using Github CI
 
-The simplest way to build the specification is not to actually build
-it, but to rely on the Khronos continuous integration process which
-builds automatically a branch when it is changed on
-https://gitlab.khronos.org/sycl/Specification
+When using our github repository, pushing to a branch will trigger the
+Github Actions CI script under `../.github/workflows/CI.yml` to build HTML
+and PDF versions of the spec. To see the outputs, click on the `Actions` tab
+in the top navigation bar, or go to
+https://github.com/KhronosGroup/SYCL-Docs/actions . Your commit should show
+up on the list of commits below. Click through to the Actions summary for
+that commit.
 
-Look at CI/CD-Jobs (the rocket-ship icon on the left menu bar or
-https://gitlab.khronos.org/sycl/Specification/-/jobs), click on the
-`Download` icon for the latest CI job in the branch of interest or
-click on `Passed` to dive into more details. Once unzipping the
-compilation artifacts, look inside `adoc/out` directory to find the
-HTML and PDF version.
+On success, a green checkmark will appear by the commit name on this page.
+Output artifacts can be downloaded as a zipfile from the `Artifacts` section
+near the bottom of the page.
+
+On failure, a red `x` will appear by the commit name. Click through to the
+`build` job and it should auto-scroll to the CI log showing where the build
+failed. Fix it and push a new commit to try again.
 
 Note that to read the HTML specification correctly with all the
 mathematical symbols, you need also to have the `katex` directory
 along the `html` one. This might not be the case if your downloading
 framework lazily unzips just what you read.
 
-You can use this CI infrastructure while developing: you can git-push
-or git-force-push your branch on the server and go to CI/CD-Jobs to
-look at the compiled version.
+If you are proposing a pull request from your own clone of our repository,
+you may need to enable Github Actions for your clone.
 
-All this works because of the existing `.gitlab-ci.yml` recipe.
 
-### Using pre-configured AsciiDoctor-capable Docker image
+### Building Using The Khronos Docker Image
 
-Compiling the specification requires some specific AsciiDoctor related
-packages.
+Building the specification on your own machine requires a large set of
+tools. Rather than installing these tools yourself, if you can run Docker on
+a Linux compatible host (probably including Windows WSL2 with a Ubuntu or
+Debian OS, and possibly including MacOS X), you can use the same
+pre-configured Docker image used by the CI builds.
 
-To simplify the setup, Khronos provides a pre-configured Docker Linux
-Ubuntu image you can use on a Docker executor to compile the
-specification on various OS able to run Docker.
+If you are on Debian/Ubuntu Linux, install Docker with:
 
-Assuming you are on Debian/Ubuntu Linux, the first time you need to
-install Docker with for example:
 ```bash
 sudo apt update
 sudo apt install docker.io
 ```
 
-The base image used to build the specifications can be downloaded or
+The Docker image used to build the specifications can then be downloaded or
 updated to the latest version via
+
 ```bash
-docker pull khronosgroup/docker-images:vulkan-docs-base
+docker pull khronosgroup/docker-images:asciidoctor-spec
 ```
-Or you can manually generate the image using the script provided in
-`https://github.com/KhronosGroup/DockerContainers`.
 
+The Dockerfile specifying this image can be found at
+`https://github.com/KhronosGroup/DockerContainers` if you need to build a
+modified or layered image. However, if something is missing or out of date
+in the image, please file an issue on the `DockerContainers` repository
+before trying to build your own image. We will try to keep the image updated
+as needed.
 
-To compile the specification you can rely on the `Makefile` inside the
-`adoc` directory, for example with:
+To build the specification using the image, use the `Makefile` inside the
+`adoc` directory:
+
 ```bash
 cd adoc
 make clean docker-html docker-pdf
 ```
 
-There are a few variables defined in the `Makefile` you can set to
-change the behavior, such as to display verbosely the compilation
-process:
+Outputs will be located in $(OUTDIR) (by default, `out/` in the `adoc`
+directory).
+
+There are some variables defined in the `Makefile` you can set to change the
+behavior, such as to verbosely display the build process:
+
 ```bash
 make QUIET= clean docker-html docker-pdf
 ```
 
-If you need to launch explicitly Docker without using `make` on the
-host, look at the `adoc/Makefile` and imitate on your system how
-Docker is launched.
-
-Since the Docker image is old, there is a new path using a script to
-upgrade the files inside the Docker image to be used as:
-```bash
-make DOCKER_COMMAND="make QUIET= --directory=/sycl/adoc clean html pdf" dock
-```
-
-### Using native computer
-
-If you are using a Debian/Ubuntu Linux distribution, you can look at
-how the previous process works and how the Docker image is done at
-https://github.com/KhronosGroup/DockerContainers and specifically
-https://github.com/KhronosGroup/DockerContainers/blob/master/Dockerfile.vulkan-docs-base
-which gives an idea of the packages to install and
-https://github.com/KhronosGroup/DockerContainers/blob/master/entrypoint.vulkan.sh
-
-*TODO*: find the minimal recipe.
-```bash
-sudo apt update
-sudo apt install bison \
-  build-essential \
-  cmake \
-  flex \
-  fonts-lyx \
-  g++ \
-  ghostscript \
-  git \
-  libcairo2-dev \
-  libffi-dev \
-  libgdk-pixbuf2.0-dev \
-  libpango1.0-dev \
-  libreadline-dev \
-  libxml2-dev \
-  nodejs \
-  node-escape-string-regexp \
-  node-he \
-  node-lunr \
-  poppler-utils \
-  python3 \
-  ruby-dev
-
-sudo apt clean
-
-sudo gem install asciidoctor \
-  asciidoctor-diagram \
-  asciidoctor-mathematical \
-  asciidoctor-pdf \
-  coderay \
-  json-schema \
-  i18n \
-  pygments.rb \
-  rouge \
-  text-hyphen
-```
-
-Then use for example:
-```bash
-make QUIET= clean html pdf
-```
-
-There is also some discussion back-ground in
-https://gitlab.khronos.org/sycl/Specification/-/merge_requests/484#note_270338
+If you need to invoke Docker without using `make` on the host, look at the
+actions in the `docker-%` target in `adoc/Makefile` and replicate them on
+your system.
 
 
-### Windows recipe
+### Building On Your Native Machine
 
-*TODO*: Investigate the Docker route
-https://docs.docker.com/docker-for-windows/install/ , WSL2, CygWin,
-VCPKG...
+If you don't want to, or can't use Docker (or a compatible replacement - it
+is possible that the Red Hat `podman` tool can run our Docker container, for
+example, though we do not support this), then you will need to install all
+the same tools in your own environment.
+
+We cannot provide instructions to do this on every possible build
+environment. If you are using Debian/Ubuntu Linux, however, you should be
+able to figure out the required tools by looking at the Dockerfile, at
+`https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile`.
+Note that the Khronos image builds on the official Ruby 2.7 Docker image, so
+you must also install Ruby.
+
+
+### Building Using GitLab CI
+
+Finally, if you are a Khronos member working in our internal Gitlab server,
+Gitlab CI builds the image just like Github CI. Go to the
+`...sycl/Specification` repository page on the gitlab server, click through
+to CI/CD-Jobs (the rocket-ship icon on the left menu bar or
+`...sycl/Specification/-/jobs`). If your job succeeded, click on the
+`Download` icon for the latest CI job in the appropriate branch to download
+the zip file of build artifacts, or click on `Passed` to see build details.
+
+The Gitlab CI script is functionally equivalent to the Github CI script, but
+is located under `.gitlab-ci.yml`, using a different YAML scheme.

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -289,7 +289,8 @@ docker-%:
 	# variables are dropped by docker.
 	sudo docker run --user `id --user`:`id --group` \
 	  --interactive --tty --rm \
-	  --volume $(SYCL_DIR):/sycl khronosgroup/docker-images:vulkan-docs-base \
+          --volume $(SYCL_DIR):/sycl \
+          khronosgroup/docker-images:asciidoctor-spec \
 	  $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" --directory=/sycl/adoc $*
 
 dock:
@@ -300,7 +301,8 @@ dock:
 	sudo docker run \
 	  --interactive --tty --rm \
 	  -e USER_ID=`id --user` -e GROUP_ID=`id --group` \
-	  --volume $(SYCL_DIR):/sycl khronosgroup/docker-images:vulkan-docs-base \
+          --volume $(SYCL_DIR):/sycl \
+          khronosgroup/docker-images:asciidoctor-spec \
 	  /sycl/adoc/scripts/install-rouge.sh \
 	  $(DOCKER_COMMAND)
 


### PR DESCRIPTION
To build HTML and PDF specs on push or manual selection.

Ready to merge - this has no impact on the actual spec.