### PR TITLE
Fix attribute position in example

### DIFF
--- a/adoc/code/deviceHas.cpp
+++ b/adoc/code/deviceHas.cpp
@@ -3,7 +3,8 @@
 
 class KernelFunctor {
  public:
-  void operator()(item<1> it) const [[sycl::device_has(aspect::fp16)]] {
+  [[sycl::device_has(aspect::fp16)]]
+  void operator()(item<1> it) const {
     foo();
     bar();
   };


### PR DESCRIPTION
Fix the position of the C++ attribute in this example.  We changed the
attribute position in #136 (34732eea75a42865ea278f376a7d40568018e86e)
to adopt the standard location for attributes that appertain to a
function.  We should have changed this example in that PR also, but it
was missed.