### PR TITLE
Clarify USM's free behaviour

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10604,7 +10604,10 @@ void sycl::free(void* ptr, sycl::context& syclContext)
 ----
 a@ Frees an allocation.  The memory pointed to by [code]#ptr# must have been
 allocated using one of the USM allocation routines.  [code]#syclContext# must
-be the same [code]#context# that was used to allocate the memory.
+be the same [code]#context# that was used to allocate the memory.  The memory 
+is freed without waiting for <<command, commands>> operating on it to be 
+completed.  If <<command, commands>>, that use this memory, are in-progress or 
+are enqueued they will have undefined behavior.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10606,7 +10606,7 @@ a@ Frees an allocation.  The memory pointed to by [code]#ptr# must have been
 allocated using one of the USM allocation routines.  [code]#syclContext# must
 be the same [code]#context# that was used to allocate the memory.  The memory 
 is freed without waiting for <<command, commands>> operating on it to be 
-completed.  If <<command, commands>>, that use this memory, are in-progress or 
+completed.  If <<command, commands>> that use this memory are in-progress or 
 are enqueued they will have undefined behavior.
 
 a@

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10607,7 +10607,7 @@ allocated using one of the USM allocation routines.  [code]#syclContext# must
 be the same [code]#context# that was used to allocate the memory.  The memory 
 is freed without waiting for <<command, commands>> operating on it to be 
 completed.  If <<command, commands>> that use this memory are in-progress or 
-are enqueued they will have undefined behavior.
+are enqueued the behavior is undefined.
 
 a@
 [source]


### PR DESCRIPTION
This PR adds two sentences to the `sycl::free` instruction to clarify that it does not wait to release the memory and if there are any enqueued commands which use it there will be undefined behaviour.

This is useful to users as it shows that they must be aware that commands can execute asynchronously and that unlike buffers the implementation will release the memory regardless of dependencies.