### PR TITLE
Fix description of atomic_ref operators

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18045,7 +18045,7 @@ a@
 ----
 T operator+=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_add(operand)#.
+   a@ Equivalent to [code]#fetch_add(operand) pass:[+] operand#.
 
 a@
 [source]
@@ -18079,7 +18079,7 @@ a@
 ----
 T operator-=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_sub(operand)#.
+   a@ Equivalent to [code]#fetch_sub(operand) - operand#.
 
 a@
 [source]
@@ -18114,7 +18114,7 @@ a@
 ----
 T operator&=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_and(operand)#.
+   a@ Equivalent to [code]#fetch_and(operand) & operand#.
 
 a@
 [source]
@@ -18135,7 +18135,7 @@ a@
 ----
 T operator|=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_or(operand)#.
+   a@ Equivalent to [code]#fetch_or(operand) | operand#.
 
 a@
 [source]
@@ -18156,7 +18156,7 @@ a@
 ----
 T operator^=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_xor(operand)#.
+   a@ Equivalent to [code]#fetch_xor(operand) ^ operand#.
 
 a@
 [source]
@@ -18213,7 +18213,7 @@ a@
 ----
 T operator+=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_add(operand)#.
+   a@ Equivalent to [code]#fetch_add(operand) pass:[+] operand#.
 
 a@
 [source]
@@ -18233,7 +18233,7 @@ a@
 ----
 T operator-=(T operand) const
 ----
-   a@ Equivalent to [code]#fetch_sub(operand)#.
+   a@ Equivalent to [code]#fetch_sub(operand) - operand#.
 
 a@
 [source]
@@ -18288,7 +18288,7 @@ a@
 ----
 T* operator+=(ptrdiff_t operand) const
 ----
-   a@ Equivalent to [code]#fetch_add(operand)#.
+   a@ Equivalent to [code]#fetch_add(operand) pass:[+] operand#.
 
 a@
 [source]
@@ -18322,7 +18322,7 @@ a@
 ----
 T* operator-=(ptrdiff_t operand) const
 ----
-   a@ Equivalent to [code]#fetch_sub(operand)#.
+   a@ Equivalent to [code]#fetch_sub(operand) - operand#.
 
 a@
 [source]


### PR DESCRIPTION
Prior to this commit, the atomic_ref operators were incorrectly
described as being equivalent to calling a fetch_* member function
(e.g. += was described as being equivalent to calling fetch_add).

In ISO C++, fetch_* functions return the value before the atomic
operation is performed, and operators return the value after the atomic
operation is performed.

Fixes #227.