### PR TITLE
Fix missing braces around kernelId

### DIFF
--- a/adoc/code/bundle-kernel-introspection.cpp
+++ b/adoc/code/bundle-kernel-introspection.cpp
@@ -14,7 +14,7 @@ int main() {
 
   // Get an executable kernel bundle containing our kernel.
   kernel_id kernelId = get_kernel_id<MyKernel>();
-  auto myBundle = get_kernel_bundle<bundle_state::executable>(myContext, kernelId);
+  auto myBundle = get_kernel_bundle<bundle_state::executable>(myContext, {kernelId});
 
   // Get the kernel's maximum work group size when running on our device.
   kernel myKernel = myBundle.get_kernel(kernelId);


### PR DESCRIPTION
`get_kernel_bundle` does not have a constructor that takes a `kernel_id` but has one that takes a `const std::vector<kernel_id> &`.