### PR TITLE
Fix "!=" specification for NaN

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16876,7 +16876,7 @@ a@
 ----
 vec<RET, NumElements> operatorOP(const vec& lhs, const vec &rhs)
 ----
-   a@ Construct a new instance of the SYCL [code]#vec# class template with the element type [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and each element of the [code]#rhs# SYCL [code]#vec#. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false# or either this SYCL [code]#vec# or the [code]#rhs# SYCL [code]#vec# is a NaN.
+   a@ Construct a new instance of the SYCL [code]#vec# class template with the element type [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and each element of the [code]#rhs# SYCL [code]#vec#. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false#.  The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=# operations result in [code]#false# if either the [code]#lhs# element or the [code]#rhs# element is a NaN.  The [code]#!=# operation results in [code]#true# if either the [code]#lhs# element or the [code]#rhs# element is a NaN.
 
 The [code]#DataT# template parameter of the constructed SYCL [code]#vec#, [code]#RET#, varies depending on the [code]#DataT# template parameter of this SYCL [code]#vec#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int8_t# or [code]#uint8_t# [code]#RET# must be [code]#int8_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int16_t#, [code]#uint16_t# or [code]#half# [code]#RET# must be [code]#int16_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int32_t#, [code]#uint32_t# or [code]#float# [code]#RET# must be [code]#int32_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int64_t#, [code]#uint64_t# or [code]#double# [code]#RET# must be [code]#uint64_t#.
 
@@ -16887,7 +16887,7 @@ a@
 ----
 vec<RET, NumElements> operatorOP(const vec &lhs, const DataT &rhs)
 ----
-   a@ Construct a new instance of the SYCL [code]#vec# class template with the [code]#DataT# parameter of [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and the [code]#rhs# scalar. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false# or either [code]#lhs# [code]#vec# or the [code]#rhs# SYCL [code]#vec# is a NaN.
+   a@ Construct a new instance of the SYCL [code]#vec# class template with the [code]#DataT# parameter of [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and the [code]#rhs# scalar. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false#.  The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=# operations result in [code]#false# if either the [code]#lhs# element or the [code]#rhs# is a NaN.  The [code]#!=# operation results in [code]#true# if either the [code]#lhs# element or the [code]#rhs# is a NaN.
 
 The [code]#DataT# template parameter of the constructed SYCL [code]#vec#, [code]#RET#, varies depending on the [code]#DataT# template parameter of this SYCL [code]#vec#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int8_t# or [code]#uint8_t# [code]#RET# must be [code]#int8_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int16_t#, [code]#uint16_t# or [code]#half# [code]#RET# must be [code]#int16_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int32_t#, [code]#uint32_t# or [code]#float# [code]#RET# must be [code]#int32_t#. For a SYCL [code]#vec# with [code]#DataT# of type [code]#int64_t#, [code]#uint64_t# or [code]#double# [code]#RET# must be [code]#uint64_t#.
 
@@ -16962,17 +16962,18 @@ a@
 ----
 vec<RET, NumElements> operatorOP(const DataT &lhs, const vec &rhs)
 ----
-   a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
-
-Construct a new instance of the SYCL [code]#vec# class template with
-the element type [code]#RET# with each element of the new SYCL
-[code]#vec# instance the result of an element-wise [code]#OP#
-relational operation between the [code]#lhs# scalar and each element
-of the [code]#rhs# SYCL [code]#vec#. Each element of the SYCL
-[code]#vec# that is returned must be [code]#-1# if the operation
-results in [code]#true# and [code]#0# if the operation results
-in [code]#false# or either this SYCL [code]#vec# or the
-[code]#rhs# SYCL [code]#vec# is a NaN.
+   a@ Construct a new instance of the SYCL [code]#vec# class template with
+      the element type [code]#RET# with each element of the new SYCL
+      [code]#vec# instance the result of an element-wise [code]#OP#
+      relational operation between the [code]#lhs# scalar and each element
+      of the [code]#rhs# SYCL [code]#vec#. Each element of the SYCL
+      [code]#vec# that is returned must be [code]#-1# if the operation
+      results in [code]#true# and [code]#0# if the operation results
+      in [code]#false#. The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+#
+      and [code]#>=# operations result in [code]#false# if either the
+      [code]#lhs# or the [code]#rhs# element is a NaN. The [code]#!=#
+      operation results in [code]#true# if either the [code]#lhs# or the
+      [code]#rhs# element is a NaN.
 
 The [code]#DataT# template parameter of the constructed SYCL
 [code]#vec#, [code]#RET#, varies depending on the [code]#DataT# template parameter of this SYCL [code]#vec#. For a SYCL
@@ -17542,9 +17543,13 @@ a@
 marray<bool, NumElements> operatorOP(const marray& lhs, const marray &rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
-      with each element of the new [code]#marray# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#marray#
+      with each element of the new [code]#marray# instance is the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#marray#
       and each element of the [code]#rhs# [code]#marray#.
-      Corresponding element of the [code]#marray# that is returned must be [code]#false# if the operation results is a NaN.
+      The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=#
+      operations result in [code]#false# if either the [code]#lhs# element or
+      the [code]#rhs# element is a NaN.  The [code]#!=# operation results in
+      [code]#true# if either the [code]#lhs# element or the [code]#rhs# element
+      is a NaN.
 
 Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
 
@@ -17556,7 +17561,11 @@ marray<bool, NumElements> operatorOP(const marray &lhs, const DataT &rhs)
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
       with each element of the new [code]#marray# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#marray#
       and the [code]#rhs# scalar.
-      Corresponding element of the [code]#marray# that is returned must be [code]#false# if the operation results is a NaN.
+      The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=#
+      operations result in [code]#false# if either the [code]#lhs# element or
+      the [code]#rhs# is a NaN.  The [code]#!=# operation results in
+      [code]#true# if either the [code]#lhs# element or the [code]#rhs# is a
+      NaN.
 
 Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
 
@@ -17627,12 +17636,15 @@ a@
 ----
 marray<bool, NumElements> operatorOP(const DataT &lhs, const marray &rhs)
 ----
-   a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
-
-Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
-with each element of the new SYCL [code]#marray# instance the result of an element-wise [code]#OP#
-relational operation between the [code]#lhs# scalar and each element of the [code]#rhs# [code]#marray#.
-Corresponding element of the [code]#marray# that is returned must be [code]#false# if the operation results is a NaN.
+   a@ Construct a new instance of the [code]#marray# class template with
+      [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
+      with each element of the new SYCL [code]#marray# instance the result of
+      an element-wise [code]#OP# relational operation between the [code]#lhs#
+      scalar and each element of the [code]#rhs# [code]#marray#.  The
+      [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=# operations
+      result in [code]#false# if either the [code]#lhs# or the [code]#rhs#
+      element is a NaN.  The [code]#!=# operation results in [code]#true# if
+      either the [code]#lhs# or the [code]#rhs# element is a NaN.
 
 Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
 


### PR DESCRIPTION
The `vec` and `marray` definitions of the `!=` operation were wrong
when one of the operands is NaN.  We previously said that this results
in `false`, but it should result in `true`.  This is in line with
IEEE 754 and with the OpenCL specification.  (The specification for all
the other relational operations was correct; they all result in `false`
when an operand is NaN.)

I also fixed an apparent typo.  The overloads for `vec` and `marray`
where the lhs is a scalar incorrectly said that they were *not*
available when `DataT` is a floating point type (for the `==`, `!=`,
etc. relational operations).  This, of course, makes no sense, so I
assume it was a copy/paste error.

Together with #234, this closes internal issue 600.