### PR TITLE
Add "constexpr" to specialization_id examples

### DIFF
--- a/adoc/code/bundle-spec-constants.cpp
+++ b/adoc/code/bundle-spec-constants.cpp
@@ -12,8 +12,8 @@ extern int get_width();
 extern int get_height();
 
 // Declare specialization constants used in our kernels.
-specialization_id<int> width;
-specialization_id<int> height;
+constexpr specialization_id<int> width;
+constexpr specialization_id<int> height;
 
 int main() {
   queue myQueue;

--- a/adoc/code/usingSpecConstants.cpp
+++ b/adoc/code/usingSpecConstants.cpp
@@ -10,7 +10,7 @@ using coeff_t = std::array<std::array<float, 3>, 3>;
 coeff_t get_coefficients();
 
 // Identify the specialization constant.
-specialization_id<coeff_t> coeff_id;
+constexpr specialization_id<coeff_t> coeff_id;
 
 void do_conv(buffer<float, 2> in, buffer<float, 2> out) {
   queue myQueue;


### PR DESCRIPTION
Somehow we forgot to update these examples when we added that
requirement that `specialization_id` variables must be declared
`constexpr`.