### PR TITLE
Clarify spec constant requirements

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13725,16 +13725,12 @@ class with the following restrictions:
 
 * the template parameter [code]#T# must be a <<device copyable>> type;
 * the [code]#specialization_id# variable must be declared as [code]#constexpr#;
-* the [code]#specialization_id# variable must be declared in one of the
-  following scopes:
-  - namespace scope (including the anonymous namespace);
-  - class scope where the class is declared in namespace scope;
-  - class scope where the class is declared in some other class scope, and the
-    outermost class is declared at namespace scope;
+* the [code]#specialization_id# variable must be declared in either namespace
+  scope (including the anonymous namespace) or in class scope;
 * if the [code]#specialization_id# variable is declared in the anonymous
   namespace, its name must be unambiguous when referenced from the global
   namespace scope (i.e. it must not have the same name as some other variable
-  declared in a named namespace);
+  declared in different namespace);
 * if the [code]#specialization_id# variable is declared in class scope, it must
   have public accessibility when referenced from namespace scope.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13726,13 +13726,22 @@ class with the following restrictions:
 * the template parameter [code]#T# must be a <<device copyable>> type;
 * the [code]#specialization_id# variable must be declared as [code]#constexpr#;
 * the [code]#specialization_id# variable must be declared in either namespace
-  scope (including the anonymous namespace) or in class scope;
-* if the [code]#specialization_id# variable is declared in the anonymous
-  namespace, its name must be unambiguous when referenced from the global
-  namespace scope (i.e. it must not have the same name as some other variable
-  declared in different namespace);
+  scope or in class scope;
 * if the [code]#specialization_id# variable is declared in class scope, it must
-  have public accessibility when referenced from namespace scope.
+  have public accessibility when referenced from namespace scope;
+* the [code]#specialization_id# variable may not be shadowed by another
+  variable [code]#V# which has the same name and is declared in an
+  [code]#inline# namespace, such that the [code]#specialization_id# variable is
+  no longer accessible after the declaration of [code]#V#.
+
+[NOTE]
+====
+The expectation is that some implementations may conceptually insert code at
+the end of a translation unit which references each `specialization_id`
+variable that is declared in that translation unit.  The restrictions listed
+above make this possible by ensuring that these variables are accessible at the
+end of the translation unit.
+====
 
 The following example illustrates some of these restrictions:
 
@@ -16165,7 +16174,7 @@ vec()
 a@
 [source]
 ----
-explicit vec(const dataT &arg)
+explicit constexpr vec(const dataT &arg)
 ----
    a@ Construct a vector of element type [code]#dataT# and
       [code]#numElements# dimensions by setting each value to [code]#arg# by
@@ -16175,14 +16184,14 @@ a@
 [source]
 ----
 template <typename... argTN>
-    vec(const argTN&... args)
+constexpr vec(const argTN&... args)
 ----
    a@ Construct a SYCL [code]#vec# instance from any combination of scalar and SYCL [code]#vec# parameters of the same element type, providing the total number of elements for all parameters sum to [code]#numElements# of this [code]#vec# specialization.
 
 a@
 [source]
 ----
-vec(const vec<dataT, numElements> &rhs)
+constexpr vec(const vec<dataT, numElements> &rhs)
 ----
    a@ Construct a vector of element type [code]#dataT# and number of elements [code]#numElements# by copy from another similar vector.
 
@@ -16993,7 +17002,7 @@ marray()
 a@
 [source]
 ----
-explicit marray(const dataT &arg)
+explicit constexpr marray(const dataT &arg)
 ----
    a@ Construct an array of element type [code]#dataT# and
       [code]#numElements# dimensions by setting each value to [code]#arg# by
@@ -17003,16 +17012,24 @@ a@
 [source]
 ----
 template <typename... argTN>
-    marray(const argTN&... args)
+constexpr marray(const argTN&... args)
 ----
    a@ Construct a SYCL [code]#marray# instance from any combination of scalar and SYCL [code]#marray# parameters of the same element type, providing the total number of elements for all parameters sum to [code]#numElements# of this [code]#marray# specialization.
 
 a@
 [source]
 ----
