### PR TITLE
Fix "marray::operator!()"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17653,8 +17653,6 @@ marray<bool, NumElements> operator!(const marray &v)
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#v# [code]#marray#
       with each element of the new [code]#marray# instance the result of an element-wise logical [code]#!# operation on each element of [code]#v# [code]#marray#.
 
-The [code]#DataT# template parameter of the constructed SYCL [code]#marray#, [code]#RET#, varies depending on the [code]#DataT# template parameter of this SYCL [code]#marray#. For a SYCL [code]#marray# with [code]#DataT# of type [code]#int8_t# or [code]#uint8_t# [code]#RET# must be [code]#int8_t#. For a SYCL [code]#marray# with [code]#DataT# of type [code]#int16_t#, [code]#uint16_t# or [code]#half# [code]#RET# must be [code]#int16_t#. For a SYCL [code]#marray# with [code]#DataT# of type [code]#int32_t#, [code]#uint32_t# or [code]#float# [code]#RET# must be [code]#int32_t#. For a SYCL [code]#marray# with [code]#DataT# of type [code]#int64_t#, [code]#uint64_t# or [code]#double# [code]#RET# must be [code]#int64_t#.
-
 |====
 
 


### PR DESCRIPTION
Fix an apparent copy/paste error with the specification of
`marray::operator!()`.  It appears that someone copy / pasted this
paragraph from the `vec` specification, but this is incorrect for
`marray`.