### PR TITLE
Fix copy-paste error in joint_scan definitions

### DIFF
--- a/adoc/headers/algorithms/exclusive_scan.h
+++ b/adoc/headers/algorithms/exclusive_scan.h
@@ -5,7 +5,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperat
 OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op); // (1)
 
 template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation>
-T joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init, BinaryOperation binary_op); // (2)
+OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init, BinaryOperation binary_op); // (2)
 
 template <typename Group, typename T, typename BinaryOperation>
 T exclusive_scan_over_group(Group g, T x, BinaryOperation binary_op); // (3)

--- a/adoc/headers/algorithms/inclusive_scan.h
+++ b/adoc/headers/algorithms/inclusive_scan.h
@@ -5,7 +5,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperat
 OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op); // (1)
 
 template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation>
-T joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op, T init); // (2)
+OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op, T init); // (2)
 
 template <typename Group, typename T, typename BinaryOperation>
 T inclusive_scan_over_group(Group g, T x, BinaryOperation binary_op); // (3)


### PR DESCRIPTION
joint_scan should always return a pointer, in keeping with the scan
algorithms from ISO C++.

Closes #177.