### PR TITLE
Local accessor should not have is_placeholder

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -7056,6 +7056,14 @@ the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
 a@
 [source]
 ----
+bool is_placeholder() const
+----
+   a@ Returns [code]#true# if the accessor was constructed as a placeholder and
+      returns [code]#false# otherwise.
+
+a@
+[source]
+----
 id<dimensions> get_offset() const
 ----
    a@ Available only when [code]#(dimensions > 0)#.
@@ -7192,6 +7200,13 @@ the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Member function @ Description
+a@
+[source]
+----
+bool is_placeholder() const
+----
+   a@ Always returns [code]#false#.
+
 a@
 [source]
 ----
@@ -7379,20 +7394,6 @@ const_reference
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Member function @ Description
-a@
-[source]
-----
-bool is_placeholder() const
-----
-   a@ Tells if this is a placeholder accessor.
-
-When [code]#accessTarget# is [code]#target::constant_buffer#, returns
-[code]#true# if the accessor was constructed as a placeholder and returns
-[code]#false# otherwise.
-
-When [code]#accessTarget# is [code]#target::host_buffer# or
-[code]#target::local#, always returns [code]#false#.
-
 a@
 [source]
 ----

--- a/adoc/headers/accessorDeprecatedLocal.h
+++ b/adoc/headers/accessorDeprecatedLocal.h
@@ -24,8 +24,6 @@ class accessor {
 
   /* -- common interface members -- */
 
-  bool is_placeholder() const;
-
   size_t get_size() const;
 
   size_t get_count() const;


### PR DESCRIPTION
The deprecated form of `accessor` with `target::local` did not have a
member function named `is_placeholder` in SYCL 1.2.1 because there is
no such thing as a local placeholder accessor.  The SYCL 2020 spec
inadvertently added `is_placeholder` as part of the deprecated API,
which was not our intent.  Remove it.

This addresses one of the issues reported in #126.