### PR TITLE
Improve wording of host task capture restrictions

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14055,7 +14055,7 @@ defined in <<sub.section.memmodel.app>>.
 Since a <<host-task>> is invoked directly by the <<sycl-runtime>> rather
 than being compiled as a <<sycl-kernel-function>>, it does not have the same
 restrictions as a <<sycl-kernel-function>>, and can therefore contain any
-arbitrary {cpp} code. However, capturing or using any SYCL class with reference
+arbitrary {cpp} code. However, capturing or using any SYCL class that has reference
 semantics (see <<sec:reference-semantics>>) is undefined behavior.
 
 A <<host-task>> can be enqueued on any <<queue>> and the callable will be


### PR DESCRIPTION
The original sentence was a little confusing at first glance because it
could be interpreted as "capturing with reference semantics" rather than
talking about the SYCL objects having reference semantics.

So this is very minor, but changing "with" to "that has" here clears up any
potential confusions.