### PR TITLE
Remove const from operator[] in reducer

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12723,7 +12723,7 @@ reducer& combine(const T& partial)
 a@
 [source]
 ----
-__unspecified__ &operator[](size_t index) const
+__unspecified__ &operator[](size_t index)
 ----
    a@ Available only when: [code]#Dimensions > 0#.
       Returns an instance of an undefined intermediate type representing

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -21,7 +21,7 @@ public:
   reducer& combine(const T& partial);
 
   /* Only available if Dimensions > 0 */
-  __unspecified__ &operator[](size_t index) const;
+  __unspecified__ &operator[](size_t index);
 
   /* Only available if identity value is known */
   T identity() const;


### PR DESCRIPTION
Prior to this commit, the subscript operator of reducer was marked
const due to a copy-paste error from the definition in accessor.

Marking this operator const prevents the reducers associated with
sycl::span reductions from storing data directly, forcing them to
be implemented as an accessor-like view. This is inconsistent with
the requirements of other (scalar) reductions; the definitions of
combine() and other shorthand operators (e.g. ++) aren't marked const.