### PR TITLE
Clarify behavior of queue destructor

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2922,6 +2922,14 @@ Each constructor takes as the last
 parameter an optional SYCL [code]#property_list# to provide properties to
 the SYCL [code]#queue#.
 
+A SYCL [code]#queue# may be destroyed even when there are uncompleted
+<<command, commands>> that have been submitted to the queue.  Doing so does not
+block.  Instead, any commands that have been submitted to the queue begin
+execution when their requisites are satisfied, just as they would had the queue
+not been destroyed.  Any event objects for those commands are signaled in the
+normal manner when the command completes.  Resources associated with the queue
+will be freed by the time the last command completes.
+
 The SYCL [code]#queue# class provides the common reference semantics
 (see <<sec:reference-semantics>>).
 


### PR DESCRIPTION
The spec already said that the `queue` destructor does not block in
section 3.9.8.1 "Synchronization in the SYCL application":

> Note that the destructors of other SYCL objects (sycl::queue,
> sycl::context,...) do not block.

However, we never really said what happens to outstanding commands
that have been submitted to the queue.  This PR clarifies that these
commands just run normally, with the same behavior as though the
queue had not been destroyed.

This seems like a sensible behavior, and it also enables a use case
similar to `std::thread::detach`.