### PR TITLE
Add acquire-release to minimum atomic_fence order

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1422,7 +1422,7 @@ info::context::atomic_fence_order_capabilities
     @ [.code]#std::vector<memory_order>#
    a@ Returns the set of memory orderings supported by [code]#atomic_fence#
       on all devices in the context, which is guaranteed to include
-      [code]#relaxed#.
+      [code]#relaxed#, [code]#acquire#, [code]#release# and [code]#acq_rel#.
 
 The memory ordering of the context determines the behavior of fence operations applied
 to any memory that can be concurrently accessed by multiple devices in the context.
@@ -2248,7 +2248,8 @@ info::device::atomic_fence_order_capabilities
 
     @ [.code]#std::vector<memory_order>#
    a@ Returns the set of memory orderings supported by [code]#atomic_fence# on the device,
-      which is guaranteed to include [code]#relaxed#.
+      which is guaranteed to include [code]#relaxed#, [code]#acquire#,
+      [code]#release# and [code]#acq_rel#.
 
 a@
 [source]


### PR DESCRIPTION
Prior to this commit, devices were only required to support relaxed
atomic fences that do nothing.

Requiring all devices to support acquire-release memory ordering is
consistent with SYCL's description of sycl::group_barrier and with
OpenCL 3.0's CL_DEVICE_ATOMIC_FENCE_CAPABILITIES query, which at minimum
returns:

CL_DEVICE_ATOMIC_ORDER_RELAXED |
CL_DEVICE_ATOMIC_ORDER_ACQ_REL |
CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP

Closes internal issue 593.