### PR TITLE
Remove type restriction on "handler::fill()"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13578,7 +13578,6 @@ void fill(accessor<T, dim, mode, tgt, isPlaceholder> dest,
 ----
 a@ Replicates the value of [code]#src# into the
 memory object accessed by [code]#dest#.
-T must be a scalar value or a SYCL vector type.
 
 a@
 [source]


### PR DESCRIPTION
The overload of `handler::fill()` that takes an accessor used to be
limited to only scalar and SYCL vector types, but it's not clear why
we need this restriction.  The underlying type of a buffer accessor
can be any "device copyable" type, and it seems like the fill operation
can be easily implemented for any of these types: the implementation
just needs to do a byte-wise copy.

There is no need to state that "T must be a device copyable type" in
this method (or any of the other explicit copy methods that take an
accessor argument) because all these operations are restricted to
buffer accessors, and the underlying type of a buffer accessor is
always device copyable.