### PR TITLE
Stable order of platform and device objects

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -416,6 +416,10 @@ object. For the full description please refer to <<subsec:buffers>>.
     non-associative or non-commutative, the behavior of a reduction may be
     non-deterministic.
 
+[[root-device]]root device::
+    A device that is not a sub-device.  The function
+    [code]#device::get_devices()# returns a vector of all the root devices.
+
 [[rule-of-five]]rule of five::
     For a given class, if at least one of the copy constructor, move
     constructor, copy assignment operator, move assignment operator or

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1025,10 +1025,12 @@ errors are handled by throwing synchronous SYCL exceptions.
 
 The execution environment for a SYCL application has a fixed number of
 platforms which does not vary as the application executes.  The application
-can get a list of all these platforms via [code]#platform::get_platforms()#.
-The [code]#platform# class also provides constructors, but constructing a new
-[code]#platform# instance merely creates a new object that is a copy of one
-of the objects returned by [code]#platform::get_platforms()#.
+can get a list of all these platforms via [code]#platform::get_platforms()#,
+and the order of the platform objects is the same each time the application
+calls that function.  The [code]#platform# class also provides constructors,
+but constructing a new [code]#platform# instance merely creates a new object
+that is a copy of one of the objects returned by
+[code]#platform::get_platforms()#.
 
 The SYCL [code]#platform# class provides the common reference semantics
 (see <<sec:reference-semantics>>).
@@ -1143,9 +1145,9 @@ std::vector<device> get_devices(
     info::device_type deviceType =
     info::device_type::all) const
 ----
-   a@ Returns a [code]#std::vector# containing all SYCL
-      [code]#devices# associated with this SYCL [code]#platform#
-      which have the device type encapsulated by [code]#deviceType#.
+   a@ Returns a [code]#std::vector# containing all the root devices associated
+      with this SYCL [code]#platform# which have the device type encapsulated
+      by [code]#deviceType#.
 
 |====
 
@@ -1471,12 +1473,14 @@ which <<kernel,kernels>> can be executed.
 All member functions of the [code]#device# class are synchronous and
 errors are handled by throwing synchronous SYCL exceptions.
 
-The execution environment for a SYCL application has a fixed number of
-devices which does not vary as the application executes.  The application
-can get a list of all these devices via [code]#device::get_devices()#.  The
-[code]#device# class also provides constructors, but constructing a new
-[code]#device# instance merely creates a new object that is a copy of one
-of the objects returned by [code]#device::get_devices()#.
+The execution environment for a SYCL application has a fixed number of root
+devices which does not vary as the application executes.  The application can
+get a list of all these devices via [code]#device::get_devices()#, and the
+order of the device objects is the same each time the application calls that
+function (assuming the parameter to that function is the same for each call).
+The [code]#device# class also provides constructors, but constructing a new
+[code]#device# instance merely creates a new object that is a copy of one of
+the objects returned by [code]#device::get_devices()#.
 
 A SYCL [code]#device# can be partitioned into multiple SYCL devices, by
 calling the [code]#create_sub_devices()# member function template. The
@@ -1732,8 +1736,8 @@ a@
 static std::vector<device> get_devices(
     info::device_type deviceType = info::device_type::all)
 ----
-   a@ Returns a [code]#std::vector# containing all SYCL
-      [code]#devices# from all <<backend, SYCL backends>> available in the
+   a@ Returns a [code]#std::vector# containing all the root devices
+      from all <<backend, SYCL backends>> available in the
       system which have the device type encapsulated by [code]#deviceType#.
 
 |====

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1145,9 +1145,9 @@ std::vector<device> get_devices(
     info::device_type deviceType =
     info::device_type::all) const
 ----
-   a@ Returns a [code]#std::vector# containing all the root devices associated
-      with this SYCL [code]#platform# which have the device type encapsulated
-      by [code]#deviceType#.
+   a@ Returns a [code]#std::vector# containing all the
+      <<root-device, root devices>> associated with this SYCL [code]#platform#
+      which have the device type encapsulated by [code]#deviceType#.
 
 |====
 
@@ -1473,14 +1473,15 @@ which <<kernel,kernels>> can be executed.
 All member functions of the [code]#device# class are synchronous and
 errors are handled by throwing synchronous SYCL exceptions.
 
-The execution environment for a SYCL application has a fixed number of root
-devices which does not vary as the application executes.  The application can
-get a list of all these devices via [code]#device::get_devices()#, and the
-order of the device objects is the same each time the application calls that
-function (assuming the parameter to that function is the same for each call).
-The [code]#device# class also provides constructors, but constructing a new
-[code]#device# instance merely creates a new object that is a copy of one of
-the objects returned by [code]#device::get_devices()#.
+The execution environment for a SYCL application has a fixed number of
+<<root-device, root devices>> which does not vary as the application executes.
+The application can get a list of all these devices via
+[code]#device::get_devices()#, and the order of the device objects is the same
+each time the application calls that function (assuming the parameter to that
+function is the same for each call).  The [code]#device# class also provides
+constructors, but constructing a new [code]#device# instance merely creates a
+new object that is a copy of one of the objects returned by
+[code]#device::get_devices()#.
 
 A SYCL [code]#device# can be partitioned into multiple SYCL devices, by
 calling the [code]#create_sub_devices()# member function template. The
@@ -1736,9 +1737,10 @@ a@
 static std::vector<device> get_devices(
     info::device_type deviceType = info::device_type::all)
 ----
-   a@ Returns a [code]#std::vector# containing all the root devices
-      from all <<backend, SYCL backends>> available in the
-      system which have the device type encapsulated by [code]#deviceType#.
+   a@ Returns a [code]#std::vector# containing all the
+      <<root-device, root devices>> from all <<backend, SYCL backends>>
+      available in the system which have the device type encapsulated by
+      [code]#deviceType#.
 
 |====
 


### PR DESCRIPTION
Clarify that the order of the `platform` and `device` objects is the
same each time `get_platforms()` or `get_devices()` is called.  This
allows an application to store the index of a platform or device and
use that index later to identify the same platform or device.

Also clarify that the `get_devices()` function returns only the root
devices, not any sub-devices that have been created.

Closes internal issue 603.