### PR TITLE
Rename "sycl::requires()" to "sycl::device_has()"

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -586,20 +586,17 @@ with this sub-group size, the implementation must throw a synchronous
 a@
 [source]
 ----
-requires(has(aspect, ...))
+device_has(aspect, ...)
 ----
    a@ This attribute may be used to decorate either the declaration of a kernel
       function that is defined in the current translation unit or to decorate
       the declaration of a non-kernel device function.  The following
       description applies when the attribute decorates a kernel function.
 
-The parameter list to the [code]#sycl::requires()# attribute may either be
-empty or it may be a single [code]#has()# clause.  The parameter list to the
-[code]#has()# clause consists of zero or more [code]#constexpr# integral
-expressions, where each integer is interpreted as one of the enumerated values
-in the [code]#sycl::aspect# enumeration type.  Specifying an empty parameter
-list to [code]#sycl::requires()# is equivalent to specifying a [code]#has()#
-clause with an empty parameter list.
+The parameter list to the [code]#sycl::device_has()# attribute consists of zero
+or more [code]#constexpr# integral expressions, where each integer is
+interpreted as one of the enumerated values in the [code]#sycl::aspect#
+enumeration type.
 
 Specifying this attribute on a kernel has two effects.  First, it causes the
 <<kernel-invocation-command>> to throw a synchronous exception with the
@@ -611,20 +608,20 @@ to issue a diagnostic if the kernel (or any of the functions it calls) uses an
 optional feature that is associated with an aspect that is not listed in the
 attribute.
 
-The value of each parameter to the [code]#has()# clause must be equal to one of
-the values in the [code]#sycl::aspect# enumeration type (including any extended
+The value of each parameter to this attribute must be equal to one of the
+values in the [code]#sycl::aspect# enumeration type (including any extended
 values the implementation may provide).  If it does not, the program is ill
 formed and the compiler must issue a diagnostic.
 
-See <<listing:requires>> for an example of this attribute.
+See <<listing:device-has>> for an example of this attribute.
 
 |====
 
-.Example of the [code]#sycl::requires()# attribute
-[[listing:requires]]
+.Example of the [code]#sycl::device_has()# attribute
+[[listing:device-has]]
 [source,,linenums]
 ----
-include::{code_dir}/requires.cpp[lines=4..-1]
+include::{code_dir}/deviceHas.cpp[lines=4..-1]
 ----
 
 
@@ -643,7 +640,7 @@ as for the kernel function attributes defined above in
 a@
 [source]
 ----
-requires(has(aspect, ...))
+device_has(aspect, ...)
 ----
    a@ This attribute may be used to decorate either the declaration of a kernel
       function that is defined in the current translation unit or to decorate
@@ -652,7 +649,7 @@ requires(has(aspect, ...))
       function declaration.
 
 The syntax of this attribute's parameter list is the same as the syntax for
-the form of [code]#sycl::requires()# that is specified on a kernel function
+the form of [code]#sycl::device_has()# that is specified on a kernel function
 (see <<table.kernel.attributes>>).
 
 This attribute is required when a non-kernel device function that uses optional

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14709,7 +14709,7 @@ application is compatible with a device unless:
 
 * It uses optional features which are not supported on the device, as described
   in <<sec:optional-kernel-features>>; or
-* It is decorated with a [code]#[[sycl::requires()]]# {cpp} attribute that
+* It is decorated with a [code]#[[sycl::device_has()]]# {cpp} attribute that
   lists an aspect that is not supported by the device, as described in
   <<sec:kernel.attributes>>.
 

--- a/adoc/code/deviceHas.cpp
+++ b/adoc/code/deviceHas.cpp
@@ -3,7 +3,7 @@
 
 class KernelFunctor {
  public:
-  void operator()(item<1> it) const [[sycl::requires(has(aspect::fp16))]] {
+  void operator()(item<1> it) const [[sycl::device_has(aspect::fp16)]] {
     foo();
     bar();
   };
@@ -16,11 +16,11 @@ class KernelFunctor {
   void bar() const {
     sycl::atomic_ref longAtomic(longValue);
     longAtomic.fetchAdd(1);   // ERROR: Compiler issues diagnostic because
-                              // "aspect::atomic64" missing from "has()"
+                              // "aspect::atomic64" missing from "device_has()"
   }
 };
 
-// Using "sycl::requires()" does not provide any guarantee that the device
+// Using "sycl::device_has()" does not provide any guarantee that the device
 // actually supports the required features.  Therefore, the host code should
 // still check the device's aspects before submitting the kernel.
 if (myQueue.get_device().has(aspect::fp16)) {


### PR DESCRIPTION
Make two changes to the `[[sycl::requires()]]` attribute based on some
implementation experience:

* Change the name from `requires` to `device_has` in order to avoid
  confusion with the C++20 "requires" keyword.

* Simplify the parameter syntax by removing the `has()` clause.  The
  parameter list is now just a list of aspects.

The second bullet point deserves some explanation.  Our original intent
was to allow the `[[sycl::requires()]]` attribute to express both
conjunctions and disjunctions of aspects in some future version of the
SYCL spec.  For example, we thought we might want to allow syntax like
this in the future:

```
[[sycl::requires(has(aspect::fp64, aspect::atomic64) || has(aspect::fp16))]]
```

We still think this might be desirable in the future, but we think
disjunctions like this will be very uncommon.  We don't want to incur
the complexity of the `has()` clause even in the common case, so we
omit it from the current syntax (which only supports conjunctions of
aspects).

If we do decide to support disjunction in the future, we can create a
new attribute that supports the expanded syntax.  For example:

```
[[sycl::device_has_expression(has(aspect::fp64, aspect::atomic64) || has(aspect::fp16))]]
```

(We can bikeshed the name `device_has_expression` later if we decide to
add this.)