### PR TITLE
Reserve error code 0

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -15936,6 +15936,16 @@ iterator end() const
 a@
 [source]
 ----
+success
+----
+   a@ The implementation never throws an exception with this error code, but it
+      is defined to ensure that no other error code has the value zero.  An
+      application can construct an [code]#std::error_code# with this code to
+      indicate "not an error".
+
+a@
+[source]
+----
 runtime
 ----
    a@ Generic runtime error.

--- a/adoc/headers/exception.h
+++ b/adoc/headers/exception.h
@@ -46,6 +46,7 @@ class exception_list {
 };
 
 enum class errc {
+  success = 0,
   runtime = /* implementation-defined */,
   kernel = /* implementation-defined */,
   accessor = /* implementation-defined */,


### PR DESCRIPTION
Since the `sycl::errc` enumeration is used to construct
`std::error_code`, the value 0 must be reserved for "not an error".
Define the enumeration `success` for this purpose.

This closes internal issue 550.