### PR TITLE
parallel_for_work_group can take function object

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12953,6 +12953,7 @@ template <typename KernelName, typename WorkgroupFunctionType, int dimensions>
     const WorkgroupFunctionType &kernelFunc)
 ----
    a@ Defines and invokes a hierarchical kernel as a lambda function
+      or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#. May
       contain multiple calls to [code]#parallel_for_work_item(..)# member functions
@@ -12974,6 +12975,7 @@ template <typename KernelName, typename WorkgroupFunctionType, int dimensions>
     const WorkgroupFunctionType &kernelFunc)
 ----
    a@ Defines and invokes a hierarchical kernel as a lambda function
+      or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#.
       May contain multiple calls to [code]#parallel_for_work_item# member functions


### PR DESCRIPTION
Clarify that the `kernelFunc` parameter to `parallel_for_work_group()`
can be a named function object, just as with `parallel_for()`.

This closes internal issue 233.