### PR TITLE
Fix unary vector operator to take a const reference

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16493,7 +16493,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-vec operatorOP(vec &v)
+vec operatorOP(consnt vec &v)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as this SYCL [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# unary arithmetic operation on each element of this SYCL [code]#vec#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16493,7 +16493,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-vec operatorOP(consnt vec &v)
+vec operatorOP(const vec &v)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as this SYCL [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# unary arithmetic operation on each element of this SYCL [code]#vec#.
 

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -143,7 +143,7 @@ class vec {
   friend vec operatorOP(vec& lhs, int) { /* ... */ }
 
   // OP is unary +, -
-  friend vec operatorOP(vec &rhs) const { /* ... */ }
+  friend vec operatorOP(const vec &rhs) const { /* ... */ }
 
   // OP is: &, |, ^
   /* Available only when: dataT != float && dataT != double


### PR DESCRIPTION
Reported by Daniel Geon Park via the Khronos Slack.

> Without a `const` reference, it is impossible to do something like:
>```
>const sycl::float4 v{};
>-v; // Error
>```
>
>Or:
>```
>-sycl::float4{}; // Error
>```

This PR adds the const reference.