### PR TITLE
Clarify that exceptions in host_task are forwarded to async handler

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14068,6 +14068,9 @@ The <<event>> returned by the submission of the associated <<command group>>
 enters the completed state (corresponding to a status of
 [code]#info::event_command_status::complete#) once the invocation of the
 provided {cpp} callable has returned.
+Any uncaught exception thrown during the execution of a <<host-task>> will be
+turned into an <<async-error>> that can be handled as described in
+<<subsubsec:exception.async>>.
 
 A <<host-task>> can optionally be used to interoperate with the
 <<native-backend-object,native backend objects>> associated with the <<queue>> executing the


### PR DESCRIPTION
I checked whether any of the descriptions for `wait` / `wait_and_throw` / `throw_asynchronous` or `exception_list` would need updating, but it does not seem so (although I find the description of the latter in section 4.13.2. to be worded somewhat strangely).

Fixes #214.