### PR TITLE
Invert order of src/dest parameters for USM copy

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3384,14 +3384,14 @@ a@
 [source]
 ----
 template <typename T>
-event copy(T* dest, const T* src, size_t count)
+event copy(const T* src, T* dest, size_t count)
 ----
 a@ <<sec:usm, USM>>
 a@
 [source]
 ----
 template <typename T>
-event copy(T* dest, const T* src, size_t count,
+event copy(const T* src, T* dest, size_t count,
            event depEvent)
 ----
 a@ <<sec:usm, USM>>
@@ -3399,7 +3399,7 @@ a@
 [source]
 ----
 template <typename T>
-event copy(T* dest, const T* src, size_t count,
+event copy(const T* srct, T* dest, size_t count,
            const std::vector<event> &depEvents)
 ----
 a@ <<sec:usm, USM>>
@@ -13586,7 +13586,7 @@ a@
 [source]
 ----
 template <typename T>
-void copy(T* dest, const T* src, size_t count)
+void copy(const T* src, T* dest, size_t count)
 ----
 a@ Copies [code]#count# elements of type [code]#T# from the pointer
 [code]#src# to the pointer [code]#dest#.

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -76,7 +76,7 @@ class handler {
   void memcpy(void *dest, const void *src, size_t numBytes);
 
   template <typename T>
-  void copy(T *dest, const T *src, size_t count);
+  void copy(const T *src, T *dest, size_t count);
 
   void memset(void *ptr, int value, size_t numBytes);
 

--- a/adoc/headers/queue.h
+++ b/adoc/headers/queue.h
@@ -124,12 +124,12 @@ class queue {
                const std::vector<event> &depEvents);
 
   template <typename T>
-  event copy(T* dest, const T *src, size_t count);
+  event copy(const T* src, T *dest, size_t count);
   template <typename T>
-  event copy(T* dest, const T *src, size_t count,
+  event copy(const T* src, T *dest, size_t count,
              event depEvent);
   template <typename T>
-  event copy(T* dest, const T *src, size_t count,
+  event copy(const T* src, T *dest, size_t count,
              const std::vector<event> &depEvents);
 
   event memset(void* ptr, int value, size_t numBytes);


### PR DESCRIPTION
We noticed that the USM `copy()` functions had a parameter order of
`(dest, src)`, which is opposite of the `copy()` functions for
accessors.  This seemed very confusing, so we decided to change the
order to match.  Since these USM functions are new in SYCL 2020 and
because no major implementation has added them yet, we think it is
still safe to make this change.

This closes internal issue #557