### PR TITLE
Remove references to independent forward progress

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1112,8 +1112,8 @@ supported if and only if the following conditions are true:
   * the work-items being synchronized are guaranteed to make forward progress
     with respect to one another.
 
-The ability of work-items to make forward progress with respect to work-items
-in other work-groups is implementation-defined.
+The ability of work-items to make forward progress with respect to other
+work-items is implementation-defined.
 
 // Later, this label will move onto a new subsection - see below
 [[sec:progmodel.cpp]]
@@ -1221,7 +1221,7 @@ by calling the [code]#group_barrier# function.
 To maximize portability across devices, developers should not assume that
 work-items within a sub-group execute in any particular order, that work-groups
 are subdivided into sub-groups in a specific way, nor that two sub-groups
-within a work-group will make independent forward progress with respect to one
+within a work-group will make forward progress with respect to one
 another.
 
 Variables with <<reduction>> semantics can be added to work-group data

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -454,9 +454,7 @@ object. For the full description please refer to <<subsec:buffers>>.
 [[sub-group]]sub-group::
     The SYCL sub-group ([code]#sycl::sub_group# class) is a
     representation of a collection of related work-items within a
-    <<work-group>> that execute concurrently, and which may make
-    independent forward progress with respect to other sub-groups in the
-    same <<work-group>>. For further details for the
+    <<work-group>> that execute concurrently. For further details for the
     [code]#sycl::sub_group# class see <<sub-group-class>>.
 
 [[sub-group-barrier]]sub-group barrier::

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1861,15 +1861,6 @@ info::device::max_num_sub_groups
 a@
 [source]
 ----
-info::device::sub_group_independent_forward_progress
-----
-
-    @ [.code]#bool#
-   a@ Returns true if the device supports independent forward progress of sub-groups with respect to other sub-groups in the same work-group.
-
-a@
-[source]
-----
 info::device::sub_group_sizes
 ----
 


### PR DESCRIPTION
The info::device::sub_group_independent_forward_progress query and
associated mentions of "independent forward progress" were inherited
from OpenCL during the introduction of sub-groups.

The ISO C++ specification defines its own classes of forward progress
(e.g. "weakly parallel forward progress") and going forward it is
important that SYCL aligns with this terminology.

Removing all mentions of "independent forward progress" from SYCL 2020
does not significantly change functionality or intent:
- OpenCL backends can query sub_group_independent_forward_progress
- Other backends can provide their own queries (via interoperability)

Providing a replacement mechanism to query the ability of work-items
to make forward progress is deferred.