### PR TITLE
Add "std::byte" support to stream

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18621,7 +18621,7 @@ include::{header_dir}/stream.h[lines=4..-1]
 a@
 [source]
 ----
-char, signed char, unsigned char, int, unsigned int, short, unsigned short, long int, unsigned long int, long long int, unsigned long long int
+char, signed char, unsigned char, int, unsigned int, short, unsigned short, long int, unsigned long int, long long int, unsigned long long int, std::byte
 ----
    a@ Outputs the value as a stream of characters.
 


### PR DESCRIPTION
Since we encourage people to migrate from the old `sycl::byte` to
`std::byte`, I presume we want to support `std::byte` in the `stream`
class.