### PR TITLE
Updated 4.6.5.2 queue shortcut functions example. malloc_device needs…

### DIFF
--- a/adoc/code/queueShortcuts.cpp
+++ b/adoc/code/queueShortcuts.cpp
@@ -3,7 +3,8 @@
 
 class MyKernel;
 
-auto usmPtr = malloc_device<int>(1024); // USM pointer
+queue myQueue;
+auto usmPtr = malloc_device<int>(1024, myQueue); // USM pointer
 
 int* data = /* pointer to some data */;
 buffer buf{data, 1024};


### PR DESCRIPTION
… at least two arguments.