### PR TITLE
Remove error condition

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -15761,9 +15761,6 @@ corresponding information.
 <<backend, SYCL backends>> can provide additional exception class objects as long as they derive
 from [code]#sycl::exception# object, or any of its derived classes.
 
-A specialization of [code]#std::is_error_condition_enum# must be defined
-for [code]#sycl::errc# inheriting from [code]#std::true_type#.
-
 A specialization of [code]#std::is_error_code_enum# must be defined
 for [code]#sycl::errc# and [code]#backend_traits<Backend>::errc#
 inheriting from [code]#std::true_type# for each [code]#Backend#, where
@@ -16059,13 +16056,6 @@ const std::error_category& sycl_category() noexcept;
    a@ Obtains a reference to the static error category object for SYCL errors.
       This object overrides the virtual function [code]#error_category()# to
       return a pointer to the string [code]#"sycl"#.
-
-a@
-[source]
-----
-std::error_condition make_error_condition(errc e) noexcept;
-----
-   a@ Constructs an error condition using [code]#e# and [code]#sycl_category()#.
 
 a@
 [source]

--- a/adoc/headers/exception.h
+++ b/adoc/headers/exception.h
@@ -65,7 +65,6 @@ enum class errc {
 template<backend b>
 using errc_for = typename backend_traits<b>::errc;
 
-std::error_condition make_error_condition(errc e) noexcept;
 std::error_code make_error_code(errc e) noexcept;
 
 const std::error_category& sycl_category() noexcept;
@@ -76,9 +75,6 @@ const std::error_category& error_category_for() noexcept;
 }  // namespace sycl
 
 namespace std {
-
-  template <>
-  struct is_error_condition_enum<sycl::errc> : true_type {};
 
   template <>
   struct is_error_code_enum<see-below> : true_type {};


### PR DESCRIPTION
According to the guidance in the WG21 document [P0824R1](
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0824r1.html),
no enumeration type `E` should ever satisfy both
`is_error_code_enum_v<E>` and `is_error_condition_enum_v<E>`
simultaneously.  However, prior to this commit, `sycl::errc` did
exactly this.

Upon further reflection, we think there is no need for SYCL to define
any `std::error_condition` and it is sufficient to define only
`std::error_code`.  Therefore, remove wording related to
`std::error_condition`.

This closes internal issue 549.