### PR TITLE
Fix information descriptors appendix introduction

### DIFF
--- a/adoc/chapters/information_descriptors.adoc
+++ b/adoc/chapters/information_descriptors.adoc
@@ -5,7 +5,7 @@
 = Information descriptors
 
 The purpose of this chapter is to include all the headers of the
-memory object descriptors, which are described in detail in
+SYCL object descriptors, which are described in detail in
 <<chapter:sycl-programming-interface>>, for platform,
 context, device, and queue.
 

--- a/adoc/chapters/information_descriptors.adoc
+++ b/adoc/chapters/information_descriptors.adoc
@@ -4,11 +4,8 @@
 [[sec:information-descriptors]]
 = Information descriptors
 
-The purpose of this chapter is to include all the headers of the
-SYCL object descriptors, which are described in detail in
-<<chapter:sycl-programming-interface>>, for platform,
-context, device, and queue.
-
+This appendix contains the definitions of all the SYCL information descriptors
+introduced in <<chapter:sycl-programming-interface>>.
 
 [[appendix.platform.descriptors]]
 == Platform information descriptors


### PR DESCRIPTION
None of the objects described in this section are memory objects, SYCL
objects seems to make more sense.