### PR TITLE
Added stream to the list of classes with common reference semantics in 4.5.2.

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -332,6 +332,7 @@ Each of the following <<sycl-runtime>> classes:
 [code]#queue#,
 [code]#sampled_image#,
 [code]#sampled_image_accessor#,
+[code]#stream#,
 [code]#unsampled_image# and
 [code]#unsampled_image_accessor#
 must obey the following statements, where [code]#T# is the runtime class type:


### PR DESCRIPTION
From 4.16. Stream class:

"The SYCL stream class provides the common reference semantics (see Section 4.5.2)."

But in Section 4.5.2 `stream` is not listed: