### PR TITLE
Remove vague architecture section

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1836,12 +1836,6 @@ same translation unit of the compiler, then the macro [code]#SYCL_EXTERNAL#
 has to be provided.
 
 
-=== Functions and data types available in kernels
-
-Inside kernels, the functions and data types available are restricted by the
-underlying capabilities of <<backend>> devices.
-
-
 == Endianness support
 
 SYCL does not mandate any particular byte order, but the byte order of the


### PR DESCRIPTION
This section from the architecture chapter seems too vague, and I
don't think it's entirely true.  My belief is that all backends are
supposed to support all core SYCL features, except those that are
specifically described as optional.  Those optional features are
already described better in section 4.6.4.3. "Device aspects" and
section 5.7. "Optional kernel features".

Since this section does not seem to specify any new requirement or
clarify anything, I propose that we just remove it.

This addresses one of the issues reported in #126.