### PR TITLE
Clarify that enumerator types are unspecified

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13,6 +13,11 @@ pertaining to any particular <<backend>>.
 SYCL guarantees that all the member functions and special member functions of
 the SYCL classes described are thread safe.
 
+The underlying types for all enumerations defined in this specification are
+implementation-defined.  In addition, all enumerators within an enumeration
+have some implementation-defined unique value unless the specification
+specifically indicates a values for the enumerator.
+
 
 [[sec:backends]]
 == Backends
@@ -9847,7 +9852,7 @@ inside of a SYCL program:
 ----
 namespace sycl {
   namespace usm {
-    enum class alloc {
+    enum class alloc : /* unspecified */ {
       host,
       device,
       shared,

--- a/adoc/headers/accessMode.h
+++ b/adoc/headers/accessMode.h
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-enum class access_mode {
+
+enum class access_mode : /* unspecified */ {
   read,
   write,
   read_write,
@@ -15,4 +16,5 @@ namespace access {
   // The legacy type "access::mode" is deprecated.
   using mode = sycl::access_mode;
 }  // namespace access
+
 }  // namespace sycl

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -3,20 +3,20 @@
 
 namespace sycl {
 
-enum class target {
+enum class target : /* unspecified */ {
   device,
   host_task,
-  global_buffer = device,             // Deprecated
   constant_buffer,                    // Deprecated
   local,                              // Deprecated
-  host_buffer                         // Deprecated
+  host_buffer,                        // Deprecated
+  global_buffer = device              // Deprecated
 };
 
 namespace access {
   // The legacy type "access::target" is deprecated.
   using sycl::target;
 
-enum class placeholder { // Deprecated
+enum class placeholder : /* unspecified */ { // Deprecated
   false_t,
   true_t
 };

--- a/adoc/headers/accessorSampledImage.h
+++ b/adoc/headers/accessorSampledImage.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-enum class image_target {
+enum class image_target : /* unspecified */ {
   device,
   host_task
 };

--- a/adoc/headers/accessorUnsampledImage.h
+++ b/adoc/headers/accessorUnsampledImage.h
@@ -3,7 +3,7 @@ g// Copyright (c) 2011-2021 The Khronos Group, Inc.
 
 namespace sycl {
 
-enum class image_target {
+enum class image_target : /* unspecified */ {
   device,
   host_task
 };

--- a/adoc/headers/atomic.h
+++ b/adoc/headers/atomic.h
@@ -3,8 +3,9 @@
 
 namespace cl {
 namespace sycl {
+
 /* Deprecated in SYCL 2020 */
-enum class memory_order : int {
+enum class memory_order : /* unspecified */ {
   relaxed
 };
 
@@ -57,5 +58,6 @@ class atomic {
   T fetch_max(T operand, memory_order memoryOrder =
     memory_order::relaxed);
 };
+
 }  // namespace sycl
 }  // namespace cl

--- a/adoc/headers/backends.h
+++ b/adoc/headers/backends.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 namespace sycl {
-enum class backend {
+enum class backend : /* unspecified */ {
   /* see below */
 };
 }  // namespace sycl

--- a/adoc/headers/bundle/freeFunctions.h
+++ b/adoc/headers/bundle/freeFunctions.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-enum class bundle_state {
+enum class bundle_state : /* unspecified */ {
   input,
   object,
   executable

--- a/adoc/headers/deviceEnumClassAspect.h
+++ b/adoc/headers/deviceEnumClassAspect.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-enum class aspect {
+enum class aspect : /* unspecified */ {
   cpu,
   gpu,
   accelerator,

--- a/adoc/headers/deviceInfo.h
+++ b/adoc/headers/deviceInfo.h
@@ -86,7 +86,7 @@ struct partition_type_affinity_domain;
 
 }  // namespace device
 
-enum class device_type : unsigned int {
+enum class device_type : /* unspecified */ {
   cpu,         // Maps to OpenCL CL_DEVICE_TYPE_CPU
   gpu,         // Maps to OpenCL CL_DEVICE_TYPE_GPU
   accelerator, // Maps to OpenCL CL_DEVICE_TYPE_ACCELERATOR
@@ -96,14 +96,14 @@ enum class device_type : unsigned int {
   all          // Maps to OpenCL CL_DEVICE_TYPE_ALL
 };
 
-enum class partition_property : int {
+enum class partition_property : /* unspecified */ {
   no_partition,
   partition_equally,
   partition_by_counts,
   partition_by_affinity_domain
 };
 
-enum class partition_affinity_domain : int {
+enum class partition_affinity_domain : /* unspecified */ {
   not_applicable,
   numa,
   L4_cache,
@@ -113,9 +113,13 @@ enum class partition_affinity_domain : int {
   next_partitionable
 };
 
-enum class local_mem_type : int { none, local, global };
+enum class local_mem_type : /* unspecified */ {
+  none,
+  local,
+  global
+};
 
-enum class fp_config : int {
+enum class fp_config : /* unspecified */ {
   denorm,
   inf_nan,
   round_to_nearest,
@@ -126,9 +130,13 @@ enum class fp_config : int {
   soft_float
 };
 
-enum class global_mem_cache_type : int { none, read_only, read_write };
+enum class global_mem_cache_type : /* unspecified */ {
+  none,
+  read_only,
+  read_write
+};
 
-enum class execution_capability : unsigned int {
+enum class execution_capability : /* unspecified */ {
   exec_kernel,
   exec_native_kernel
 };

--- a/adoc/headers/eventInfo.h
+++ b/adoc/headers/eventInfo.h
@@ -9,7 +9,7 @@ struct command_execution_status;
 
 }  // namespace event
 
-enum class event_command_status : int {
+enum class event_command_status : /* unspecified */ {
   submitted,
   running,
   complete

--- a/adoc/headers/exception.h
+++ b/adoc/headers/exception.h
@@ -45,22 +45,22 @@ class exception_list {
   iterator end() const;    // refer to past-the-end last asynchronous exception
 };
 
-enum class errc {
+enum class errc : /* unspecified */ {
   success = 0,
-  runtime = /* implementation-defined */,
-  kernel = /* implementation-defined */,
-  accessor = /* implementation-defined */,
-  nd_range = /* implementation-defined */,
-  event = /* implementation-defined */,
-  kernel_argument = /* implementation-defined */,
-  build = /* implementation-defined */,
-  invalid = /* implementation-defined */,
-  memory_allocation = /* implementation-defined */,
-  platform = /* implementation-defined */,
-  profiling = /* implementation-defined */,
-  feature_not_supported = /* implementation-defined */,
-  kernel_not_supported = /* implementation-defined */,
-  backend_mismatch = /* implementation-defined */
+  runtime,
+  kernel,
+  accessor,
+  nd_range,
+  event,
+  kernel_argument,
+  build,
+  invalid,
+  memory_allocation,
+  platform,
+  profiling,
+  feature_not_supported,
+  kernel_not_supported,
+  backend_mismatch
 };
 
 template<backend b>

--- a/adoc/headers/imageSampler.h
+++ b/adoc/headers/imageSampler.h
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-enum class addressing_mode: unsigned int {
+
+enum class addressing_mode : /* unspecified */ {
   mirrored_repeat,
   repeat,
   clamp_to_edge,
@@ -10,12 +11,12 @@ enum class addressing_mode: unsigned int {
   none
 };
 
-enum class filtering_mode: unsigned int {
+enum class filtering_mode : /* unspecified */ {
   nearest,
   linear
 };
 
-enum class coordinate_normalization_mode : unsigned int {
+enum class coordinate_normalization_mode : /* unspecified */ {
   normalized,
   unnormalized
 };
@@ -25,4 +26,5 @@ struct image_sampler {
   coordinate_mode coordinate;
   filtering_mode filtering;
 };
+
 }  // namespace sycl

--- a/adoc/headers/memoryOrder.h
+++ b/adoc/headers/memoryOrder.h
@@ -4,8 +4,13 @@
 namespace sycl {
 
 enum class memory_order : /* unspecified */ {
-  relaxed, acquire, release, acq_rel, seq_cst
+  relaxed,
+  acquire,
+  release,
+  acq_rel,
+  seq_cst
 };
+
 inline constexpr auto memory_order_relaxed = memory_order::relaxed;
 inline constexpr auto memory_order_acquire = memory_order::acquire;
 inline constexpr auto memory_order_release = memory_order::release;

--- a/adoc/headers/memoryScope.h
+++ b/adoc/headers/memoryScope.h
@@ -4,8 +4,13 @@
 namespace sycl {
 
 enum class memory_scope : /* unspecified */ {
-  work_item, sub_group, work_group, device, system
+  work_item,
+  sub_group,
+  work_group,
+  device,
+  system
 };
+
 inline constexpr auto memory_scope_work_item = memory_scope::work_item;
 inline constexpr auto memory_scope_sub_group = memory_scope::sub_group;
 inline constexpr auto memory_scope_work_group = memory_scope::work_group;

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -3,18 +3,19 @@
 
 namespace sycl {
 namespace access {
-enum class address_space : int {
+
+enum class address_space : /* unspecified */ {
   global_space,
   local_space,
   constant_space, // Deprecated in SYCL 2020
   private_space,
-  generic_space,
+  generic_space
 };
 
-enum class decorated : int {
+enum class decorated : /* unspecified */ {
   no,
   yes,
-  legacy,
+  legacy
 };
 
 }  // namespace access

--- a/adoc/headers/sampledImage.h
+++ b/adoc/headers/sampledImage.h
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-enum class image_format : unsigned int {
+
+enum class image_format : /* unspecified */ {
   r8g8b8a8_unorm,
   r16g16b16a16_unorm,
   r8g8b8a8_sint,
@@ -13,7 +14,7 @@ enum class image_format : unsigned int {
   r32b32g32a32_uint,
   r16b16g16a16_sfloat,
   r32g32b32a32_sfloat,
-  b8g8r8a8_unorm,
+  b8g8r8a8_unorm
 };
 
 template <int Dimensions = 1, typename AllocatorT = sycl::image_allocator>
@@ -58,4 +59,5 @@ class sampled_image {
   template<typename... Ts>
   auto get_host_access(Ts... args);
 };
+
 }  // namespace sycl

--- a/adoc/headers/stream.h
+++ b/adoc/headers/stream.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-enum class stream_manipulator {
+enum class stream_manipulator : /* unspecified */ {
   flush,
   dec,
   hex,

--- a/adoc/headers/unsampledImage.h
+++ b/adoc/headers/unsampledImage.h
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-enum class image_format : unsigned int {
+
+enum class image_format : /* unspecified */ {
   r8g8b8a8_unorm,
   r16g16b16a16_unorm,
   r8g8b8a8_sint,
@@ -13,7 +14,7 @@ enum class image_format : unsigned int {
   r32b32g32a32_uint,
   r16b16g16a16_sfloat,
   r32g32b32a32_sfloat,
-  b8g8r8a8_unorm,
+  b8g8r8a8_unorm
 };
 
 template <int Dimensions = 1, typename AllocatorT = sycl::image_allocator>
@@ -101,4 +102,5 @@ class unsampled_image {
 
   void set_write_back(bool flag = true);
 };
+
 }  // namespace sycl

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-enum class rounding_mode {
+enum class rounding_mode : /* unspecified */ {
   automatic,
   rte,
   rtz,


### PR DESCRIPTION
Clarify that the underlying type for all scoped enumerations is
implementation-defined.  Also clarify that the values of enumerators
within an enumeration are implementation-defined.

Closes internal issue 386