### PR TITLE
A few minor fixes

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -7440,7 +7440,7 @@ buffer, unless this is a <<ranged-accessor>> in which case it is the range that
 was specified when the accessor was constructed.
 
 When [code]#accessTarget# is [code]#target::local#, the returned value is the
-the range that was specified when the accessor was constructed.
+range that was specified when the accessor was constructed.
 
 a@
 [source]
@@ -7850,12 +7850,12 @@ access to this memory from within a <<sycl-kernel-function>>.  The
 simultaneously in an implementation, each work-group receives its own
 independent copy of the allocated local memory.
 
-The underlying [code]#dataT# type can be any {cpp} type.  If [code]#dataT# is
-an implicit-lifetime type (as defined in the {cpp} core language), the local
-accessor implicitly creates objects of that type with indeterminate values.
-For other types, the local accessor merely allocates uninitialized memory, and
-the application is responsible for constructing objects in that memory (e.g. by
-calling placement-new).
+The underlying [code]#dataT# type can be any {cpp} type that the device
+supports.  If [code]#dataT# is an implicit-lifetime type (as defined in the
+{cpp} core language), the local accessor implicitly creates objects of that
+type with indeterminate values.  For other types, the local accessor merely
+allocates uninitialized memory, and the application is responsible for
+constructing objects in that memory (e.g. by calling placement-new).
 
 A local accessor must not be used in a <<sycl-kernel-function>> that is invoked
 via [code]#single_task# or via the simple form of [code]#parallel_for# that

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -116,6 +116,9 @@ Changes to buffers, images and accessors:
     element have been changed to return a [code]#const# reference for
     read-only accessors.  The [code]#get_pointer()# member function has also
     been changed to return a [code]#const# pointer for read-only accessors.
+    The [code]#value_type# and [code]#reference# member types of
+    [code]#accessor# have been changed to be [code]#const# types for read-only
+    accessors.
 
   * The [code]#accessor# member function [code]#get_pointer()# now returns
     a raw pointer.  The [code]#get_multi_ptr()# member function was introduced


### PR DESCRIPTION
* Clarify that the underlying type of a local accessor can be any C++
  type **that the device supports**.

* Note that the accessor `value_type` and `reference` class types have
  changed since 1.2.1 for read-only accessors.

* Fix a grammatical typo.

These address issues reported in #126.