### PR TITLE
Remove const function qualifier from non-member unary operator function

### DIFF
--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -143,7 +143,7 @@ class vec {
   friend vec operatorOP(vec& lhs, int) { /* ... */ }
 
   // OP is unary +, -
-  friend vec operatorOP(const vec &rhs) const { /* ... */ }
+  friend vec operatorOP(const vec &rhs) { /* ... */ }
 
   // OP is: &, |, ^
   /* Available only when: dataT != float && dataT != double


### PR DESCRIPTION
Further fix for #118 and #115.

We want to make sure the non-member unary operator is not a `const` function. It's not clear that this is legal C++. The fix removes the `const`.