### PR TITLE
Fix bugs in USM API signatures

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10065,10 +10065,10 @@ public:
                 const property_list &propList = {}) noexcept;
   usm_allocator(const queue &q,
                 const property_list &propList = {}) noexcept;
-  usm_allocator(const usm_allocator &other) noexcept = default;
-  usm_allocator(usm_allocator &&) noexcept = default;
-  usm_allocator &operator=(const usm_allocator &) = delete;
-  usm_allocator &operator=(usm_allocator &&) = default;
+  usm_allocator(const usm_allocator &other) noexcept;
+  usm_allocator(usm_allocator &&) noexcept;
+  usm_allocator &operator=(const usm_allocator &);
+  usm_allocator &operator=(usm_allocator &&);
 
 
   template <class U>
@@ -10750,7 +10750,7 @@ via an instance of [code]#property_list#.
 a@
 [source]
 ----
-void sycl::free(void* ptr, sycl::context& syclContext)
+void sycl::free(void* ptr, const context& syclContext)
 ----
 a@ Frees an allocation.  The memory pointed to by [code]#ptr# must have been
 allocated using one of the USM allocation routines.  [code]#syclContext# must
@@ -10762,7 +10762,7 @@ are enqueued the behavior is undefined.
 a@
 [source]
 ----
-void sycl::free(void* ptr, sycl::queue& syclQueue)
+void sycl::free(void* ptr, const queue& syclQueue)
 ----
 a@ Alternate form where [code]#syclQueue# provides the [code]#context#.
 


### PR DESCRIPTION
Fix three bugs in the API signatures for USM:

* There is no reason to require the implementation of `usm_allocator`
  to use `default` versions of the copy / move constructors and
  assignment operators.  The only reason we might require this is to
  make `usm_allocator` a trivially copyable type.  However, it can not
  be trivially copyable because all implementations need to store a
  `context` object, which is not trivially copyable.

* The `usm_allocator` copy assignment operator should not be declared
  `delete`.  I think this was just a typo.

* The `context` and `queue` parameters to `sycl::free()` should be
  "const reference" instead of "reference".  This makes them consistent
  with all the other USM APIs that take `context` or `queue` parameters.