### PR TITLE
Clarify when host_task events are considered complete

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13934,6 +13934,10 @@ invoked directly by the SYCL runtime, regardless of which <<device>> the
 
 A <<host-task>> is enqueued on a <<queue>> via the [code]#host_task#
 member function of the [code]#handler# class.
+The <<event>> returned by the submission of the associated <<command group>> is
+considered complete (corresponding to a status of
+[code]#info::event_command_status::complete#) once the invocation of the
+provided {cpp} callable has returned.
 
 A <<host-task>> can optionally be used to interoperate with the
 <<native-backend-object,native backend objects>> associated with the <<queue>> executing the

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13934,8 +13934,8 @@ invoked directly by the SYCL runtime, regardless of which <<device>> the
 
 A <<host-task>> is enqueued on a <<queue>> via the [code]#host_task#
 member function of the [code]#handler# class.
-The <<event>> returned by the submission of the associated <<command group>> is
-considered complete (corresponding to a status of
+The <<event>> returned by the submission of the associated <<command group>>
+enters the completed state (corresponding to a status of
 [code]#info::event_command_status::complete#) once the invocation of the
 provided {cpp} callable has returned.
 


### PR DESCRIPTION
Following internal discussion on #140, this clarifies that the `sycl::event` returned by the submission of a `host_task` is considered complete once the invocation of the provided callable has returned.

Resolves #140.