### PR TITLE
Disallow declaring anything in sycl:: namespace or sub-namespaces

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -105,6 +105,12 @@ where [code]#<backend_name># is the name of the <<backend>> as defined in the
 namespaces for any extensions that a vendor may provide, including any
 <<backend>> that the vendor may define outside of the Khronos SYCL group.
 
+An end-user should not declare anything in the [code]#::sycl#
+namespace or its nested namespaces, except if allowed for specific
+cases by the specification itself (like customization points in some
+extensions for example).
+
+
 == Class availability
 
 In SYCL some <<sycl-runtime>> classes are available to the SYCL application,

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -105,10 +105,9 @@ where [code]#<backend_name># is the name of the <<backend>> as defined in the
 namespaces for any extensions that a vendor may provide, including any
 <<backend>> that the vendor may define outside of the Khronos SYCL group.
 
-An end-user should not declare anything in the [code]#::sycl#
-namespace or its nested namespaces, except if allowed for specific
-cases by the specification itself (like customization points in some
-extensions for example).
+Unless otherwise specified, the behavior of a SYCL program is undefined
+if it adds any entity to namespace [code]#sycl# or to a
+namespace within namespace [code]#sycl#.
 
 
 == Class availability


### PR DESCRIPTION
This clarifies https://github.com/KhronosGroup/SYCL-Docs/issues/97