### PR TITLE
Remove "device image selection function" term

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -175,11 +175,6 @@ object. For the full description please refer to <<subsec:buffers>>.
     code representation which needs to be compiled before it can be invoked.
     Other representations are possible too.
 
-[[device-image-selection-function]]device image selection function::
-    A callable object which takes the begin and end iterators of a
-    <<kernel-bundle>> pointing to a sequence of <<device-image>> and returns an
-    iterator to a chosen <<device-image>>.
-
 [[device-selector]]device selector::
     A way to select a device used in various places. This is a callable
     object taking a <<device>> reference and returning an integer rank.


### PR DESCRIPTION
Remove the glossary term "device image selection function".  There
were no reference to this term in the spec, and the description no
longer matches the way device image selection works.

This closes internal issue 313