### PR TITLE
Clarify wording for "device selector" in the Glossary

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -178,7 +178,7 @@ object. For the full description please refer to <<subsec:buffers>>.
 [[device-selector]]device selector::
     A way to select a device used in various places. This is a callable
     object taking a <<device>> reference and returning an integer rank.
-    One of the device with the highest positive value is selected. See
+    One of the device with the highest non-negative value is selected. See
     <<sec:device-selector>> for more details.
 
 [[event]]event::


### PR DESCRIPTION
[4.6.1.1] states

   If the highest value is negative no device is selected.

As such, be more precise about the behavior for "0" 
in the glossary wording.