### PR TITLE
Fix prototype of OCL make_event

### DIFF
--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -491,10 +491,13 @@ context make_context(
 a@
 [source]
 ----
-event make_event(const cl_event &clEvent,
+event make_event(
+    const std::vector<cl_event> &clEvents,
     const context &syclContext)
 ----
-   a@ Constructs a SYCL [code]#event# instance from an OpenCL [code]#cl_event# in accordance with the requirements described in <<sec:backend-interoperability>>.
+   a@ Constructs a SYCL [code]#event# instance from a vector of OpenCL
+      [code]#cl_event# objects in accordance with the requirements described in
+      <<sec:backend-interoperability>>.
 a@
 [source]
 ----


### PR DESCRIPTION
Fix the prototype of the OpenCL backend interop function `make_event()`.
The type of the first parameter must be
`const backend_input_t<backend::opencl, event> &`, but this type alias
is defined as `std::vector<cl_event>` in the table "List of native
types per SYCL object in the OpenCL backend".  We decided that the
table is correct, so change the prototype to match.

Closes internal issue 588.