### PR TITLE
Remove confusing paragraph about events

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12840,16 +12840,6 @@ where buffers (<<subsec:buffers>>) and accessor (<<subsec:accessors>>) classes
 are described.  The overall memory model of the SYCL application is described in
 <<sub.section.memmodel.app>>.
 
-It is possible to obtain events for the start of the <<command-group-function-object>>,
-the kernel starting, and the command group completing.
-These events are useful for
-profiling and synchronization of kernels.
-When using buffers, safe synchronization in SYCL requires synchronization on
-buffer availability, not on kernel completion. This is because
-the memory that data is stored in upon kernel
-completion is not rigidly specified. The events are provided at the submission of the
-<<command-group-function-object>> to the queue to be executed on.
-
 It is possible for a <<command-group-function-object>> to fail to enqueue to a queue,
 or for it to fail to execute correctly. A user can therefore supply a secondary
 queue when submitting a command group to the primary queue. If the <<sycl-runtime>>


### PR DESCRIPTION
Remove this paragraph about obtaining an event for a command group.
It's not clear what this paragraph is trying to communicate, and some
of the information is wrong.  For example, you cannot get an event that
represents "start of the command group function object" or for the
"kernel starting".  You can only get a single event that represents the
command group as a whole.  You can get profiling information that tells
when these things happen, but you cannot get an event.

Section 4.6.6 "Event class" already describes events and the profiling
information they provide.  Section 3.7.1.2 "SYCL command groups and
execution order" already describes the execution model of command
groups and their relationship to the buffers they use.  Therefore,
there is no new information being presented in this paragraph.

Together with #242 close internal issue 424.