### PR TITLE
Clarify equality of "kernel_id" objects

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14373,6 +14373,12 @@ functions and common member functions that are listed in
 <<sec:reference-semantics>> in <<table.specialmembers.common.reference>> and
 <<table.hiddenfriends.common.reference>>, respectively.
 
+As with all SYCL objects that have the common reference semantics, kernel
+identifiers are equality comparable.  Two [code]#kernel_id# objects that refer
+to the same application kernel or to the same device built-in kernel are
+guaranteed to compare equal.  Two [code]#kernel_id# objects that refer to
+different kernels are guaranteed to compare unequal
+
 There is no public default constructor for this class.
 
 [source,,linenums]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14374,10 +14374,9 @@ functions and common member functions that are listed in
 <<table.hiddenfriends.common.reference>>, respectively.
 
 As with all SYCL objects that have the common reference semantics, kernel
-identifiers are equality comparable.  Two [code]#kernel_id# objects that refer
-to the same application kernel or to the same device built-in kernel are
-guaranteed to compare equal.  Two [code]#kernel_id# objects that refer to
-different kernels are guaranteed to compare unequal
+identifiers are equality comparable.  Two [code]#kernel_id# objects compare
+equal if an only if they refer to the same application kernel or to the same
+device built-in kernel.
 
 There is no public default constructor for this class.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14375,7 +14375,7 @@ functions and common member functions that are listed in
 
 As with all SYCL objects that have the common reference semantics, kernel
 identifiers are equality comparable.  Two [code]#kernel_id# objects compare
-equal if an only if they refer to the same application kernel or to the same
+equal if and only if they refer to the same application kernel or to the same
 device built-in kernel.
 
 There is no public default constructor for this class.


### PR DESCRIPTION
Clarify that two `kernel_id` objects compare equal if and only if they
refer to the same kernel.