### PR TITLE
Clarify get_pointer_{type,device}

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10914,20 +10914,25 @@ a@
 usm::alloc get_pointer_type(const void *ptr,
                             const context &ctxt)
 ----
-a@ Returns the USM allocation type for [code]#ptr# if [code]#ptr#
-falls inside a valid USM allocation.  Returns [code]#usm::alloc::unknown# if
-[code]#ptr# is not a valid USM allocation.
+a@ Returns the USM allocation type for [code]#ptr# if [code]#ptr# falls inside
+a valid USM allocation for the context [code]#syclContext#.  Returns
+[code]#usm::alloc::unknown# if [code]#ptr# does not point within a valid USM
+allocation from [code]#syclContext#.
 
 a@
 [source]
 ----
-sycl::device get_pointer_device(const void *ptr,
-                                const context &ctxt)
+device get_pointer_device(const void *ptr,
+                          const context &ctxt)
 ----
-a@  Returns the [code]#device# associated with the USM allocation.  If
-[code]#ptr# is an allocation of type [code]#usm::alloc::host#, returns the
-first device in [code]#ctxt#. Throws an error if [code]#ptr# is not a valid
-USM allocation.
+a@ Returns the [code]#device# associated with the USM allocation.  If
+[code]#ptr# points within a USM device or shared allocation for the context
+[code]#syclContext#, returns the same device that was passed when allocating
+the memory.  If [code]#ptr# points within a USM host allocation for the context
+[code]#syclContext#, returns the first device in [code]#syclContext#.  Throws a
+synchronous [code]#exception# with the [code]#errc::invalid# error code if
+[code]#ptr# does not point within a valid USM allocation from
+[code]#syclContext#.
 
 |====
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10912,7 +10912,7 @@ a@
 [source]
 ----
 usm::alloc get_pointer_type(const void *ptr,
-                            const context &ctxt)
+                            const context &syclContext)
 ----
 a@ Returns the USM allocation type for [code]#ptr# if [code]#ptr# falls inside
 a valid USM allocation for the context [code]#syclContext#.  Returns
@@ -10923,7 +10923,7 @@ a@
 [source]
 ----
 device get_pointer_device(const void *ptr,
-                          const context &ctxt)
+                          const context &syclContext)
 ----
 a@ Returns the [code]#device# associated with the USM allocation.  If
 [code]#ptr# points within a USM device or shared allocation for the context


### PR DESCRIPTION
Clarify several things about the USM query functions `get_pointer_type`
and `get_pointer_device`:

* The return value of `get_pointer_device` is the same `device` that
  was used to allocate the USM memory (for "device" and "shared"
  allocations).  Some readers were previously confused about the
  behavior when the allocation was made against a sub-device.

* For `get_pointer_device`, the pointer need not be at the start of the
  USM memory region.  It can be any pointer within the USM memory
  region.  We said this already for `get_pointer_type`, but this
  wording was missing from `get_pointer_device`.

* For both queries, the USM memory region must correspond to the
  `context` that is passed.  We didn't say this before, but it was
  clearly our intent.  Otherwise, there would be no need for these
  functions to take a `context` parameter.

Closes internal issue 599.