### PR TITLE
Rephrase the confusing 'buffer scope' wording

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5910,7 +5910,7 @@ class as an example. The same rules will apply to images as well.
 When using a SYCL buffer, the ownership of the pointer passed to the constructor
 of the class is, by default, passed to <<sycl-runtime>>, and that pointer cannot be used
 on the host side until the buffer or image is destroyed.
-A SYCL application can use memory managed by a SYCL buffer within the buffer scope
+A SYCL application can access the contents of the memory managed by a SYCL buffer
 by using a [code]#host_accessor# as defined in <<subsec:accessors>>.
 However, there is no guarantee that the host accessor synchronizes with the
 original host address used in its constructor.


### PR DESCRIPTION
This PR changes the following phrase:

"A SYCL application can use memory managed by a SYCL buffer within the buffer scope by using a host accessor as defined in <<subsec:accessors>>."

to:

"A SYCL application can access the contents of the memory managed by a SYCL buffer
by using a host accessor as defined in <<subsec:accessors>>.

The intent is to remove the confusing wording of 'buffer scope'.