-marray(const marray<dataT, numElements> &rhs)
+constexpr marray(const marray<dataT, numElements> &rhs)
 ----
    a@ Construct an array of element type [code]#dataT# and number of elements [code]#numElements# by copy from another similar vector.
+
+a@
+[source]
+----
+constexpr marray(marray<dataT, numElements> &&rhs)
+----
+   a@ Construct an array of element type [code]#dataT# and number of elements
+      [code]#numElements# by moving from another similar vector.
 
 |====
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13721,12 +13721,31 @@ overhead associated with recompilation of the kernel's bundle.
 ==== Declaring a specialization constant
 
 Specialization constants must be declared using the [code]#specialization_id#
-class, and the declaration must be outside of <<kernel-scope>> using static
-storage duration.  The declaration must be in either namespace scope or class
-scope.
+class with the following restrictions:
 
-A synopsis of this class is shown below.  The template parameter [code]#T# must
-be a forward-declarable type.
+* The template parameter [code]#T# must be a <<device copyable>> type.
+* The [code]#specialization_id# variable must be declared as [code]#constexpr#.
+* The [code]#specialization_id# variable must be declared in one of the
+  following scopes:
+  - Namespace scope (including the anonymous namespace).
+  - Class scope where the class is declared in namespace scope.
+  - Class scope where the class is declared in some other class scope, and the
+    outermost class is declared at namespace scope.
+* If the [code]#specialization_id# variable is declared in the anonymous
+  namespace, its name must be unambiguous when referenced from the global
+  namespace scope (i.e. it must not have the same name as some other variable
+  declared in a named namespace).
+* If the [code]#specialization_id# variable is declared in class scope, it must
+  have public accessibility when referenced from namespace scope.
+
+The following example illustrates some of these restrictions:
+
+[source,,linenums]
+----
+include::{code_dir}/specialization_id.cpp[lines=4..-1]
+----
+
+A synopsis of this class is shown below.
 
 [source,,linenums]
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13723,19 +13723,19 @@ overhead associated with recompilation of the kernel's bundle.
 Specialization constants must be declared using the [code]#specialization_id#
 class with the following restrictions:
 
-* The template parameter [code]#T# must be a <<device copyable>> type.
-* The [code]#specialization_id# variable must be declared as [code]#constexpr#.
-* The [code]#specialization_id# variable must be declared in one of the
+* the template parameter [code]#T# must be a <<device copyable>> type;
+* the [code]#specialization_id# variable must be declared as [code]#constexpr#;
+* the [code]#specialization_id# variable must be declared in one of the
   following scopes:
-  - Namespace scope (including the anonymous namespace).
-  - Class scope where the class is declared in namespace scope.
-  - Class scope where the class is declared in some other class scope, and the
-    outermost class is declared at namespace scope.
-* If the [code]#specialization_id# variable is declared in the anonymous
+  - namespace scope (including the anonymous namespace);
+  - class scope where the class is declared in namespace scope;
+  - class scope where the class is declared in some other class scope, and the
+    outermost class is declared at namespace scope;
+* if the [code]#specialization_id# variable is declared in the anonymous
   namespace, its name must be unambiguous when referenced from the global
   namespace scope (i.e. it must not have the same name as some other variable
-  declared in a named namespace).
-* If the [code]#specialization_id# variable is declared in class scope, it must
+  declared in a named namespace);
+* if the [code]#specialization_id# variable is declared in class scope, it must
   have public accessibility when referenced from namespace scope.
 
 The following example illustrates some of these restrictions:

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13730,9 +13730,14 @@ class with the following restrictions:
 * if the [code]#specialization_id# variable is declared in class scope, it must
   have public accessibility when referenced from namespace scope;
 * the [code]#specialization_id# variable may not be shadowed by another
-  variable [code]#V# which has the same name and is declared in an
+  identifier [code]#X# which has the same name and is declared in an
   [code]#inline# namespace, such that the [code]#specialization_id# variable is
-  no longer accessible after the declaration of [code]#V#.
+  no longer accessible after the declaration of [code]#X#;
+* if the [code]#specialization_id# variable is declared in a namespace, none of
+  the enclosing namespace names [code]#N# may be shadowed by another identifier
+  [code]#X# which has the same name as [code]#N# and is declared in an
+  [code]#inline# namespace, such that [code]#N# is no longer accessible after
+  the declaration of [code]#X#.
 
 [NOTE]
 ====

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -4,41 +4,41 @@
 #include <sycl/sycl.hpp>
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
-struct Mixed {int i; float f;};
+struct Compound {int i; float f;};
 
 constexpr specialization_id<int> a{1};            // OK
