### PR TITLE
Fix name of error code

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13777,7 +13777,7 @@ into the memory object accessed by [code]#dest#.  The size of the [code]#src#
 accessor determines the number of bytes that are copied, and [code]#dest# must
 have at least this many bytes.  If the size of [code]#dest# is too small, the
 implementation throws a synchronous [code]#exception# with the
-[code]#errc::invalid_object# error code.
+[code]#errc::invalid# error code.
 
 a@
 [source]


### PR DESCRIPTION
There is no error code named `invalid_object`.  This got renamed a
while ago, and we must have missed this one.