### PR TITLE
Clarify behaviour for range of zero

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -581,6 +581,11 @@ work-item executes the same code but the specific execution pathway through the
 code and the data operated upon can vary by using the work-item global id to
 specialize the computation.
 
+An index space of size zero is allowed.  All aspects of kernel execution proceed
+as normal with the exception that the kernel function itself is not executed.
+Note this means the command queue will still schedule this kernel after satisfying
+the requirements and this satisfies requirements of any dependent enqueued kernels.
+
 ==== Basic kernels
 
 SYCL allows a simple execution model in which a kernel is invoked over an
@@ -1204,8 +1209,10 @@ work-group in <<local memory,local>> or <<global memory>> and to synchronize bet
 work-items in the same work-group by calling the
 [code]#group_barrier# function. All work-groups in a given
 [code]#parallel_for# will be the same size, and the global size
-defined in the nd-range must be a multiple of the work-group size in
-each dimension.
+defined in the nd-range must either be a multiple of the work-group size in
+each dimension, or the global size must be zero. In the case the global size
+is zero, the kernel function is not executed, the local size is ignored, and
+any dependencies are satisfied.
 
 Work-groups may be further subdivided into <<sub-group>>s.
 The size and number of sub-groups is implementation-defined and may differ for

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -355,8 +355,10 @@ object. For the full description please refer to <<subsec:buffers>>.
     Contains a <<range>> specifying the number of global
     <<work-item,work items>>, a <<range>> specifying the number of local
     <<work-item,work items>> and a <<id>> specifying the global offset. Can be
-    one, two or three dimensional. The minimum size of each <<range>>
-    within the <<nd-range>> is 1 per dimension. In the SYCL interface an
+    one, two or three dimensional. The minimum size of <<range>>
+    within the <<nd-range>> is 0 per dimension; where any dimension is set to zero,
+    the index space in all dimensions will be zero.
+    In the SYCL interface an
     <<nd-range>> is represented by the [code]#nd_range# class (see
     <<subsubsec:nd-range-class>>).
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12939,8 +12939,8 @@ template <typename KernelName, int dimensions, typename... Rest>
       the callable.
 
 Throws an [code]#exception# with the [code]#errc::nd_range# error code if the
-global size defined in the associated [code]#executionRange# is not evenly
-divisible by the local size in each dimension.
+global size defined in the associated [code]#executionRange# defines a non-zero
+index space which is not evenly divisible by the local size in each dimension.
 
 a@
 [source]
@@ -13046,8 +13046,8 @@ template <int dimensions> void parallel_for(
       invoked for the specified [code]#executionRange#.
 
 Throws an [code]#exception# with the [code]#errc::nd_range# error code if the
-global size defined in the associated [code]#executionRange# is not evenly
-divisible by the local size in each dimension.
+global size defined in the associated [code]#executionRange# defines a non-zero
+index space which is not evenly divisible by the local size in each dimension.
 
 This invocation function ignores any [code]#kernel_bundle# that was bound to
 this command group handler via [code]#handler::use_kernel_bundle()# and instead

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -308,6 +308,9 @@ from one-dimensional [code]#item# and one-dimensional [code]#id# to scalar types
 have been defined. All of these modifications lead to simpler SYCL code in common
 use cases.
 
+The behaviour of executing a kernel over a [code]#range# or [code]#nd_range#
+with index space of zero has been clarified.
+
 Some device-specific queries have been renamed to more clearly be "`device-specific
 kernel`" [code]#get_info# queries ([code]#info::kernel_device_specific#)
 instead of "`work-group`" ([code]#get_workgroup_info#) and sub-group


### PR DESCRIPTION
This PR will resolve internal Issue 542.

This clarifies the situation when a `range` or `nd_range` of zero is specified with a `parallel_for`.
In short, the kernel *function* does not execute, but all other aspects of kernel execution for dependencies are satisfied (i.e. accessor and event dependencies are still required to be met before scheduling, and queue submissions depending on this kernel submission will be satisfied). This follows the behaviour of OpenCL 2.1.