-constexpr specialization_id<Mixed> b{2, 3.14};    // OK
+constexpr specialization_id<Compound> b{2, 3.14}; // OK
 inline constexpr specialization_id<int> c{3};     // OK
 static constexpr specialization_id<int> d{4};     // OK
 specialization_id<int> e{5};                      // ILLEGAL: not constexpr
 
-namespace foo {
-  constexpr specialization_id<int> same_name{6};  // OK
-}
-namespace bar {
-  constexpr specialization_id<int> same_name{7};  // OK
-}
-namespace {
-  constexpr specialization_id<int> other_name{8}; // OK
-}
-namespace {
-  constexpr specialization_id<int> same_name{9};  // ILLEGAL: ambiguous name in anonymous
-                                                  // namespace
-}
-
 struct Bar {
-  static constexpr specialization_id<int> f{10};  // OK
+  static constexpr specialization_id<int> f{6};   // OK
 };
 struct Baz {
   struct Inner {
-    static constexpr specialization_id<int> g{11};// OK
+    static constexpr specialization_id<int> g{7}; // OK
   };
 };
 class Boo {
-  static constexpr specialization_id<int> h{12};  // ILLEGAL: not public member
+  static constexpr specialization_id<int> h{8};   // ILLEGAL: not public member
 };
 
 void Func() {
-  static constexpr specialization_id<int> i{13};  // ILLEGAL: not at namespace or class scope
+  static constexpr specialization_id<int> i{9};   // ILLEGAL: not at namespace or
+                                                  // class scope
   /* ... */
+}
+
+constexpr specialization_id<int> same_name{10};   // OK
+namespace foo {
+  constexpr specialization_id<int> same_name{11}; // OK
+}
+namespace {
+  constexpr specialization_id<int> same_name{12}; // OK
+}
+inline namespace other {
+  int same_name;                                  // ILLEGAL: shadows "specialization_id"
+                                                  // variable with same name in enclosing
+                                                  // namespace scope
 }

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -42,3 +42,8 @@ inline namespace other {
                                                   // variable with same name in enclosing
                                                   // namespace scope
 }
+inline namespace {
+  namespace foo {                                 // ILLEGAL: namespace name shadows "::foo"
+  }                                               // namespace which contains
+                                                  // "specialization_id" variable.
+}

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2011-2021 The Khronos Group, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sycl/sycl.hpp>
+using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
+
+struct Mixed {int i; float f;};
+
+constexpr specialization_id<int> a{1};            // OK
+static constexpr specialization_id<int> b{2};     // OK
+specialization_id<int> c{3};                      // ERROR: not constexpr
+
+namespace foo {
+  constexpr specialization_id<Mixed> c{1, 3.14};  // OK
+}
+namespace {
+  constexpr specialization_id<Mixed> d{2, 2.718}; // OK
+}
+
+struct Bar {
+  static constexpr specialization_id<int> e{4};   // OK
+};
+struct Baz {
+  struct Inner {
+    static constexpr specialization_id<int> f{5}; // OK
+  };
+};
+class Boo {
+  static constexpr specialization_id<int> g{6};   // ERROR: not public member
+};
+
+void Func() {
+  static constexpr specialization_id<int> h{7};   // ERROR: not at namespace or class scope
+  /* ... */
+}

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -7,29 +7,38 @@ using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 struct Mixed {int i; float f;};
 
 constexpr specialization_id<int> a{1};            // OK
