### PR TITLE
Clarify accessor target of explicit copy ops

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13390,19 +13390,19 @@ Manual copy operations can be seen as specialized kernels executing on the
 device, except that typically this operations will be implemented using a
 host API that exists as part of a backend (e.g, OpenCL enqueue copy operations).
 
-The SYCL memory objects involved in a copy operation are specified using
-buffer accessors.
-Explicit copy operations have a source and a destination.
-When an accessor is the _source_ of the operation, the destination can be
-a host pointer or another accessor.
-The _source_ accessor can have either [code]#read# or
-[code]#read_write# access mode.
+These explicit copy operations have a source and a destination.  When an
+accessor is the _source_ of the operation, the destination can be a host
+pointer or another accessor.  The _source_ accessor must have either
+[code]#access_mode::read# or [code]#access_mode::read_write# access mode.  When
+an accessor is the _destination_ of the explicit copy operation, the source can
+be a host pointer or another accessor.  The _destination_ accessor must have
+either [code]#access_mode::write#, [code]#access_mode::read_write#,
+[code]#access_mode::discard_write# or [code]#access_mode::discard_read_write#
+access mode.
 
-When an accessor is the _destination_ of the explicit copy operation,
-the source can be a host pointer or another accessor.
-The _destination_ accessor can have either
-[code]#write#, [code]#read_write#, [code]#discard_write#,
-[code]#discard_read_write# access modes.
+When an accessor is used as a parameter to one of these explicit copy
+operations, the target must be either [code]#target::device# or
+[code]#target::constant_buffer#.
 
 When accessors are both the origin and the destination,
 the operation is executed on objects controlled by the SYCL runtime.


### PR DESCRIPTION
The main change in this commit is to clarify that the `target` template
parameter for accessors used in the explicit copy operations must be
either `target::device` (aka `target::global_buffer`) or
`target::constant_buffer`.  Although, `target::constant_buffer` is
deprecated, I could not think of any reason to disallow it, so I
thought we should allow it for backward compatibility with 1.2.1.

Some other minor clarifications are:

* Remove the sentence saying that the accessor must be a "buffer
  accessor".  This is redundant now that we state that the only
  allowable values for the `target` parameter are `target::device` and
  `target::constant_buffer` (which are both buffer accessors).

* Use the word "must" instead of "may" when describing the allowable
  accessor modes.

Here is my justification for why the other `target` parameters should
not be allowed:

* The spec already disallows `target::host_buffer` because we state
  that this target only allows access outside of a "command", and we
  define "command" to include the explicit copy operations.  Therefore,
  `target::host_buffer` cannot be allowed.

* The spec already disallows `target::local` because that is not a
  "buffer accessor", and the spec stated that a buffer accessor was
  required.

* Allowing `target::host_task` does not make sense to me.  If the
  application wants to explicitly copy memory to the host, it should
  use a host pointer as a parameter to the explicit copy, or it should
  use the `update_host()` member function instead.  Since
  `target::host_task` is new in SYCL 2020, there is no issue of
  backwards compatibility.