### PR TITLE
Update device and platform version descriptions

### DIFF
--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -149,15 +149,17 @@ combination of the two.
 
 The SYCL system presents the user with a set of devices, grouped into some
 number of platforms.
-The device version is an indication of the device's
-capabilities, as represented by the device information returned by the
-[code]#sycl::device::get_info()# member function.  Examples of attributes
-associated with the device version are resource limits and information
-about functionality beyond the requirements in the <<core-spec>>.
-The version returned corresponds to the highest version of the OpenCL
-specification for which the device is conformant, but is not higher than
-the version of the device's platform which bounds the overall capabilities
-of the runtime operating the device.
+
+The version returned by [code]#sycl::platform::get_info()# and
+[code]#sycl::device::get_info()# for the attributes
+[code]#info::platform::driver_version# and [code]#info::device::driver_version#
+respectively, represents the OpenCL software driver version in the form:
+[code]#major_number.minor_number#.
+
+The version returned for the device corresponds to the highest version of the
+OpenCL specification for which the device is conformant, but is not higher than
+the version of the device's platform which bounds the overall capabilities of
+the runtime operating the device.
 
 
 === OpenCL memory model

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -156,6 +156,7 @@ described in the table below:
 |====
 | SYCL                                 | OpenCL
 | [code]#info::platform::version#      | [code]#CL_PLATFORM_VERSION#
+| [code]#info::device::version#        | [code]#CL_DEVICE_VERSION#
 | [code]#info::device::driver_version# | [code]#CL_DRIVER_VERSION#
 |====
 

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -157,7 +157,6 @@ described in the table below:
 | SYCL                                 | OpenCL
 | [code]#info::platform::version#      | [code]#CL_PLATFORM_VERSION#
 | [code]#info::device::version#        | [code]#CL_DEVICE_VERSION#
-| [code]#info::device::driver_version# | [code]#CL_DRIVER_VERSION#
 |====
 
 === OpenCL memory model

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -144,23 +144,20 @@ units (where each PE maintains its own program counter) or as some
 combination of the two.
 
 
-// From Architecture, Section 3.3.1 (Platform mixed version support)
-=== Platform mixed version support
+=== Backend specific information descriptors
 
-The SYCL system presents the user with a set of devices, grouped into some
-number of platforms.
+Some of the SYCL information descriptors are backend-defined. For the OpenCL
+backend these information descriptors map directly to OpenCL properties as
+described in the table below:
 
-The version returned by [code]#sycl::platform::get_info()# and
-[code]#sycl::device::get_info()# for the attributes
-[code]#info::platform::driver_version# and [code]#info::device::driver_version#
-respectively, represents the OpenCL software driver version in the form:
-[code]#major_number.minor_number#.
-
-The version returned for the device corresponds to the highest version of the
-OpenCL specification for which the device is conformant, but is not higher than
-the version of the device's platform which bounds the overall capabilities of
-the runtime operating the device.
-
+[[table.opencl.info]]
+.Mapping of SYCL information descriptors to OpenCL properties
+[width="40%",options="header",cols="50%,50%"]
+|====
+| SYCL                                 | OpenCL
+| [code]#info::platform::version#      | [code]#CL_PLATFORM_VERSION#
+| [code]#info::device::driver_version# | [code]#CL_DRIVER_VERSION#
+|====
 
 === OpenCL memory model
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2400,7 +2400,8 @@ info::device::driver_version
 ----
 
     @ [.code]#std::string#
-   a@ Returns a backend-defined driver version as a [code]#std::string#.
+   a@ Returns a vendor-defined string describing the version of the underlying
+      backend software driver.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1187,7 +1187,7 @@ info::platform::version
 ----
 
     @ [.code]#std::string#
-   a@ Returns the software driver version of the <<device>>.
+   a@ Returns a backend-defined <<platform>> version.
 
 a@
 [source]
@@ -2401,8 +2401,6 @@ info::device::driver_version
 
     @ [.code]#std::string#
    a@ Returns a backend-defined driver version as a [code]#std::string#.
-      If using the OpenCL backend, the returned value represents the
-      OpenCL software driver version in the form: major_number.minor_number.
 
 a@
 [source]
@@ -2432,7 +2430,8 @@ info::device::version
 
     @ [.code]#std::string#
    a@ Returns the SYCL version as a [code]#std::string# in the form:
-      [code]#<major_version>.<minor_version>#.
+      [code]#<version>.<revision>#, with [code]#<version># being a year based
+      number, for example [code]#2020.4#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2429,8 +2429,9 @@ info::device::version
 ----
 
     @ [.code]#std::string#
-   a@ Returns the year based SYCL version as a [code]#std::string#. This
-      property is deprecated.
+   a@ Returns the SYCL version as a [code]#std::string# in the form:
+      [code]#<version>.<revision>#, with [code]#<version># being a year based
+      number, for example [code]#2020.4#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2429,9 +2429,8 @@ info::device::version
 ----
 
     @ [.code]#std::string#
-   a@ Returns the SYCL version as a [code]#std::string# in the form:
-      [code]#<version>.<revision>#, with [code]#<version># being a year based
-      number, for example [code]#2020.4#.
+   a@ Returns the year based SYCL version as a [code]#std::string#. This
+      property is deprecated.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2429,9 +2429,7 @@ info::device::version
 ----
 
     @ [.code]#std::string#
-   a@ Returns the SYCL version as a [code]#std::string# in the form:
-      [code]#<version>.<revision>#, with [code]#<version># being a year based
-      number, for example [code]#2020.4#.
+   a@ Returns a backend-defined <<device>> version.
 
 a@
 [source]

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -262,6 +262,8 @@ that only selects devices that have all the requested aspects.
 The device query [code]#info::fp_config::correctly_rounded_divide_sqrt# has
 been deprecated.
 
+The device query [code]#info::device::version# has been deprecated.
+
 A new reduction library consisting of the [code]#reduction# function and
 [code]#reducer# class was introduced to simplify the expression of variables
 with <<reduction>> semantics in SYCL kernels. See <<sec:reduction>>.

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -262,8 +262,6 @@ that only selects devices that have all the requested aspects.
 The device query [code]#info::fp_config::correctly_rounded_divide_sqrt# has
 been deprecated.
 
-The device query [code]#info::device::version# has been deprecated.
-
 A new reduction library consisting of the [code]#reduction# function and
 [code]#reducer# class was introduced to simplify the expression of variables
 with <<reduction>> semantics in SYCL kernels. See <<sec:reduction>>.


### PR DESCRIPTION
This PR is a draft in attempt to resolve https://github.com/KhronosGroup/SYCL-Docs/issues/222

Any further feedback on these is appreciated.

This patch updates:
* `device::version` description to use the new SYCL versioning scheme.
* Update wording of `platform::version`, a platform has multiple devices
  so referencing the device doesn't seem sensible.
* Remove mentions of OpenCL backend in descriptors table
* Update OpenCL backend doc to describe the meaning of the version
  numbers.
