### PR TITLE
Fix definition of fp_config::correctly_rounded_divide_sqrt

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2044,8 +2044,8 @@ info::device::half_fp_config
     negative infinity rounding modes are supported.
   * [code]#info::fp_config::fma:# IEEE754-2008 fused multiply add is
     supported.
-  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# correctly rounded
-    divide and sqrt as defined by the IEEE754 specification are supported.
+  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
+    sqrt are correctly rounded as defined by the IEEE754 specification.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.
@@ -2078,8 +2078,8 @@ info::device::single_fp_config
     negative infinity rounding modes are supported.
   * [code]#info::fp_config::fma:# IEEE754-2008 fused multiply add is
     supported.
-  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# correctly rounded
-    divide and sqrt as defined by the IEEE754 specification are supported.
+  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
+    sqrt are correctly rounded as defined by the IEEE754 specification.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2046,6 +2046,7 @@ info::device::half_fp_config
     supported.
   * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
     sqrt are correctly rounded as defined by the IEEE754 specification.
+    This property is deprecated.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.
@@ -2080,6 +2081,7 @@ info::device::single_fp_config
     supported.
   * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
     sqrt are correctly rounded as defined by the IEEE754 specification.
+    This property is deprecated.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2044,8 +2044,8 @@ info::device::half_fp_config
     negative infinity rounding modes are supported.
   * [code]#info::fp_config::fma:# IEEE754-2008 fused multiply add is
     supported.
-  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
-    sqrt are correctly rounded as defined by the IEEE754 specification.
+  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# correctly rounded
+    divide and sqrt as defined by the IEEE754 specification are supported.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.
@@ -2078,8 +2078,8 @@ info::device::single_fp_config
     negative infinity rounding modes are supported.
   * [code]#info::fp_config::fma:# IEEE754-2008 fused multiply add is
     supported.
-  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# divide and
-    sqrt are correctly rounded as defined by the IEEE754 specification.
+  * [code]#info::fp_config::correctly_rounded_divide_sqrt:# correctly rounded
+    divide and sqrt as defined by the IEEE754 specification are supported.
   * [code]#info::fp_config::soft_float:# basic floating-point
     operations (such as addition, subtraction, multiplication) are
     implemented in software.

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -4,6 +4,8 @@
 [[cha:what-changed-from]]
 = What has changed from previous versions
 
+The device query [code]#info::fp_config::correctly_rounded_divide_sqrt# has
+been deprecated.
 
 [[sec:what-changed-between]]
 == What has changed from SYCL 1.2.1 to SYCL 2020

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -4,9 +4,6 @@
 [[cha:what-changed-from]]
 = What has changed from previous versions
 
-The device query [code]#info::fp_config::correctly_rounded_divide_sqrt# has
-been deprecated.
-
 [[sec:what-changed-between]]
 == What has changed from SYCL 1.2.1 to SYCL 2020
 
@@ -261,6 +258,9 @@ functions used as <<device-selector,device selectors>> described in
 A new device selector utility has been added to <<sec:device-selector>>,
 the [code]#aspect_selector#, which returns a selector object
 that only selects devices that have all the requested aspects.
+
+The device query [code]#info::fp_config::correctly_rounded_divide_sqrt# has
+been deprecated.
 
 A new reduction library consisting of the [code]#reduction# function and
 [code]#reducer# class was introduced to simplify the expression of variables


### PR DESCRIPTION
The definition that was used before was taken from the OpenCL 1.2
specification, see section 4.2, table 4.3:

> CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT – divide and sqrt are correctly
> rounded as defined by the IEEE754 specification.

However this definition is misleading because what is really advertised
by this property is that the correctly rounded divide and sqrt are
supported, not that they are correctly rounded by default on the
given device.

In the OpenCL 1.2 specification this is made clear in section 5.6.4.2
which defines the build program flag
`-cl-fp32-correctly-rounded-divide-sqrt`.

Where it states the following:

> If this build option is not specified, the minimum numerical accuracy of
> single precision floating-point divide and sqrt are as defined in section 7.4
> of the OpenCL specification.

And:

> This build option can only be specified if the
> CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT is set in CL_DEVICE_SINGLE_FP_CONFIG (as
> defined in table 4.3) for devices that the program is being build.
> clBuildProgram or clCompileProgram will fail to compile the program for a
> device if the -cl-fp32-correctly-rounded-divide-sqrt option is specified and
> CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT is not set for the device.

But since SYCL doesn't specify build options, this entire section doesn't
appear in the SYCL specification and we're left with just the misleading
property definition that makes it sound like the correctly rounded divide and
sqrt will be used by default.

And so this patch alters the wording to only say that the correctly rounded
variants are supported, and not suggest that they are always used.

This new definition is still pretty vague, but it should allow implementations to support this device property as intended. And I'm unsure if further clarifications are feasible since the toggling mechanism (compiler flag) between regular precision or correctly rounded would likely remain implementation defined.