### PR TITLE
Xilinx is now part of AMD

### DIFF
--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -5,14 +5,18 @@
 
   * Maria Rovatsou, Codeplay
   * Lee Howes, Qualcomm
-  * Ronan Keryell, Xilinx (current)
+  * Ronan Keryell, AMD (current)
 
 *Contributors*
 
   * Eric Berdahl, Adobe
   * Shivani Gupta, Adobe
   * David Neto, Altera
+  * Andrew Gozillon, AMD
+  * Gauthier Harnisch, AMD
+  * Ronan Keryell, AMD
   * Brian Sumner, AMD
+  * Lin-Ya Yu, AMD
   * Thomas Applencourt, Argonne National Laboratory
   * Hal Finkel, Argonne National Laboratory
   * Kevin Harms, Argonne National Laboratory
@@ -71,10 +75,6 @@
   * Peter Thoman, University of Innsbruck
   * Biagio Cosenza, University of Salerno
   * Paul Preney, University of Windsor
-  * Andrew Gozillon, Xilinx
-  * Gauthier Harnisch, Xilinx
-  * Ronan Keryell, Xilinx
-  * Lin-Ya Yu, Xilinx
 
 // Jon: in other specs we credit Khronos staff who have helped.
 // Ronan: indeed! Just reading this while actually adding the... Khronos


### PR DESCRIPTION
Move Xilinx contributors into the AMD part.