### PR TITLE
Add missing property_list to reduction header

### DIFF
--- a/adoc/headers/reduction.h
+++ b/adoc/headers/reduction.h
@@ -20,4 +20,4 @@ __unspecified__ reduction(T* var, const T& identity, BinaryOperation combiner, c
 
 /* Available only if has_known_identity<BinaryOperation, T>::value is false */
 template <typename T, typename Extent, typename BinaryOperation>
-__unspecified__ reduction(span<T, Extent> vars, const T& identity, BinaryOperation combiner);
+__unspecified__ reduction(span<T, Extent> vars, const T& identity, BinaryOperation combiner, const property_list &propList = {});


### PR DESCRIPTION
All overloads of the reduction interface should accept a property_list.

This commit brings the reduction header in line with the table beneath
it (which already correctly shows a property_list for all overloads).