### PR TITLE
Fixes to reducers

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12594,7 +12594,7 @@ a@
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
       Available only when: [code]#Dimensions == 0 &&
-      (is_same_v<BinaryOperation, plus<>> || is_same_v<BinaryOperation, plus<T>>)#.
+      (std::is_same_v<BinaryOperation, plus<>> || std::is_same_v<BinaryOperation, plus<T>>)#.
 
 a@
 [source]
@@ -12603,7 +12603,7 @@ a@
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
       Available only when: [code]#Dimensions == 0 &&
-      (is_same_v<BinaryOperation, multiplies<>> || is_same_v<BinaryOperation, multiplies<T>>)#.
+      (std::is_same_v<BinaryOperation, multiplies<>> || std::is_same_v<BinaryOperation, multiplies<T>>)#.
 
 a@
 [source]
@@ -12612,7 +12612,7 @@ a@
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
       Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
-      (is_same_v<BinaryOperation, bit_and<>> || is_same_v<BinaryOperation, bit_and<T>>)#.
+      (std::is_same_v<BinaryOperation, bit_and<>> || std::is_same_v<BinaryOperation, bit_and<T>>)#.
 
 a@
 [source]
@@ -12621,7 +12621,7 @@ a@
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
       Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
-      (is_same_v<BinaryOperation, bit_or<>> || is_same_v<BinaryOperation, bit_or<T>>)#.
+      (std::is_same_v<BinaryOperation, bit_or<>> || std::is_same_v<BinaryOperation, bit_or<T>>)#.
       
 a@
 [source]
@@ -12630,7 +12630,7 @@ a@
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
       Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
-      (is_same_v<BinaryOperation, bit_xor<>> || is_same_v<BinaryOperation, bit_xor<T>>)#.
+      (std::is_same_v<BinaryOperation, bit_xor<>> || std::is_same_v<BinaryOperation, bit_xor<T>>)#.
 
 a@
 [source]
@@ -12638,8 +12638,8 @@ a@
     reducer& operator++(reducer<T,plus<T>,0>& accum)
 ----
    a@ Equivalent to calling [code]#accum.combine(1)#.
-      Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
-      (is_same_v<BinaryOperation, plus<>> || is_same_v<BinaryOperation, plus<T>>)#.
+      Available only when: [code]#Dimensions == 0 && std::is_integral_v<T> && !std::is_same_v<T, bool> &&
+      (std::is_same_v<BinaryOperation, plus<>> || std::is_same_v<BinaryOperation, plus<T>>)#.
 
 |====
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12635,7 +12635,7 @@ a@
 a@
 [source]
 ----
-    reducer& operator++(reducer<T,plus<T>,0>& accum)
+    reducer& operator++(reducer& accum)
 ----
    a@ Equivalent to calling [code]#accum.combine(1)#.
       Available only when: [code]#Dimensions == 0 && std::is_integral_v<T> && !std::is_same_v<T, bool> &&

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12555,6 +12555,7 @@ reducer& combine(const T& partial)
    a@ Available only when: [code]#Dimensions == 0#.
       Combine the value of [code]#partial# with the reduction variable
       associated with this [code]#reducer#.
+      Returns [code]#*this#.
 
 a@
 [source]
@@ -12582,61 +12583,63 @@ T identity() const
 |====
 
 [[table.operators.reducer]]
-.Operators of the [code]#reducer# class
+.Hidden friend operators of the [code]#reducer# class
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Operator @ Description
 a@
 [source]
 ----
-template <typename T>
-    void operator+=(reducer<T,plus<T>,0>& accum, const T& partial)
+    reducer& operator+=(reducer& accum, const T& partial)
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
+      Available only when: [code]#Dimensions == 0 &&
+      (is_same_v<BinaryOperation, plus<>> || is_same_v<BinaryOperation, plus<T>>)#.
 
 a@
 [source]
 ----
