### PR TITLE
Replace std::dynamic_extent with sycl:: version

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1164,7 +1164,7 @@ Some features of SYCL are aligned with the next {cpp} specification, as defined
 in <<sec:normativerefs>>.
 
 The following features are pre-adopted by SYCL 2020 and made available in the
-[code]#sycl::# namespace: [code]#std::span#,
+[code]#sycl::# namespace: [code]#std::span#, [code]#std::dynamic_extent#,
 [code]#std::bit_cast#. The implementations of pre-adopted features are
 compliant with the next {cpp} specification, and are expected to forward directly
 to standard {cpp} features in a future version of SYCL.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12391,7 +12391,7 @@ a@
 reduction<T, BinaryOperation>(span<T, Extent> vars,
 BinaryOperation combiner, const property_list &propList = {})
 ----
-   a@ Available only when [code]#Extent != std::dynamic_extent#.
+   a@ Available only when [code]#Extent != sycl::dynamic_extent#.
       Construct an unspecified object representing a reduction
       of the variable(s) described by [code]#vars# using the combination
       operation specified by [code]#combiner#. Zero or more properties
@@ -12441,7 +12441,7 @@ reduction<T, BinaryOperation>(span<T, Extent> vars, const T& identity,
 BinaryOperation combiner, const property_list &propList = {})
 ----
    a@ Available only when [code]#has_known_identity<BinaryOperation, T>::value#
-      is [code]#false# and [code]#Extent != std::dynamic_extent#.
+      is [code]#false# and [code]#Extent != sycl::dynamic_extent#.
       Construct an unspecified object representing a reduction
       of the variable(s) described by [code]#vars# using the combination
       operation specified by [code]#combiner#. The value of


### PR DESCRIPTION
Adds std::dynamic_extent to the list of pre-adopted C++20 features.
This was only implied before (by pre-adoption of std::span).