### PR TITLE
Add missing prototype for get_sub_group()

### DIFF
--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -23,6 +23,8 @@ public:
 
   group<Dimensions> get_group() const;
 
+  sub_group get_sub_group() const;
+
   size_t get_group(int dimension) const;
 
   size_t get_group_linear_id() const;


### PR DESCRIPTION
The synopsis for `nd_item` was mistakenly missing the declaration for
`get_sub_group()`.  There was already a description for this function
in the table of `nd_item` member functions; it was only missing from
the synopsis.