-template <typename T>
-    void operator*=(reducer<T,multiplies<T>,0>& accum, const T& partial)
+    reducer& operator*=(reducer& accum, const T& partial)
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
+      Available only when: [code]#Dimensions == 0 &&
+      (is_same_v<BinaryOperation, multiplies<>> || is_same_v<BinaryOperation, multiplies<T>>)#.
 
 a@
 [source]
 ----
-template <typename T>
-    void operator|=(reducer<T,bit_or<T>,0>& accum, const T& partial)
+    reducer& operator&=(reducer& accum, const T& partial)
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
-      Only available for integral types.
+      Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
+      (is_same_v<BinaryOperation, bit_and<>> || is_same_v<BinaryOperation, bit_and<T>>)#.
 
 a@
 [source]
 ----
-template <typename T>
-    void operator&=(reducer<T,bit_and<T>,0>& accum, const T& partial)
+    reducer& operator|=(reducer& accum, const T& partial)
 ----
    a@ Equivalent to calling [code]#accum.combine(partial)#.
-      Only available for integral types.
+      Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
+      (is_same_v<BinaryOperation, bit_or<>> || is_same_v<BinaryOperation, bit_or<T>>)#.
+      
+a@
+[source]
+----
+    reducer& operator^=(reducer& accum, const T& partial)
+----
+   a@ Equivalent to calling [code]#accum.combine(partial)#.
+      Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
+      (is_same_v<BinaryOperation, bit_xor<>> || is_same_v<BinaryOperation, bit_xor<T>>)#.
 
 a@
 [source]
 ----
-template <typename T>
-    void operator^=(reducer<T,bit_xor<T>,0>& accum, const T& partial)
-----
-   a@ Equivalent to calling [code]#accum.combine(partial)#.
-      Only available for integral types.
-
-a@
-[source]
-----
-template <typename T>
-    void operator++(reducer<T,plus<T>,0>& accum)
+    reducer& operator++(reducer<T,plus<T>,0>& accum)
 ----
    a@ Equivalent to calling [code]#accum.combine(1)#.
-      Only available for integral types.
+      Available only when: [code]#Dimensions == 0 && is_integral_v<T> &&
+      (is_same_v<BinaryOperation, plus<>> || is_same_v<BinaryOperation, plus<T>>)#.
 
 |====
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12550,9 +12550,10 @@ include::{header_dir}/reducer.h[lines=4..-1]
 a@
 [source]
 ----
-void combine(const T& partial) const
+reducer& combine(const T& partial)
 ----
-   a@ Combine the value of [code]#partial# with the reduction variable
+   a@ Available only when: [code]#Dimensions == 0#.
+      Combine the value of [code]#partial# with the reduction variable
       associated with this [code]#reducer#.
 
 a@
@@ -12560,7 +12561,7 @@ a@
 ----
 __unspecified__ &operator[](size_t index) const
 ----
-   a@ Available only when: [code]#Dimensions > 1#.
+   a@ Available only when: [code]#Dimensions > 0#.
       Returns an instance of an undefined intermediate type representing
       a [code]#reducer# of the same type as this [code]#reducer#,
       with the dimensionality [code]#Dimensions-1# and containing an
@@ -12578,7 +12579,6 @@ T identity() const
    a@ Return the identity value of the combination operation associated with
       this [code]#reducer#.  Only available if the identity value is known
       to the implementation.
-
 |====
 
 [[table.operators.reducer]]

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -46,7 +46,7 @@ public:
    * BinaryOperation == bit_xor<> or BinaryOperation == bit_xor<T> */
   friend reducer& operator^=(reducer&, const T&) { /* ... */ }
 
-  /* Only available if Dimensions == 0, T is an integral type and either
+  /* Only available if Dimensions == 0, T is an integral type, T is not bool and either
    * BinaryOperation == plus<> or BinaryOperation == plus<T> */
   friend reducer& operator++(reducer&) { /* ... */ }
 

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -29,7 +29,6 @@ public:
   /* Only available if Dimensions == 0 and either
    * BinaryOperation == plus<> or BinaryOperation == plus<T> */
   friend reducer& operator+=(reducer&, const T&) { /* ... */ }
