### PR TITLE
Fix typo in renaming: get_id() => get_group_id()

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11921,7 +11921,7 @@ a@
 ----
 size_t get_group_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_id()[dimension]#.
+   a@ Return the same value as [code]#get_group_id()[dimension]#.
 
 a@
 [source]
@@ -11978,7 +11978,7 @@ a@
 ----
 size_t operator[](int dimension) const
 ----
-   a@ Return the same value as [code]#get_id(dimension)#.
+   a@ Return the same value as [code]#get_group_id(dimension)#.
 
 a@
 [source]


### PR DESCRIPTION
get_id() from SYCL 1.2.1 was renamed to get_group_id() in SYCL 2020.