### PR TITLE
Fixed return type of group_broadcast(Group g, T x)

### DIFF
--- a/adoc/headers/groups/broadcast.h
+++ b/adoc/headers/groups/broadcast.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename T>
-bool group_broadcast(Group g, T x); // (1)
+T group_broadcast(Group g, T x); // (1)
 
 template <typename Group, typename T>
 T group_broadcast(Group g, T x, Group::linear_id_type local_linear_id); // (2)


### PR DESCRIPTION
Since `group_broadcast(g, x)` is equivalent to `group_broadcast(g, x, 0)`
return types of both these functions should be the type of `x`, i.e. `T`.

Spec stipulated `group_broadcast(g, x)` to have `bool` return type instead.