-static constexpr specialization_id<int> b{2};     // OK
-specialization_id<int> c{3};                      // ERROR: not constexpr
+constexpr specialization_id<Mixed> b{2, 3.14};    // OK
+inline constexpr specialization_id<int> c{3};     // OK
+static constexpr specialization_id<int> d{4};     // OK
+specialization_id<int> e{5};                      // ILLEGAL: not constexpr
 
 namespace foo {
-  constexpr specialization_id<Mixed> c{1, 3.14};  // OK
+  constexpr specialization_id<int> same_name{6};  // OK
+}
+namespace bar {
+  constexpr specialization_id<int> same_name{7};  // OK
 }
 namespace {
-  constexpr specialization_id<Mixed> d{2, 2.718}; // OK
+  constexpr specialization_id<int> other_name{8}; // OK
+}
+namespace {
+  constexpr specialization_id<int> same_name{9};  // ILLEGAL: ambiguous name in anonymous
+                                                  // namespace
 }
 
 struct Bar {
-  static constexpr specialization_id<int> e{4};   // OK
+  static constexpr specialization_id<int> f{10};  // OK
 };
 struct Baz {
   struct Inner {
-    static constexpr specialization_id<int> f{5}; // OK
+    static constexpr specialization_id<int> g{11};// OK
   };
 };
 class Boo {
-  static constexpr specialization_id<int> g{6};   // ERROR: not public member
+  static constexpr specialization_id<int> h{12};  // ILLEGAL: not public member
 };
 
 void Func() {
-  static constexpr specialization_id<int> h{7};   // ERROR: not at namespace or class scope
+  static constexpr specialization_id<int> i{13};  // ILLEGAL: not at namespace or class scope
   /* ... */
 }

--- a/adoc/headers/marray.h
+++ b/adoc/headers/marray.h
@@ -14,13 +14,13 @@ class marray {
 
   marray();
 
-  explicit marray(const dataT &arg);
+  explicit constexpr marray(const dataT &arg);
 
   template <typename... argTN>
-  marray(const argTN&... args);
+  constexpr marray(const argTN&... args);
 
-  marray(const marray<dataT, numElements> &rhs);
-  marray(marray<dataT, numElements> &&rhs);
+  constexpr marray(const marray<dataT, numElements> &rhs);
+  constexpr marray(marray<dataT, numElements> &&rhs);
 
   // Available only when: numElements == 1
   operator dataT() const;

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -49,12 +49,12 @@ class vec {
 
   vec();
 
-  explicit vec(const dataT &arg);
+  explicit constexpr vec(const dataT &arg);
 
   template <typename... argTN>
-  vec(const argTN&... args);
+  constexpr vec(const argTN&... args);
 
-  vec(const vec<dataT, numElements> &rhs);
+  constexpr vec(const vec<dataT, numElements> &rhs);
 
 #ifdef __SYCL_DEVICE_ONLY__
   vec(vector_t nativeVector);


### PR DESCRIPTION
This commit adjusts the requirements for declaring `specialization_id`
variables after doing a deeper analysis of how they can be implemented.
Following are the major changes:

* Add a requirement that the underlying type `T` must be device
  copyable.  This is necessary because the specialization constant's
  value could be copied from host to device in some implementations.
  We think this restriction was intended all along.

* Add a requirement that the `specialization_id` variable must be
  declared `constexpr`.  We intended all along to require the default
  value to be known at compile time, but the previous wording didn't
  state this.  By requiring the `specialization_id` variable to be
  `constexpr`, we also require the arguments to the constructor (the
  default value) to be known at compile time.

* We think that applications may want to use `marray` or `vec` as the
  underlying type of a `specialization_id` variable.  Make their constructors
  `constexpr` (where appropriate) to make this possible.

* Remove the requirement that the `specialization_id` must be declared
  with static storage duration.  This is redundant now that we require
  it to be declared `constexpr` since all namespace scope variables
  have static storage duration and all class scope `constexpr`
  variables also have static storage duration.

* Add a requirement that a `specialization_id` variable declared in
  class scope must be publicly accessible.  We think that a
  common implementation will generate a post-integration header file
  that is conceptually included at the end of the translation unit, and
  this header will reference the name of each `specialization_id`
  variable.  This is not possible if a class scope `specialization_id` variable
  has non-public access.

* Add a requirement that a `specialization_id` variable declared in
  namespace scope may not be "shadowed" by another variable
  with the same name declared in an `inline` namespace, such that
  the `specialization_id` variable is no longer accessible.  (The spec has
  an example showing this situation.)  Again, this situation would
  prevent the post-integration header from accessing the `specialization_id`
  variable.  We think this is a very weird corner case which will not
  affect any reasonable applications.