### PR TITLE
Add read-write host unsampled image accessor

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8370,9 +8370,11 @@ within a <<host-task>>.  The latter provides access from host code that is
 outside of a <<host-task>>.
 
 The dimensionality of an unsampled image accessor must match the dimensionality
-of the underlying image to which it provides access.  Unsampled image accessors
-support only two access modes: [code]#access_mode::read# and
-[code]#access_mode::write#.
+of the underlying image to which it provides access.  Both unsampled image
+accessor classes support the [code]#access_mode::read# and
+[code]#access_mode::write# access modes.  In addition, the
+[code]#host_unsampled_image_accessor# class supports
+[code]#access_mode::read_write#.
 
 The [code]#accessTarget# template parameter dictates how the
 [code]#unsampled_image_accessor# can be used: [code]#image_target::device#
@@ -8548,7 +8550,8 @@ a@
 template <typename coordT>
 dataT read(const coordT &coords) const
 ----
-   a@ Available only when [code]#(accessMode == access_mode::read)#.
+   a@ Available only when [code]#(accessMode == access_mode::read ||
+      accessMode == access_mode::read_write)#.
 
 Reads and returns an element of the [code]#unsampled_image# at the coordinates
 specified by [code]#coords#.  Permitted types for [code]#coordT# are
@@ -8564,7 +8567,8 @@ a@
 template <typename coordT>
 void write(const coordT &coords, const dataT &color) const
 ----
-   a@ Available only when [code]#(accessMode == access_mode::write)#.
+   a@ Available only when [code]#(accessMode == access_mode::write ||
+      accessMode == access_mode::read_write)#.
 
 Writes the value specified by [code]#color# to the element of the image at the
 coordinates specified by [code]#coords#.  Permitted types for [code]#coordT#
@@ -8618,6 +8622,8 @@ that they imply.
     | [code]#access_mode::read#
 | [code]#write_only#
     | [code]#access_mode::write#
+| [code]#read_write#
+    | [code]#access_mode::read_write#
 |====
 
 

--- a/adoc/headers/accessorUnsampledImage.h
+++ b/adoc/headers/accessorUnsampledImage.h
@@ -51,8 +51,10 @@ class unsampled_image_accessor {
 };
 
 template <typename dataT,
-          int dimensions,
-          access_mode accessMode>
+          int dimensions = 1,
+          access_mode accessMode =
+            (std::is_const_v<dataT> ? access_mode::read
+                                    : access_mode::read_write)>
 class host_unsampled_image_accessor {
  public:
   using value_type =             // const dataT for read-only accessors, dataT otherwise
@@ -74,14 +76,16 @@ class host_unsampled_image_accessor {
 
   size_t size() const noexcept;
 
-  /* Available only when: accessMode == access_mode::read
+  /* Available only when: (accessMode == access_mode::read ||
+                           accessMode == access_mode::read_write)
   if dimensions == 1, coordT = int
   if dimensions == 2, coordT = int2
   if dimensions == 4, coordT = int4 */
   template <typename coordT>
   dataT read(const coordT &coords) const noexcept;
 
-  /* Available only when: accessMode == access_mode::write
+  /* Available only when: (accessMode == access_mode::write ||
+                           accessMode == access_mode::read_write)
   if dimensions == 1, coordT = int
   if dimensions == 2, coordT = int2
   if dimensions == 3, coordT = int4 */


### PR DESCRIPTION
A reviewer noted to me that SYCL 1.2.1 supported a read-write image
accessor for `target::host_image`.  SYCL 2020 inadvertently dropped
this functionality because `host_unsampled_image_accessor` does not
support read-write access mode.  Add that functionality back, so we
are again on parity with SYCL 1.2.1.

Adding a read-write mode also has a happy side-effect.  This is now
a reasonable default mode, so change the synopsis to show read-write
as the default (unless `dataT` is `const`).  Adding a default for
`accessMode` also allows us to add a default for `dimensions`, so
make that default to `1`, which matches the default for
`unsampled_image` and the default for the other accessors.