### PR TITLE
some math definition corrections/clarifications

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20898,7 +20898,7 @@ a@
 ----
 genint ilogb (genfloat x)
 ----
-   a@ Compute the integral part of logr (latexmath:[|x|]) and return the result as an integer, where r is the value returned by std::numeric_limits<genfloat>::radix.
+   a@ Compute the integral part of logr (latexmath:[|x|]) and return the result as an integer, where r is the value returned by [code]#std::numeric_limits<genfloat>::radix#.
 
 a@
 [source]
@@ -20960,7 +20960,7 @@ a@
 ----
 genfloat logb (genfloat x)
 ----
-   a@ Compute the integral part of logr (latexmath:[|x|]), where r is the value returned by std::numeric_limits<genfloat>::radix.
+   a@ Compute the integral part of logr (latexmath:[|x|]), where r is the value returned by [code]#std::numeric_limits<genfloat>::radix#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20865,7 +20865,7 @@ a@
 ----
 genfloat fmod (genfloat x, genfloat y)
 ----
-   a@ Modulus. Returns latexmath:[x \bmod y].
+   a@ Modulus. Returns latexmath:[x - y \cdot \mathrm{trunc}(x/y)].
 
 a@
 [source]
@@ -20898,7 +20898,7 @@ a@
 ----
 genint ilogb (genfloat x)
 ----
-   a@ Compute the integral part of the logarithm of latexmath:[x]. The base of the logarithm is the radix (integer base) used by the representation of floating point numbers.
+   a@ Compute the integral part of logr (latexmath:[|x|]) and return the result as an integer, where r is the value returned by std::numeric_limits<genfloat>::radix.
 
 a@
 [source]
@@ -20960,7 +20960,7 @@ a@
 ----
 genfloat logb (genfloat x)
 ----
-   a@ Compute the integral part of the logarithm of latexmath:[|x|]. The base of the logarithm is the radix (integer base) used by the representation of floating point numbers.
+   a@ Compute the integral part of logr (latexmath:[|x|]), where r is the value returned by std::numeric_limits<genfloat>::radix.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20865,7 +20865,7 @@ a@
 ----
 genfloat fmod (genfloat x, genfloat y)
 ----
-   a@ Modulus. Returns latexmath:[x \bmod y \cdot \mathrm{trunc}(x/y)].
+   a@ Modulus. Returns latexmath:[x \bmod y].
 
 a@
 [source]
@@ -20898,7 +20898,7 @@ a@
 ----
 genint ilogb (genfloat x)
 ----
-   a@ Return the exponent as an integer value.
+   a@ Compute the integral part of the logarithm of latexmath:[x]. The base of the logarithm is the radix (integer base) used by the representation of floating point numbers.
 
 a@
 [source]
@@ -20960,8 +20960,7 @@ a@
 ----
 genfloat logb (genfloat x)
 ----
-   a@ Compute the exponent of x, which is the integral
-      part of logr (latexmath:[|x|]).
+   a@ Compute the integral part of the logarithm of latexmath:[|x|]. The base of the logarithm is the radix (integer base) used by the representation of floating point numbers.
 
 a@
 [source]


### PR DESCRIPTION
logb / ilogb had incorrect/unclear definitions: The "exponent of x" is clearly not "the integral
      part of logr (latexmath:[|x|])": we can't find an exponent of x from a function of x, the exponent `n` of `x` needs to be defined, i.e. `x^n`.

For fmod I am still confused and would appreciate any clarification anyone has: If we are multiplying `x mod y` by `trunc (x/y)` then why is the function called fmod? DPC++ implementation of fmod is just doing `x mod y`. So which is wrong, definition or implementation?

**Further Note:** atan2pi is also not rendering correctly in the spec PDF, although the latex looks fine so I'm unsure why this is or how to fix it.



Signed-off-by: JackAKirk <jack.kirk@codeplay.com>