-  friend reducer& operator++(reducer&) { /* ... */ }
 
   /* Only available if Dimensions == 0 and either
    * BinaryOperation == multiplies<> or BinaryOperation == multiplies<T> */
@@ -46,6 +45,10 @@ public:
   /* Only available if Dimensions == 0, T is an integral type and either
    * BinaryOperation == bit_xor<> or BinaryOperation == bit_xor<T> */
   friend reducer& operator^=(reducer&, const T&) { /* ... */ }
+
+  /* Only available if Dimensions == 0, T is an integral type and either
+   * BinaryOperation == plus<> or BinaryOperation == plus<T> */
+  friend reducer& operator++(reducer&) { /* ... */ }
 
 };
 

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -4,12 +4,21 @@
 // Exposition only
 template <typename T, typename BinaryOperation, int Dimensions, /* unspecified */>
 class reducer {
+public:
 
-  reducer(const reducer<T,BinaryOperation,Dimensions>&) = delete;
-  reducer<T,BinaryOperation,Dimensions>& operator(const reducer<T,BinaryOperation,Dimensions>&) = delete;
+  using value_type = T;
+  using binary_operation = BinaryOperation;
+  static constexpr int dimensions = Dimensions;
+
+  reducer(const reducer&) = delete;
+  reducer(reducer&&) = delete;
+  reducer& operator=(const reducer&) = delete;
+  reducer& operator=(reducer&&) = delete;
+
+  ~reducer();
 
   /* Only available if Dimensions == 0 */
-  void combine(const T& partial);
+  reducer& combine(const T& partial);
 
   /* Only available if Dimensions > 0 */
   __unspecified__ &operator[](size_t index) const;
@@ -17,26 +26,26 @@ class reducer {
   /* Only available if identity value is known */
   T identity() const;
 
+  /* Only available if Dimensions == 0 and either
+   * BinaryOperation == plus<> or BinaryOperation == plus<T> */
+  friend reducer& operator+=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator++(reducer&) { /* ... */ }
+
+  /* Only available if Dimensions == 0 and either
+   * BinaryOperation == multiplies<> or BinaryOperation == multiplies<T> */
+  friend reducer& operator*=(reducer&, const T&) { /* ... */ }
+
+  /* Only available if Dimensions == 0, T is an integral type and either
+   * BinaryOperation == bit_and<> or BinaryOperation == bit_and<T> */
+  friend reducer& operator&=(reducer&, const T&) { /* ... */ }
+
+  /* Only available if Dimensions == 0, T is an integral type and either
+   * BinaryOperation == bit_or<> or BinaryOperation == bit_or<T> */
+  friend reducer& operator|=(reducer&, const T&) { /* ... */ }
+
+  /* Only available if Dimensions == 0, T is an integral type and either
+   * BinaryOperation == bit_xor<> or BinaryOperation == bit_xor<T> */
+  friend reducer& operator^=(reducer&, const T&) { /* ... */ }
+
 };
 
-template <typename T>
-void operator+=(reducer<T,plus<T>,0>&, const T&);
-
-template <typename T>
-void operator*=(reducer<T,multiplies<T>,0>&, const T&);
-
-/* Only available for integral types */
-template <typename T>
-void operator&=(reducer<T,bit_and<T>,0>&, const T&);
-
-/* Only available for integral types */
-template <typename T>
-void operator|=(reducer<T,bit_or<T>,0>&, const T&);
-
-/* Only available for integral types */
-template <typename T>
-void operator^=(reducer<T,bit_xor<T>,0>&, const T&);
-
-/* Only available for integral types */
-template <typename T>
-void operator++(reducer<T,plus<T>,0>&);


### PR DESCRIPTION
Internal issue #535

In the reducers section:

Made member functions public
Added aliases for template parameters
Fixed deleting copy/move constructors/assignment operators
Changed the return type of `combine` to `reducer&`
Made operators hidden friends and changed their return type to `reducer&`
Fixed constraints with `Dimensions` to be consistent between code and prose (`Dimensions` start at `0`) 
Fixed `combine` to be a non-const member function in prose