### PR TITLE
[multi_ptr] Clean multi_ptr interface description to better align with the rest of the document.

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8953,7 +8953,7 @@ multi_ptr(multi_ptr&&)
 a@
 [source]
 ----
-multi_ptr(multi_ptr<ElementType, Space, yes>::pointer)
+explicit multi_ptr(multi_ptr<ElementType, Space, yes>::pointer)
 ----
    a@ Constructor that takes as an argument a decorated pointer.
 
@@ -9011,7 +9011,7 @@ a@
 [source]
 ----
 template <typename ElementType, access::address_space Space, access::decorated DecorateAddress>
-    multi_ptr<ElementType, Space, DecorateAddress> make_ptr(ElementType* pointer)
+multi_ptr<ElementType, Space, DecorateAddress> make_ptr(ElementType* pointer)
 ----
    a@ Global function to create a [code]#multi_ptr# instance depending
       on the address space of the [code]#pointer# argument.
@@ -9032,24 +9032,21 @@ template <typename ElementType, access::address_space Space, access::decorated D
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    multi_ptr &operator=(const multi_ptr&)
+multi_ptr &operator=(const multi_ptr&)
 ----
    a@ Copy assignment operator.
 
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    multi_ptr &operator=(multi_ptr&&)
+multi_ptr &operator=(multi_ptr&&)
 ----
    a@ Move assignment operator.
 
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    multi_ptr &operator=(std::nullptr_t)
+multi_ptr &operator=(std::nullptr_t)
 ----
    a@ Assigns [code]#nullptr# to the [code]#multi_ptr#.
 
@@ -9057,7 +9054,7 @@ a@
 [source]
 ----
 template<access::address_space ASP, access::decorated IsDecorated>
-    multi_ptr &operator=(const multi_ptr<value_type, ASP, IsDecorated>&)
+multi_ptr &operator=(const multi_ptr<value_type, ASP, IsDecorated>&)
 ----
    a@ Available only when: [code]#Space == access::address_space::generic_space && ASP != access::address_space::constant_space#.
 
@@ -9067,7 +9064,7 @@ a@
 [source]
 ----
 template<access::address_space ASP, access::decorated IsDecorated>
-    multi_ptr &operator=(multi_ptr<value_type, ASP, IsDecorated>&&
+multi_ptr &operator=(multi_ptr<value_type, ASP, IsDecorated>&&
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space && ASP != access::address_space::constant_space#.
@@ -9077,8 +9074,7 @@ Move the value of the left hand side [code]#multi_ptr# into the [code]#generic_p
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    pointer operator->() const
+pointer operator->() const
 ----
    a@ Available only when: [code]#!std::is_void<value_type>::value#.
 
@@ -9087,8 +9083,7 @@ Returns the underlying pointer.
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    reference operator*() const
+reference operator*() const
 ----
    a@ Available only when: [code]#!std::is_void<value_type>::value#.
 
@@ -9097,8 +9092,7 @@ Returns a reference to the pointed value.
 a@
 [source]
 ----
-template <typename value_type, access::address_space Space, access::decorated DecorateAddress>
-    operator pointer() const
+operator pointer() const
 ----
    a@ Implicit conversion to the underlying pointer type.
       *Deprecated:* The member function [code]#get# should be used instead
@@ -9107,7 +9101,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<value_type, access::address_space::private_space, IsDecorated>() const
+explicit operator multi_ptr<value_type, access::address_space::private_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9120,7 +9114,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<const value_type, access::address_space::private_space, IsDecorated>() const
+explicit operator multi_ptr<const value_type, access::address_space::private_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9133,7 +9127,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<value_type, access::address_space::global_space, IsDecorated>() const
+explicit operator multi_ptr<value_type, access::address_space::global_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9146,7 +9140,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<const value_type, access::address_space::global_space, IsDecorated>() const
+explicit operator multi_ptr<const value_type, access::address_space::global_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9159,7 +9153,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<value_type, access::address_space::local_space, IsDecorated>() const
+explicit operator multi_ptr<value_type, access::address_space::local_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9172,7 +9166,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<const value_type, access::address_space::local_space, IsDecorated>() const
+explicit operator multi_ptr<const value_type, access::address_space::local_space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space#.
@@ -9185,7 +9179,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<void, Space, IsDecorated>() const
+operator multi_ptr<void, Space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#!std::is_void<value_type>::value && !std::is_const<value_type>::value#.
@@ -9196,7 +9190,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<const void, Space, IsDecorated>() const
+operator multi_ptr<const void, Space, IsDecorated>() const
 ----
    a@ Available only when:
       [code]#!std::is_void<value_type>::value && std::is_const<value_type>::value#.
@@ -9207,7 +9201,7 @@ a@
 [source]
 ----
 template <access::decorated IsDecorated>
-    operator multi_ptr<const value_type, Space, IsDecorated>() const
+operator multi_ptr<const value_type, Space, IsDecorated>() const
 ----
    a@ Implicit conversion to a [code]#multi_ptr#
       of type [code]#const value_type#.
@@ -9215,8 +9209,7 @@ template <access::decorated IsDecorated>
 a@
 [source]
 ----
-
-    operator multi_ptr<const value_type, Space, access::decorated::no>() const
+operator multi_ptr<const value_type, Space, access::decorated::no>() const
 ----
    a@ Available only when:
       [code]#is_decorated == true#.
@@ -9227,8 +9220,7 @@ decorated pointers or references.
 a@
 [source]
 ----
-
-    operator multi_ptr<const value_type, Space, access::decorated::yes>() const
+operator multi_ptr<const value_type, Space, access::decorated::yes>() const
 ----
    a@ Available only when:
       [code]#is_decorated == false#.


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/SYCL-Docs/pull/148

Remove class template clause placed above member function.
Remove extra spaces not present in the rest of the document.