### PR TITLE
Normalize position of & and * in the source code parts of the specification

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -1
+BreakInheritanceList: BeforeComma
+BreakConstructorInitializers: BeforeComma
+Cpp11BracedListStyle: false
+PointerAlignment: Left
+SpaceBeforeCpp11BracedList: true

--- a/adoc/chapters/extensions.adoc
+++ b/adoc/chapters/extensions.adoc
@@ -113,7 +113,7 @@ constructor overload for an existing SYCL class.  In cases like this, the
 extension should ensure that one of the function parameters has a type that is
 defined in the extension's namespace.  For example, the Acme vendor could add
 a new constructor for [code]#sycl::context# with the signature
-[code]#context(ext::acme::frobber &)#.
+[code]#context(ext::acme::frobber&)#.
 
 A similar situation can occur if an existing SYCL template is specialized with
 an extended enumerated value.

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -483,16 +483,16 @@ a@
 [source]
 ----
 context make_context(
-    const cl_context &clContext,
-    const async_handler &asyncHandler = {})
+    const cl_context& clContext,
+    const async_handler& asyncHandler = {})
 ----
    a@ Constructs a SYCL [code]#context# instance from an OpenCL [code]#cl_context# in accordance with the requirements described in <<sec:backend-interoperability>>.
 a@
 [source]
 ----
 event make_event(
-    const std::vector<cl_event> &clEvents,
-    const context &syclContext)
+    const std::vector<cl_event>& clEvents,
+    const context& syclContext)
 ----
    a@ Constructs a SYCL [code]#event# instance from a vector of OpenCL
       [code]#cl_event# objects in accordance with the requirements described in
@@ -501,23 +501,23 @@ a@
 [source]
 ----
 device make_device(
-    const cl_device_id &clDeviceId)
+    const cl_device_id& clDeviceId)
 ----
    a@ Constructs a SYCL [code]#device# instance from an OpenCL [code]#cl_device_id# in accordance with the requirements described in <<sec:backend-interoperability>>.
 a@
 [source]
 ----
 platform make_platform(
-    const cl_platform_id &clPlatformId)
+    const cl_platform_id& clPlatformId)
 ----
    a@ Constructs a SYCL [code]#platform# instance from an OpenCL [code]#cl_platform_id# in accordance with the requirements described in <<sec:backend-interoperability>>.
 a@
 [source]
 ----
 queue make_queue(
-    const cl_command_queue &clQueue,
-    const context &syclContext,
-    const async_handler &asyncHandler = {})
+    const cl_command_queue& clQueue,
+    const context& syclContext,
+    const async_handler& asyncHandler = {})
 ----
    a@ Constructs a SYCL [code]#queue# instance with an optional
       [code]#async_handler# from an OpenCL [code]#cl_command_queue#
@@ -529,8 +529,8 @@ a@
 template <typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 buffer<T, Dimensions, AllocatorT> make_buffer(
-    const cl_mem &clMemObject,
-    const context &syclContext,
+    const cl_mem& clMemObject,
+    const context& syclContext,
     event availableEvent)
 ----
    a@ Available only when: [code]#Dimensions == 1#.
@@ -545,8 +545,8 @@ a@
 template <typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 buffer<T, Dimensions, AllocatorT> make_buffer(
-    const cl_mem &clMemObject,
-    const context &syclContext)
+    const cl_mem& clMemObject,
+    const context& syclContext)
 ----
    a@ Available only when: [code]#Dimensions == 1#.
 
@@ -558,8 +558,8 @@ a@
 template <int Dimensions = 1,
           typename AllocatorT = image_allocator>
 sampled_image<Dimensions, AllocatorT> make_sampled_image(
-    const cl_mem &clMemObject,
-    const context &syclContext,
+    const cl_mem& clMemObject,
+    const context& syclContext,
     image_sampler syclImageSampler,
     event availableEvent)
 ----
@@ -573,8 +573,8 @@ a@
 template <int Dimensions = 1,
           typename AllocatorT = image_allocator>
 sampled_image<Dimensions, AllocatorT> make_sampled_image(
-    const cl_mem &clMemObject,
-    const context &syclContext,
+    const cl_mem& clMemObject,
+    const context& syclContext,
     image_sampler syclImageSampler)
 ----
    a@ Constructs a SYCL [code]#sampled_image# instance from an OpenCL [code]#cl_mem# in accordance with the requirements described in <<sec:backend-interoperability>>.
@@ -586,8 +586,8 @@ a@
 template <int Dimensions = 1,
           typename AllocatorT = image_allocator>
 unsampled_image<Dimensions, AllocatorT> make_unsampled_image(
-    const cl_mem &clMemObject,
-    const context &syclContext,
+    const cl_mem& clMemObject,
+    const context& syclContext,
     event availableEvent)
 ----
    a@ Constructs a SYCL [code]#unsampled_image# instance from an OpenCL [code]#cl_mem# in accordance with the requirements described in <<sec:backend-interoperability>>.
@@ -600,15 +600,15 @@ a@
 template <int Dimensions = 1,
           typename AllocatorT = image_allocator>
 unsampled_image<Dimensions, AllocatorT> make_unsampled_image(
-    const cl_mem &clMemObject,
-    const context &syclContext)
+    const cl_mem& clMemObject,
+    const context& syclContext)
 ----
    a@ Constructs a SYCL [code]#unsampled_image# instance from an OpenCL [code]#cl_mem# in accordance with the requirements described in <<sec:backend-interoperability>>.
 a@
 [source]
 ----
-kernel make_kernel(const cl_kernel &clKernel,
-                   const context &syclContext);
+kernel make_kernel(const cl_kernel& clKernel,
+                   const context& syclContext);
 ----
    a@ Constructs a SYCL [code]#kernel# instance from an OpenCL kernel object.
 a@
@@ -616,7 +616,7 @@ a@
 ----
 template <bundle_state State>
 kernel_bundle<State> make_kernel_bundle(
-    const cl_program &clProgram,
+    const cl_program& clProgram,
     const context& syclContext)
 ----
    a@ Constructs a SYCL [code]#kernel_bundle# instance from an OpenCL
@@ -663,8 +663,8 @@ a@
 [source]
 ----
 bool has_extension(
-    const sycl::platform &syclPlatform,
-    const std::string &extension)
+    const sycl::platform& syclPlatform,
+    const std::string& extension)
 ----
    a@ Returns true if the OpenCL platform associated with [code]#syclPlatform#
    supports the extension identified by [code]#extension#, otherwise it returns
@@ -675,8 +675,8 @@ a@
 [source]
 ----
 bool has_extension(
-    const sycl::device &syclDevice,
-    const std::string &extension)
+    const sycl::device& syclDevice,
+    const std::string& extension)
 ----
    a@ Returns true if the OpenCL device associated with [code]#syclDevice#
    supports the extension identified by [code]#extension#, otherwise it returns
@@ -755,9 +755,9 @@ include::{header_dir}/openclBackend/createBundle.h[lines=4..-1]
 [source,,linenums]
 ----
 template <bundle_state State>
-kernel_bundle<State> create_bundle(const context &ctxt,
-                                   const std::vector<device> &devs,
-                                   const std::vector<cl_program> &clPrograms)
+kernel_bundle<State> create_bundle(const context& ctxt,
+                                   const std::vector<device>& devs,
+                                   const std::vector<cl_program>& clPrograms)
 ----
   . _Preconditions:_ The <<context>> specified by [code]#ctxt#
     must be associated with the OpenCL <<backend>>.
@@ -782,8 +782,8 @@ by invoking the OpenCL APIs.
 [source,,linenums]
 ----
 kernel_bundle<bundle_state::executable>
-create_bundle(const context &ctxt, const std::vector<device> &devs,
-              const std::vector<cl_kernel> &clKernels)
+create_bundle(const context& ctxt, const std::vector<device>& devs,
+              const std::vector<cl_kernel>& clKernels)
 ----
   . _Preconditions:_ The <<context>> specified by [code]#ctxt#
     must be associated with the OpenCL <<backend>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -416,7 +416,7 @@ include::{header_dir}/common-reference.h[lines=4..-1]
 a@
 [source]
 ----
-T(const T &rhs)
+T(const T& rhs)
 ----
    a@ Constructs a [code]#T# instance as a copy of the RHS SYCL
       [code]#T# in accordance with the requirements set out above.
@@ -424,7 +424,7 @@ T(const T &rhs)
 a@
 [source]
 ----
-T(T &&rhs)
+T(T&& rhs)
 ----
    a@ Constructs a SYCL [code]#T# instance as a move of the RHS SYCL
       [code]#T# in accordance with the requirements set out above.
@@ -432,7 +432,7 @@ T(T &&rhs)
 a@
 [source]
 ----
-T &operator=(const T &rhs)
+T& operator=(const T& rhs)
 ----
    a@ Assigns this SYCL [code]#T# instance with a copy of the RHS SYCL
       [code]#T# in accordance with the requirements set out above.
@@ -440,7 +440,7 @@ T &operator=(const T &rhs)
 a@
 [source]
 ----
-T &operator=(T &&rhs)
+T& operator=(T&& rhs)
 ----
    a@ Assigns this SYCL [code]#T# instance with a move of the RHS SYCL
       [code]#T# in accordance with the requirements set out above.
@@ -470,7 +470,7 @@ a@
 a@
 [source]
 ----
-bool operator==(const T &lhs, const T &rhs)
+bool operator==(const T& lhs, const T& rhs)
 ----
    a@ Returns true if this LHS SYCL [code]#T# is equal to the RHS SYCL
       [code]#T# in accordance with the requirements set out above,
@@ -479,7 +479,7 @@ bool operator==(const T &lhs, const T &rhs)
 a@
 [source]
 ----
-bool operator!=(const T &lhs, const T &rhs)
+bool operator!=(const T& lhs, const T& rhs)
 ----
    a@ Returns true if this LHS SYCL [code]#T# is not equal to the RHS
       SYCL [code]#T# in accordance with the requirements set out above,
@@ -546,28 +546,28 @@ include::{header_dir}/common-byval.h[lines=4..-1]
 a@
 [source]
 ----
-T(const T &rhs);
+T(const T& rhs);
 ----
    a@ Copy constructor.
 
 a@
 [source]
 ----
-T(T &&rhs);
+T(T&& rhs);
 ----
    a@ Move constructor.
 
 a@
 [source]
 ----
-T &operator=(const T &rhs);
+T& operator=(const T& rhs);
 ----
    a@ Copy assignment operator.
 
 a@
 [source]
 ----
-T &operator=(T &&rhs);
+T& operator=(T&& rhs);
 ----
    a@ Move assignment operator.
 
@@ -588,14 +588,14 @@ a@
 a@
 [source]
 ----
-bool operator==(const T &lhs, const T &rhs)
+bool operator==(const T& lhs, const T& rhs)
 ----
    a@ Returns true if this LHS SYCL [code]#T# is equal to the RHS SYCL [code]#T# in accordance with the requirements set out above, otherwise returns false.
 
 a@
 [source]
 ----
-bool operator!=(const T &lhs, const T &rhs)
+bool operator!=(const T& lhs, const T& rhs)
 ----
    a@ Returns true if this LHS SYCL [code]#T# is not equal to the RHS SYCL [code]#T# in accordance with the requirements set out above, otherwise returns false.
 
@@ -886,8 +886,8 @@ a@
 [source]
 ----
 __unspecified_callable__ aspect_selector(
-   const std::vector<aspect> &aspectList,
-   const std::vector<aspect> &denyList = {});
+   const std::vector<aspect>& aspectList,
+   const std::vector<aspect>& denyList = {});
 
 template <typename... AspectList>
 __unspecified_callable__ aspect_selector(AspectList... aspectList);
@@ -939,7 +939,7 @@ sycl::device my_gpu { sycl::gpu_selector_v };
 
 sycl::queue my_accelerator { sycl::accelerator_selector_v };
 
-int prefer_my_vendor(const sycl::device & d) {
+int prefer_my_vendor(const sycl::device& d) {
   // Return 1 if the vendor name is "MyVendor" or 0 else.
   // 0 does not prevent another device to be picked as a second choice
   return d.get_info<info::device::vendor>() == "MyVendor";
@@ -952,7 +952,7 @@ sycl::device preferred_device { prefer_my_vendor };
 sycl::queue half_precision_controller {
   // Can use a lambda as a device ranking function.
   // Returns a negative number to fail in the case there is no such device
-  [] (auto &d) { return d.has(sycl::aspect::fp16) ? 1 : -1; }
+  [] (auto& d) { return d.has(sycl::aspect::fp16) ? 1 : -1; }
 };
 
 // To ease porting SYCL 1.2.1 code, there are types whose
@@ -1073,7 +1073,7 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-    explicit platform(const DeviceSelector &)
+    explicit platform(const DeviceSelector&)
 ----
    a@ Constructs a SYCL [code]#platform# instance that is a copy of the
       [code]#platform# which contains the device returned by the
@@ -1132,7 +1132,7 @@ bool has(aspect asp) const
 a@
 [source]
 ----
-bool has_extension(const std::string & extension) const
+bool has_extension(const std::string& extension) const
 ----
    a@ Deprecated, use [code]#has()# instead.
 
@@ -1297,7 +1297,7 @@ explicit context(async_handler asyncHandler = {})
 a@
 [source]
 ----
-explicit context(const device &dev,
+explicit context(const device& dev,
     async_handler asyncHandler = {})
 ----
    a@ Constructs a SYCL [code]#context# instance using the [code]#dev# parameter as the associated SYCL [code]#device# and the SYCL [code]#platform# associated with the [code]#dev# parameter as the associated SYCL [code]#platform#. The constructed SYCL [code]#context# will use the [code]#asyncHandler# parameter to handle exceptions.
@@ -1305,7 +1305,7 @@ explicit context(const device &dev,
 a@
 [source]
 ----
-explicit context(const std::vector<device> & deviceList,
+explicit context(const std::vector<device>& deviceList,
     async_handler asyncHandler = {})
 ----
    a@ Constructs a SYCL [code]#context# instance using the SYCL [code]#device(s)# in the [code]#deviceList# parameter as the associated SYCL [code]#device(s)# and the SYCL [code]#platform# associated with each SYCL [code]#device# in the [code]#deviceList# parameter as the associated SYCL [code]#platform#. This requires that all SYCL [code]#devices# in the [code]#deviceList# parameter have the same associated SYCL [code]#platform#. The constructed SYCL [code]#context# will use the [code]#asyncHandler# parameter to handle exceptions.
@@ -1529,7 +1529,7 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-    explicit device(const DeviceSelector &)
+    explicit device(const DeviceSelector&)
 ----
    a@ Constructs a SYCL [code]#device# instance that is a copy of the device
       returned by the <<device-selector>> parameter.
@@ -1620,7 +1620,7 @@ a@
 [source]
 ----
 bool has_extension(
-    const std::string &extension) const
+    const std::string& extension) const
 ----
    a@ Deprecated, use [code]#has()# instead.
 
@@ -1654,7 +1654,7 @@ a@
 ----
 template <info::partition_property Prop>
 std::vector<device> create_sub_devices(
-    const std::vector<size_t> &counts) const
+    const std::vector<size_t>& counts) const
 ----
    a@ Available only when [code]#Prop# is
       [code]#info::partition_property::partition_by_counts#.  Returns a
@@ -2967,7 +2967,7 @@ include::{header_dir}/queue.h[lines=4..-1]
 a@
 [source]
 ----
-explicit queue(const property_list &propList = {})
+explicit queue(const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance using the device
 constructed from the [code]#default_selector_v#.
@@ -2978,8 +2978,8 @@ be provided to the constructed SYCL [code]#queue# via an instance of
 a@
 [source]
 ----
-explicit queue(const async_handler &asyncHandler,
-               const property_list &propList = {})
+explicit queue(const async_handler& asyncHandler,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance with an
 [code]#async_handler# using the device constructed from the
@@ -2992,8 +2992,8 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-explicit queue(const DeviceSelector &deviceSelector,
-               const property_list &propList = {})
+explicit queue(const DeviceSelector& deviceSelector,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance using the device
 returned by the <<device-selector>> provided. Zero or
@@ -3005,9 +3005,9 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-explicit queue(const DeviceSelector &deviceSelector,
-               const async_handler &asyncHandler,
-               const property_list &propList = {})
+explicit queue(const DeviceSelector& deviceSelector,
+               const async_handler& asyncHandler,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance with an
 [code]#async_handler# using the device returned by the
@@ -3018,8 +3018,8 @@ an instance of [code]#property_list#.
 a@
 [source]
 ----
-explicit queue(const device &syclDevice,
-               const property_list &propList = {})
+explicit queue(const device& syclDevice,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance using the [code]#syclDevice# provided. Zero or more properties can be provided to the
 constructed SYCL [code]#queue# via an instance of [code]#property_list#.
@@ -3027,9 +3027,9 @@ constructed SYCL [code]#queue# via an instance of [code]#property_list#.
 a@
 [source]
 ----
-explicit queue(const device &syclDevice,
-               const async_handler &asyncHandler,
-               const property_list &propList = {})
+explicit queue(const device& syclDevice,
+               const async_handler& asyncHandler,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance with an [code]#async_handler# using the [code]#syclDevice# provided. Zero or more
 properties can be provided to the constructed SYCL [code]#queue#
@@ -3039,9 +3039,9 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-explicit queue(const context &syclContext,
-               const DeviceSelector &deviceSelector,
-               const property_list &propList = {})
+explicit queue(const context& syclContext,
+               const DeviceSelector& deviceSelector,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance that is associated
 with the [code]#syclContext# provided, using the device
@@ -3058,10 +3058,10 @@ a@
 [source]
 ----
 template <typename DeviceSelector>
-explicit queue(const context &syclContext,
-               const DeviceSelector &deviceSelector,
-               const async_handler &asyncHandler,
-               const property_list &propList = {})
+explicit queue(const context& syclContext,
+               const DeviceSelector& deviceSelector,
+               const async_handler& asyncHandler,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance with an
 [code]#async_handler# that is associated with the
@@ -3078,9 +3078,9 @@ instance of [code]#property_list#.
 a@
 [source]
 ----
-explicit queue(const context &syclContext,
-               const device &syclDevice,
-               const property_list &propList = {})
+explicit queue(const context& syclContext,
+               const device& syclDevice,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance using the [code]#syclDevice#
 provided.  This device must either be contained by [code]#syclContext# or it
@@ -3092,10 +3092,10 @@ the constructed SYCL [code]#queue# via an instance of [code]#property_list#.
 a@
 [source]
 ----
-explicit queue(const context &syclContext,
-               const device &syclDevice,
-               const async_handler &asyncHandler,
-               const property_list &propList = {})
+explicit queue(const context& syclContext,
+               const device& syclDevice,
+               const async_handler& asyncHandler,
+               const property_list& propList = {})
 ----
 a@ Constructs a SYCL [code]#queue# instance with an [code]#async_handler# using
 the [code]#syclDevice# provided.  This device must either be contained by
@@ -3211,7 +3211,7 @@ a@
 [source]
 ----
 template <typename T>
-event submit(T cgf, queue & secondaryQueue)
+event submit(T cgf, queue& secondaryQueue)
 ----
 a@ Submit a <<command-group-function-object>> to the queue, in order to be scheduled
 for execution on the device. On a kernel error, this <<command-group-function-object>>
@@ -3282,7 +3282,7 @@ a@
 [source]
 ----
 template <typename KernelName, typename KernelType>
-event single_task(const KernelType &kernelFunc)
+event single_task(const KernelType& kernelFunc)
 ----
 a@ <<sycl-kernel-function, Kernel function>>
 a@ Equivalent to submitting a command-group containing
@@ -3292,7 +3292,7 @@ a@
 ----
 template <typename KernelName, typename KernelType>
 event single_task(event depEvent,
-                  const KernelType &kernelFunc)
+                  const KernelType& kernelFunc)
 ----
 a@ <<sycl-kernel-function, Kernel function>>
 a@ Equivalent to submitting a command-group containing
@@ -3302,8 +3302,8 @@ a@
 [source]
 ----
 template <typename KernelName, typename KernelType>
-event single_task(const std::vector<event> &depEvents,
-                  const KernelType &kernelFunc)
+event single_task(const std::vector<event>& depEvents,
+                  const KernelType& kernelFunc)
 ----
 a@ <<sycl-kernel-function, Kernel function>>
 a@ Equivalent to submitting a command-group containing
@@ -3342,7 +3342,7 @@ template <typename KernelName,
           int Dimensions,
           typename... Rest>
 event parallel_for(range<Dimensions> numWorkItems,
-                   const std::vector<event> &depEvents,
+                   const std::vector<event>& depEvents,
                    Rest&&... rest)
 ----
 a@ <<sycl-kernel-function, Kernel function>>
@@ -3382,7 +3382,7 @@ template <typename KernelName,
           int Dimensions,
           typename... Rest>
 event parallel_for(nd_range<Dimensions> executionRange,
-                   const std::vector<event> &depEvents,
+                   const std::vector<event>& depEvents,
                    Rest&&... rest)
 ----
 a@ <<sycl-kernel-function, Kernel function>>
@@ -3411,7 +3411,7 @@ a@
 [source]
 ----
 event memcpy(void* dest, const void* src, size_t numBytes,
-             const std::vector<event> &depEvents)
+             const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3442,7 +3442,7 @@ a@
 ----
 template <typename T>
 event copy(const T* srct, T* dest, size_t count,
-           const std::vector<event> &depEvents)
+           const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3470,7 +3470,7 @@ a@
 [source]
 ----
 event memset(void* ptr, int value, size_t numBytes,
-             const std::vector<event> &depEvents)
+             const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3501,7 +3501,7 @@ a@
 ----
 template <typename T>
 event fill(void* ptr, const T& pattern, size_t count,
-           const std::vector<event> &depEvents)
+           const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3529,7 +3529,7 @@ a@
 [source]
 ----
 event prefetch(void* ptr, size_t numBytes,
-               const std::vector<event> &depEvents)
+               const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3557,7 +3557,7 @@ a@
 [source]
 ----
 event mem_advise(void* ptr, size_t numBytes, int advice,
-                 const std::vector<event> &depEvents)
+                 const std::vector<event>& depEvents)
 ----
 a@ <<sec:usm, USM>>
 a@ Equivalent to submitting a command-group containing
@@ -3597,7 +3597,7 @@ template <typename SrcT, int SrcDims, access_mode SrcMode,
           target SrcTgt, access::placeholder IsPlaceholder,
           typename DestT>
 event copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
-           DestT *dest);
+           DestT* dest);
 ----
 a@ <<subsec:explicitmemory,Explicit copy>>
 a@ Equivalent to submitting a command-group containing
@@ -3610,7 +3610,7 @@ template <typename SrcT, typename DestT, int DestDims,
           access_mode DestMode, target DestTgt,
           access::placeholder IsPlaceholder>
 event
-copy(const SrcT *src,
+copy(const SrcT* src,
      accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder> dest);
 ----
 a@ <<subsec:explicitmemory,Explicit copy>>
@@ -3648,7 +3648,7 @@ a@
 ----
   template <typename T, int Dims, access_mode Mode, target Tgt,
             access::placeholder IsPlaceholder>
-  event fill(accessor<T, Dims, Mode, Tgt, IsPlaceholder> dest, const T &src);
+  event fill(accessor<T, Dims, Mode, Tgt, IsPlaceholder> dest, const T& src);
 ----
 a@ <<subsec:explicitmemory,Explicit copy>>
 a@ Equivalent to submitting a command-group containing
@@ -3897,7 +3897,7 @@ a@
 [source]
 ----
 static void wait(
-    const std::vector<event> &eventList)
+    const std::vector<event>& eventList)
 ----
    a@ Synchronously wait on a list of events.
 
@@ -3905,7 +3905,7 @@ a@
 [source]
 ----
 static void wait_and_throw(
-    const std::vector<event> &eventList)
+    const std::vector<event>& eventList)
 ----
    a@ Synchronously wait on a list of events.
 
@@ -4285,8 +4285,8 @@ include::{header_dir}/buffer.h[lines=4..-1]
 a@
 [source]
 ----
-buffer(const range<Dimensions> & bufferRange,
-const property_list &propList = {})
+buffer(const range<Dimensions>& bufferRange,
+const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
       The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
@@ -4297,9 +4297,9 @@ const property_list &propList = {})
 a@
 [source]
 ----
-buffer(const range<Dimensions> & bufferRange,
+buffer(const range<Dimensions>& bufferRange,
 AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
       The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
@@ -4311,8 +4311,8 @@ a@
 [source]
 ----
 buffer(T* hostData,
-const range<Dimensions> & bufferRange,
-    const property_list &propList = {})
+const range<Dimensions>& bufferRange,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided.
       The buffer is initialized with the memory specified by [code]#hostData#.
@@ -4325,9 +4325,9 @@ a@
 [source]
 ----
 buffer(T* hostData,
-const range<Dimensions> & bufferRange,
+const range<Dimensions>& bufferRange,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided.
       The buffer is initialized with the memory specified by [code]#hostData#.
@@ -4340,8 +4340,8 @@ a@
 [source]
 ----
 buffer(const T* hostData,
-const range<Dimensions> & bufferRange,
-    const property_list &propList = {})
+const range<Dimensions>& bufferRange,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the
       [code]#hostData# parameter provided. The ownership of this
@@ -4373,9 +4373,9 @@ a@
 [source]
 ----
 buffer(const T* hostData,
-const range<Dimensions> & bufferRange,
+const range<Dimensions>& bufferRange,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the
       [code]#hostData# parameter provided. The ownership of this
@@ -4408,8 +4408,8 @@ a@
 [source]
 ----
 template <typename Container>
-buffer(Container &container,
-    const property_list &propList = {})
+buffer(Container& container,
+    const property_list& propList = {})
 ----
    a@ Construct a one dimensional SYCL [code]#buffer# instance
       from the elements starting at [code]#std::data(container)#
@@ -4438,9 +4438,9 @@ a@
 [source]
 ----
 template <typename Container>
-buffer(Container &container,
+buffer(Container& container,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a one dimensional SYCL [code]#buffer# instance
       from the elements starting at [code]#std::data(container)#
@@ -4468,9 +4468,9 @@ is convertible to [code]#T*#.
 a@
 [source]
 ----
-buffer(const std::shared_ptr<T> &hostData,
-const range<Dimensions> & bufferRange,
-    const property_list &propList = {})
+buffer(const std::shared_ptr<T>& hostData,
+const range<Dimensions>&  bufferRange,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
       The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
@@ -4480,10 +4480,10 @@ const range<Dimensions> & bufferRange,
 a@
 [source]
 ----
-buffer(const std::shared_ptr<T> &hostData,
-const range<Dimensions> & bufferRange,
+buffer(const std::shared_ptr<T>& hostData,
+const range<Dimensions>&  bufferRange,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
       The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
@@ -4493,9 +4493,9 @@ const range<Dimensions> & bufferRange,
 a@
 [source,c++]
 ----
-buffer(const std::shared_ptr<T[]> &hostData,
-const range<Dimensions> & bufferRange,
-    const property_list &propList = {})
+buffer(const std::shared_ptr<T[]>& hostData,
+const range<Dimensions>&  bufferRange,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
       The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
@@ -4505,10 +4505,10 @@ const range<Dimensions> & bufferRange,
 a@
 [source,c++]
 ----
-buffer(const std::shared_ptr<T[]> &hostData,
-const range<Dimensions> & bufferRange,
+buffer(const std::shared_ptr<T[]>& hostData,
+const range<Dimensions>& bufferRange,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
       The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
@@ -4520,7 +4520,7 @@ a@
 ----
 template <typename InputIterator>
 buffer(InputIterator first, InputIterator last,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Create a new allocated 1D buffer initialized from the given elements
       ranging from [code]#first# up to one before [code]#last#.
@@ -4535,7 +4535,7 @@ a@
 template <typename InputIterator>
 buffer(InputIterator first, InputIterator last,
     AllocatorT allocator = {},
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Create a new allocated 1D buffer initialized from the given elements
       ranging from [code]#first# up to one before [code]#last#.
@@ -4547,8 +4547,8 @@ buffer(InputIterator first, InputIterator last,
 a@
 [source]
 ----
-buffer(buffer &b, const id<Dimensions> &baseIndex,
-      const range<Dimensions> &subRange)
+buffer(buffer& b, const id<Dimensions>& baseIndex,
+      const range<Dimensions>& subRange)
 ----
    a@ Create a new sub-buffer without allocation to have separate
       accessors later. [code]#b# is the buffer with the real data, which must not be a sub-buffer.
@@ -4641,7 +4641,7 @@ a@
 template<access_mode Mode = access_mode::read_write,
          target Targ = target::device>
 accessor<T, Dimensions, Mode, Targ>
-    get_access(handler &commandGroupHandler)
+    get_access(handler& commandGroupHandler)
 ----
    a@ Returns a valid [code]#accessor# to the buffer with the specified
       access mode and target in the command group buffer.
@@ -4666,7 +4666,7 @@ a@
 template<access_mode Mode = access_mode::read_write,
          target Targ=target::device>
 accessor<T, Dimensions, Mode, Targ>
-    get_access(handler &commandGroupHandler,
+    get_access(handler& commandGroupHandler,
                range<Dimensions> accessRange,
                id<Dimensions> accessOffset = {})
 ----
@@ -4898,7 +4898,7 @@ property::buffer::use_host_ptr::use_host_ptr()
 a@
 [source]
 ----
-property::buffer::use_mutex::use_mutex(std::mutex &mutexRef)
+property::buffer::use_mutex::use_mutex(std::mutex& mutexRef)
 ----
    a@ Constructs a SYCL [code]#use_mutex# property instance with a reference to [code]#mutexRef# parameter provided.
 
@@ -4921,7 +4921,7 @@ property::buffer::context_bound::context_bound(context boundContext)
 a@
 [source]
 ----
-std::mutex *property::buffer::use_mutex::get_mutex_ptr() const
+std::mutex* property::buffer::use_mutex::get_mutex_ptr() const
 ----
    a@ Returns the [code]#std::mutex# which was specified when
       constructing this SYCL [code]#use_mutex# property.
@@ -5142,8 +5142,8 @@ a@
 [source]
 ----
 unsampled_image(image_format format,
-const range<Dimensions> &rangeRef,
-    const property_list &propList = {})
+const range<Dimensions>& rangeRef,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with
       uninitialized memory.
@@ -5167,9 +5167,9 @@ a@
 [source]
 ----
 unsampled_image(image_format format,
-const range<Dimensions> &rangeRef,
+const range<Dimensions>& rangeRef,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with
       uninitialized memory.
@@ -5193,9 +5193,9 @@ a@
 [source]
 ----
 unsampled_image(image_format format,
-const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> &pitch,
-    const property_list &propList = {})
+const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
+    const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
@@ -5221,10 +5221,10 @@ a@
 [source]
 ----
 unsampled_image(image_format format,
-const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> &pitch,
+const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
@@ -5249,10 +5249,10 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-unsampled_image(void *hostPointer,
+unsampled_image(void* hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5277,11 +5277,11 @@ image_format format,
 a@
 [source]
 ----
-unsampled_image(void *hostPointer,
+unsampled_image(void* hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
+    const range<Dimensions>& rangeRef,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5305,11 +5305,11 @@ image_format format,
 a@
 [source]
 ----
-unsampled_image(void *hostPointer,
+unsampled_image(void* hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> &pitch,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
+    const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#
 
@@ -5336,12 +5336,12 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-unsampled_image(void *hostPointer,
+unsampled_image(void* hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> &pitch,
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
@@ -5369,8 +5369,8 @@ a@
 ----
 unsampled_image(std::shared_ptr<void>& hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5396,9 +5396,9 @@ a@
 ----
 unsampled_image(std::shared_ptr<void>& hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
+    const range<Dimensions>& rangeRef,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5424,9 +5424,9 @@ a@
 ----
 unsampled_image(std::shared_ptr<void>& hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> & pitch,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5452,10 +5452,10 @@ a@
 ----
 unsampled_image(std::shared_ptr<void>& hostPointer,
 image_format format,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> & pitch,
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
     AllocatorT allocator,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5628,11 +5628,11 @@ include::{header_dir}/sampledImage.h[lines=4..-1]
 a@
 [source]
 ----
-sampled_image(const void *hostPointer,
+sampled_image(const void* hostPointer,
 image_format format,
     image_sampler sampler,
-    const range<Dimensions> &rangeRef,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#sampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5657,12 +5657,12 @@ image_format format,
 a@
 [source]
 ----
-sampled_image(const void *hostPointer,
+sampled_image(const void* hostPointer,
 image_format format,
     image_sampler sampler,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> &pitch,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
+    const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
@@ -5692,8 +5692,8 @@ a@
 sampled_image(std::shared_ptr<const void>& hostPointer,
 image_format format,
     image_sampler sampler,
-    const range<Dimensions> &rangeRef,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#sampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5721,9 +5721,9 @@ a@
 sampled_image(std::shared_ptr<const void>& hostPointer,
 image_format format,
     image_sampler sampler,
-    const range<Dimensions> &rangeRef,
-    const range<Dimensions-1> & pitch,
-    const property_list &propList = {})
+    const range<Dimensions>& rangeRef,
+    const range<Dimensions-1>& pitch,
+    const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#sampled_image# instance with the
       [code]#hostPointer# parameter provided. The ownership of this
@@ -5893,7 +5893,7 @@ property::image::use_host_ptr::use_host_ptr()
 a@
 [source]
 ----
-property::image::use_mutex::use_mutex(std::mutex &mutexRef)
+property::image::use_mutex::use_mutex(std::mutex& mutexRef)
 ----
    a@ Constructs a SYCL [code]#use_mutex# property instance with a reference to [code]#mutexRef# parameter provided.
 
@@ -5916,7 +5916,7 @@ property::image::context_bound::context_bound(context boundContext)
 a@
 [source]
 ----
-std::mutex *property::image::use_mutex::get_mutex_ptr() const
+std::mutex* property::image::use_mutex::get_mutex_ptr() const
 ----
    a@ Returns the [code]#std::mutex# which was specified when
       constructing this SYCL [code]#use_mutex# property.
@@ -6386,7 +6386,7 @@ same dimensionality as the accessor.  The second way is by passing a single
 in <<sec:multi-dim-subscript>>.
 
 In all these cases, the reference to the contained element is of type
-[code]#const DataT &# for read-only accessors and of type [code]#DataT &# for
+[code]#const DataT&# for read-only accessors and of type [code]#DataT&# for
 other accessors.
 
 Accessors of all types have a range that defines the set of indices that may be
@@ -6578,8 +6578,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -6591,9 +6591,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -6606,8 +6606,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6619,8 +6619,8 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    TagT tag, const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6633,9 +6633,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6648,9 +6648,9 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
-    TagT tag, const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6665,9 +6665,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6682,9 +6682,9 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6701,10 +6701,10 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6721,10 +6721,10 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6742,10 +6742,10 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6762,10 +6762,10 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6784,11 +6784,11 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6806,11 +6806,11 @@ a@
 [source]
 ----
 template <typename AllocatorT, typename TagT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -6837,7 +6837,7 @@ the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
 a@
 [source]
 ----
-void swap(accessor &other);
+void swap(accessor& other);
 ----
    a@ Swaps the contents of the current accessor with the contents of
       [code]#other#.
@@ -7063,8 +7063,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7076,9 +7076,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7091,8 +7091,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7104,9 +7104,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7119,9 +7119,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7136,10 +7136,10 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7156,10 +7156,10 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7176,11 +7176,11 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    handler &commandGroupHandlerRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    handler& commandGroupHandlerRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7282,8 +7282,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7295,8 +7295,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7308,9 +7308,9 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7326,10 +7326,10 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7419,8 +7419,8 @@ include::{header_dir}/accessorDeprecatedLocal.h[lines=4..-1]
 a@
 [source]
 ----
-accessor(handler &commandGroupHandlerRef,
-         const property_list &propList = {})
+accessor(handler& commandGroupHandlerRef,
+         const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7433,8 +7433,8 @@ a@
 [source]
 ----
 accessor(range<Dimensions> allocationSize,
-         handler &commandGroupHandlerRef,
-         const property_list &propList = {})
+         handler& commandGroupHandlerRef,
+         const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7789,8 +7789,8 @@ a@
 [source]
 ----
 template <typename AllocatorT>
-host_accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+host_accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7803,8 +7803,8 @@ a@
 ----
 template <typename AllocatorT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    const property_list &propList = {})
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7817,8 +7817,8 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-    TagT tag, const property_list &propList = {})
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7832,9 +7832,9 @@ a@
 ----
 template <typename AllocatorT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7852,9 +7852,9 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7872,10 +7872,10 @@ a@
 ----
 template <typename AllocatorT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    const property_list &propList = {})
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7893,10 +7893,10 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 host_accessor(
-    buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+    buffer<DataT, Dimensions, AllocatorT>& bufferRef,
     range<Dimensions> accessRange,
     id<Dimensions> accessOffset,
-    TagT tag, const property_list &propList = {})
+    TagT tag, const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -7922,7 +7922,7 @@ the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
 a@
 [source]
 ----
-void swap(host_accessor &other);
+void swap(host_accessor& other);
 ----
    a@ Swaps the contents of the current accessor with the contents of
       [code]#other#.
@@ -8082,8 +8082,8 @@ local_accessor()
 a@
 [source]
 ----
-local_accessor(handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+local_accessor(handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -8096,8 +8096,8 @@ a@
 [source]
 ----
 local_accessor(range<Dimensions> allocationSize,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Available only when [code]#(Dimensions > 0)#.
 
@@ -8118,7 +8118,7 @@ provides properties for the constructed accessor.
 a@
 [source]
 ----
-void swap(local_accessor &other);
+void swap(local_accessor& other);
 ----
    a@ Swaps the contents of the current accessor with the contents of
       [code]#other#.
@@ -8617,9 +8617,9 @@ a@
 ----
 template <typename AllocatorT>
 unsampled_image_accessor(
-    unsampled_image<Dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+    unsampled_image<Dimensions, AllocatorT>& imageRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Constructs an [code]#unsampled_image_accessor# for accessing an
       [code]#unsampled_image# within a <<command>> on the [code]#queue#
@@ -8636,9 +8636,9 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 unsampled_image_accessor(
-    unsampled_image<Dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef, TagT tag,
-    const property_list &propList = {})
+    unsampled_image<Dimensions, AllocatorT>& imageRef,
+    handler& commandGroupHandlerRef, TagT tag,
+    const property_list& propList = {})
 ----
    a@ Constructs an [code]#unsampled_image_accessor# for accessing an
       [code]#unsampled_image# within a <<command>> on the [code]#queue#
@@ -8665,8 +8665,8 @@ a@
 ----
 template <typename AllocatorT>
 host_unsampled_image_accessor(
-    unsampled_image<Dimensions, AllocatorT> &imageRef,
-    const property_list &propList = {})
+    unsampled_image<Dimensions, AllocatorT>& imageRef,
+    const property_list& propList = {})
 ----
    a@ Constructs a [code]#host_unsampled_image_accessor# for accessing an
       [code]#unsampled_image# immediately on the host.  The optional
@@ -8677,8 +8677,8 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 host_unsampled_image_accessor(
-    unsampled_image<Dimensions, AllocatorT> &imageRef,
-    TagT tag, const property_list &propList = {})
+    unsampled_image<Dimensions, AllocatorT>& imageRef,
+    TagT tag, const property_list& propList = {})
 ----
    a@ Constructs a [code]#host_unsampled_image_accessor# for accessing an
       [code]#unsampled_image# immediately on the host.  The [code]#tag# is used
@@ -8706,7 +8706,7 @@ a@
 [source]
 ----
 template <typename CoordT>
-DataT read(const CoordT &coords) const
+DataT read(const CoordT& coords) const
 ----
    a@ Available only when [code]#(AccessMode == access_mode::read ||
       AccessMode == access_mode::read_write)#.
@@ -8723,7 +8723,7 @@ a@
 [source]
 ----
 template <typename CoordT>
-void write(const CoordT &coords, const DataT &color) const
+void write(const CoordT& coords, const DataT& color) const
 ----
    a@ Available only when [code]#(AccessMode == access_mode::write ||
       AccessMode == access_mode::read_write)#.
@@ -8886,9 +8886,9 @@ a@
 ----
 template <typename AllocatorT>
 sampled_image_accessor(
-    sampled_image<Dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef,
-    const property_list &propList = {})
+    sampled_image<Dimensions, AllocatorT>& imageRef,
+    handler& commandGroupHandlerRef,
+    const property_list& propList = {})
 ----
    a@ Constructs a [code]#sampled_image_accessor# for accessing a
       [code]#sampled_image# within a <<command>> on the [code]#queue#
@@ -8905,9 +8905,9 @@ a@
 ----
 template <typename AllocatorT, typename TagT>
 sampled_image_accessor(
-    sampled_image<Dimensions, AllocatorT> &imageRef,
-    handler &commandGroupHandlerRef, TagT tag,
-    const property_list &propList = {})
+    sampled_image<Dimensions, AllocatorT>& imageRef,
+    handler& commandGroupHandlerRef, TagT tag,
+    const property_list& propList = {})
 ----
    a@ Constructs a [code]#sampled_image_accessor# for accessing a
       [code]#sampled_image# within a <<command>> on the [code]#queue#
@@ -8934,8 +8934,8 @@ a@
 ----
 template <typename AllocatorT>
 host_sampled_image_accessor(
-    sampled_image<Dimensions, AllocatorT> &imageRef,
-    const property_list &propList = {})
+    sampled_image<Dimensions, AllocatorT>& imageRef,
+    const property_list& propList = {})
 ----
    a@ Constructs a [code]#host_sampled_image_accessor# for accessing a
       [code]#sampled_image# immediately on the host.  The optional
@@ -8961,7 +8961,7 @@ a@
 [source]
 ----
 template <typename CoordT>
-DataT read(const CoordT &coords) const
+DataT read(const CoordT& coords) const
 ----
    a@ Reads and returns a sampled element of the [code]#sampled_image# at the
       coordinates specified by [code]#coords#.  Permitted types for
@@ -9098,7 +9098,7 @@ multi_ptr()
 a@
 [source]
 ----
-multi_ptr(const multi_ptr &)
+multi_ptr(const multi_ptr&)
 ----
    a@ Copy constructor.
 
@@ -9210,21 +9210,21 @@ is not compatible with [code]#Space#.
 a@
 [source]
 ----
-multi_ptr &operator=(const multi_ptr&)
+multi_ptr& operator=(const multi_ptr&)
 ----
    a@ Copy assignment operator.
 
 a@
 [source]
 ----
-multi_ptr &operator=(multi_ptr&&)
+multi_ptr& operator=(multi_ptr&&)
 ----
    a@ Move assignment operator.
 
 a@
 [source]
 ----
-multi_ptr &operator=(std::nullptr_t)
+multi_ptr& operator=(std::nullptr_t)
 ----
    a@ Assigns [code]#nullptr# to the [code]#multi_ptr#.
 
@@ -9232,7 +9232,7 @@ a@
 [source]
 ----
 template<access::address_space AS, access::decorated IsDecorated>
-multi_ptr &operator=(const multi_ptr<value_type, AS, IsDecorated>&)
+multi_ptr& operator=(const multi_ptr<value_type, AS, IsDecorated>&)
 ----
    a@ Available only when: [code]#Space == access::address_space::generic_space && AS != access::address_space::constant_space#.
 
@@ -9242,7 +9242,7 @@ a@
 [source]
 ----
 template<access::address_space AS, access::decorated IsDecorated>
-multi_ptr &operator=(multi_ptr<value_type, AS, IsDecorated>&&
+multi_ptr& operator=(multi_ptr<value_type, AS, IsDecorated>&&
 ----
    a@ Available only when:
       [code]#Space == access::address_space::generic_space && AS != access::address_space::constant_space#.
@@ -9435,7 +9435,7 @@ pointer get() const
 a@
 [source]
 ----
-__unspecified__ * get_decorated() const
+__unspecified__* get_decorated() const
 ----
    a@ Returns the underlying pointer decorated by the address space that it addresses.
       Note that the support involves implementation-defined device compiler extensions.
@@ -10121,39 +10121,39 @@ public:
   };
 
   usm_allocator() = delete;
-  usm_allocator(const context &ctxt,
-                const device &dev,
-                const property_list &propList = {});
-  usm_allocator(const queue &q,
-                const property_list &propList = {});
-  usm_allocator(const usm_allocator &other);
-  usm_allocator(usm_allocator &&) noexcept;
-  usm_allocator &operator=(const usm_allocator &);
-  usm_allocator &operator=(usm_allocator &&);
+  usm_allocator(const context& ctxt,
+                const device& dev,
+                const property_list& propList = {});
+  usm_allocator(const queue& q,
+                const property_list& propList = {});
+  usm_allocator(const usm_allocator& other);
+  usm_allocator(usm_allocator&&) noexcept;
+  usm_allocator& operator=(const usm_allocator&);
+  usm_allocator& operator=(usm_allocator&&);
 
   template <class U>
-  usm_allocator(usm_allocator<U, AllocKind, Alignment> const &) noexcept;
+  usm_allocator(usm_allocator<U, AllocKind, Alignment> const&) noexcept;
 
   /// Allocate memory
-  T *allocate(size_t count);
+  T* allocate(size_t count);
 
   /// Deallocate memory
-  void deallocate(T *Ptr, size_t count);
+  void deallocate(T* Ptr, size_t count);
 
   /// Equality Comparison
   ///
   /// Allocators only compare equal if they are of the same USM kind, alignment,
   /// context, and device
   template <class U, usm::alloc AllocKindU, size_t AlignmentU>
-  friend bool operator==(const usm_allocator<T, AllocKind, Alignment> &,
-                         const usm_allocator<U, AllocKindU, AlignmentU> &);
+  friend bool operator==(const usm_allocator<T, AllocKind, Alignment>&,
+                         const usm_allocator<U, AllocKindU, AlignmentU>&);
 
   /// Inequality Comparison
   /// Allocators only compare unequal if they are not of the same USM kind, alignment,
   /// context, or device
   template <class U, usm::alloc AllocKindU, size_t AlignmentU>
-  friend bool operator!=(const usm_allocator<T, AllocKind, Alignment> &,
-                         const usm_allocator<U, AllocKindU, AlignmentU> &);
+  friend bool operator!=(const usm_allocator<T, AllocKind, Alignment>&,
+                         const usm_allocator<U, AllocKindU, AlignmentU>&);
 };
 ----
 
@@ -10165,9 +10165,9 @@ public:
 a@
 [source]
 ----
-usm_allocator(const context &ctxt,
-              const device &dev,
-              const property_list &propList = {})
+usm_allocator(const context& ctxt,
+              const device& dev,
+              const property_list& propList = {})
 ----
 a@ Constructs a [code]#usm_allocator# instance that allocates USM memory for
 the provided context and device.  If [code]#AllocKind# is
@@ -10180,8 +10180,8 @@ contained by [code]#ctxt#, otherwise this constructor throws a synchronous
 a@
 [source]
 ----
-usm_allocator(const queue &q,
-              const property_list &propList = {})
+usm_allocator(const queue& q,
+              const property_list& propList = {})
 ----
 a@ Constructs a [code]#usm_allocator# instance that allocates USM memory for
 the context and device from the provided [code]#queue#.
@@ -10213,7 +10213,7 @@ a@
 void* sycl::malloc_device(size_t numBytes,
                           const device& syclDevice,
                           const context& syclContext,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated memory on [code]#syclDevice# on
 success.  The allocation size is specified in bytes.  This memory is not
@@ -10235,7 +10235,7 @@ template <typename T>
 T* sycl::malloc_device(size_t count,
                        const device& syclDevice,
                        const context& syclContext,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@  Returns a pointer to the newly allocated memory on [code]#syclDevice# on
 success.  The allocation size is specified in number of elements of type
@@ -10257,7 +10257,7 @@ a@
 ----
 void* sycl::malloc_device(size_t numBytes,
                           const queue& syclQueue,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device#
 and [code]#context#.
@@ -10273,7 +10273,7 @@ a@
 template <typename T>
 T* sycl::malloc_device(size_t count,
                        const queue& syclQueue,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device#
 and [code]#context#.
@@ -10291,7 +10291,7 @@ sycl::aligned_alloc_device(size_t alignment,
                            size_t numBytes,
                            const device& syclDevice,
                            const context& syclContext,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated memory on
 the specified [code]#device# with [code]#alignment#-byte alignment on success.
@@ -10317,7 +10317,7 @@ sycl::aligned_alloc_device(size_t alignment,
                            size_t count,
                            const device& syclDevice,
                            const context& syclContext,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated memory on
 the specified [code]#device# with [code]#alignment#-byte alignment on success.
@@ -10341,7 +10341,7 @@ void*
 sycl::aligned_alloc_device(size_t alignment,
                            size_t numBytes,
                            const queue& syclQueue,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device#
 and [code]#context#.
@@ -10359,7 +10359,7 @@ T*
 sycl::aligned_alloc_device(size_t alignment,
                            size_t count,
                            const queue& syclQueue,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device#
 and [code]#context#.
@@ -10383,7 +10383,7 @@ a@
 ----
 void* sycl::malloc_host(size_t numBytes,
                         const context& syclContext,
-                        const property_list &propList = {})
+                        const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated host memory on
 success. This allocation is specified in bytes. The allocation is
@@ -10403,7 +10403,7 @@ a@
 template <typename T>
 T* sycl::malloc_host(size_t count,
                      const context& syclContext,
-                     const property_list &propList = {})
+                     const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated host memory on
 success. This allocation is specified in number of elements of type [code]#T#.
@@ -10423,7 +10423,7 @@ a@
 ----
 void* sycl::malloc_host(size_t numBytes,
                         const queue& syclQueue,
-                        const property_list &propList = {})
+                        const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
 Zero or more properties can be provided to the allocation function
@@ -10438,7 +10438,7 @@ a@
 template <typename T>
 T* sycl::malloc_host(size_t count,
                      const queue& syclQueue,
-                     const property_list &propList = {})
+                     const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
 Zero or more properties can be provided to the allocation function
@@ -10454,7 +10454,7 @@ void*
 sycl::aligned_alloc_host(size_t alignment,
                          size_t numBytes,
                          const context& syclContext,
-                         const property_list &propList = {})
+                         const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated host memory on
 success. This allocation is specified in bytes and aligned to the specified
@@ -10477,7 +10477,7 @@ T*
 sycl::aligned_alloc_host(size_t alignment,
                          size_t count,
                          const context& syclContext,
-                         const property_list &propList = {})
+                         const property_list& propList = {})
 ----
 a@ Returns a pointer to the newly allocated host memory on
 success. This allocation is specified in elements of type [code]#T# and
@@ -10499,7 +10499,7 @@ void*
 sycl::aligned_alloc_host(size_t alignment,
                          size_t numBytes,
                          const queue& syclQueue,
-                         const property_list &propList = {})
+                         const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
 Zero or more properties can be provided to the allocation function
@@ -10516,7 +10516,7 @@ void*
 sycl::aligned_alloc_host(size_t alignment,
                          size_t count,
                          const queue& syclQueue,
-                         const property_list &propList = {})
+                         const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
 Zero or more properties can be provided to the allocation function
@@ -10540,7 +10540,7 @@ a@
 void* sycl::malloc_shared(size_t numBytes,
                           const device& syclDevice,
                           const context& syclContext,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Returns a shared allocation that is accessible on the host and
 on [code]#syclDevice#.
@@ -10564,7 +10564,7 @@ template <typename T>
 T* sycl::malloc_shared(size_t count,
                        const device& syclDevice,
                        const context& syclContext,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@ Returns a shared allocation that is accessible on the host and
 on [code]#syclDevice#.
@@ -10586,7 +10586,7 @@ a@
 ----
 void* sycl::malloc_shared(size_t numBytes,
                           const queue& syclQueue,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
@@ -10602,7 +10602,7 @@ a@
 template <typename T>
 T* sycl::malloc_shared(size_t count,
                        const queue& syclQueue,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
@@ -10620,7 +10620,7 @@ sycl::aligned_alloc_shared(size_t alignment,
                            size_t numBytes,
                            const device& syclDevice,
                            const context& syclContext,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Returns a shared allocation that is accessible on the host and
 on [code]#syclDevice#.
@@ -10647,7 +10647,7 @@ sycl::aligned_alloc_shared(size_t alignment,
                            size_t count,
                            const device& syclDevice,
                            const context& syclContext,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Returns a shared allocation that is accessible on the host and
 on [code]#syclDevice#.
@@ -10672,7 +10672,7 @@ void*
 sycl::aligned_alloc_shared(size_t alignment,
                            size_t numBytes,
                            const queue& syclQueue,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
@@ -10690,7 +10690,7 @@ T*
 sycl::aligned_alloc_shared(size_t alignment,
                            size_t count,
                            const queue& syclQueue,
-                           const property_list &propList = {})
+                           const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
@@ -10726,11 +10726,11 @@ a device that doesn't have [code]#aspect::usm_host_allocations#.
 a@
 [source]
 ----
-void *sycl::malloc(size_t numBytes,
+void* sycl::malloc(size_t numBytes,
                    const device& syclDevice,
                    const context& syclContext,
                    usm::alloc kind,
-                   const property_list &propList = {})
+                   const property_list& propList = {})
 ----
 a@ Returns a [code]#kind# allocation.
 This allocation is specified in bytes. This memory
@@ -10748,11 +10748,11 @@ a@
 [source]
 ----
 template <typename T>
-T *sycl::malloc(size_t count,
+T* sycl::malloc(size_t count,
                 const device& syclDevice,
                 const context& syclContext,
                 usm::alloc kind,
-                const property_list &propList = {})
+                const property_list& propList = {})
 ----
 a@ Returns a [code]#kind# allocation.
 This allocation is specified in number of elements of type [code]#T#.
@@ -10770,10 +10770,10 @@ is contained by that context, otherwise this function throws a synchronous
 a@
 [source]
 ----
-void *sycl::malloc(size_t numBytes,
+void* sycl::malloc(size_t numBytes,
                    const queue& syclQueue,
                    usm::alloc kind,
-                   const property_list &propList = {})
+                   const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#
 and any necessary [code]#device#.
@@ -10784,10 +10784,10 @@ a@
 [source]
 ----
 template <typename T>
-T *sycl::malloc(size_t count,
+T* sycl::malloc(size_t count,
                 const queue& syclQueue,
                 usm::alloc kind,
-                const property_list &propList = {})
+                const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#
 and any necessary [code]#device#.
@@ -10797,12 +10797,12 @@ via an instance of [code]#property_list#.
 a@
 [source]
 ----
-void *sycl::aligned_alloc(size_t alignment,
+void* sycl::aligned_alloc(size_t alignment,
                           size_t numBytes,
                           const device& syclDevice,
                           const context& syclContext,
                           usm::alloc kind,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Returns a [code]#kind# allocation.
 This allocation is specified in bytes and aligned to the
@@ -10826,7 +10826,7 @@ T* sycl::aligned_alloc(size_t alignment,
                        const device& syclDevice,
                        const context& syclContext,
                        usm::alloc kind,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@ Returns a [code]#kind# allocation.
 This allocation is specified in number of elements of type [code]#T# and aligned
@@ -10844,11 +10844,11 @@ is contained by that context, otherwise this function throws a synchronous
 a@
 [source]
 ----
-void *sycl::aligned_alloc(size_t alignment,
+void* sycl::aligned_alloc(size_t alignment,
                           size_t numBytes,
                           const queue& syclQueue,
                           usm::alloc kind,
-                          const property_list &propList = {})
+                          const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#
 and any necessary [code]#device#.
@@ -10863,7 +10863,7 @@ T* sycl::aligned_alloc(size_t alignment,
                        size_t count,
                        const queue& syclQueue,
                        usm::alloc kind,
-                       const property_list &propList = {})
+                       const property_list& propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#
 and any necessary [code]#device#.
@@ -10917,8 +10917,8 @@ are only supported on the host.
 a@
 [source]
 ----
-usm::alloc get_pointer_type(const void *ptr,
-                            const context &syclContext)
+usm::alloc get_pointer_type(const void* ptr,
+                            const context& syclContext)
 ----
 a@ Returns the USM allocation type for [code]#ptr# if [code]#ptr# falls inside
 a valid USM allocation for the context [code]#syclContext#.  Returns
@@ -10928,8 +10928,8 @@ allocation from [code]#syclContext#.
 a@
 [source]
 ----
-device get_pointer_device(const void *ptr,
-                          const context &syclContext)
+device get_pointer_device(const void* ptr,
+                          const context& syclContext)
 ----
 a@ Returns the [code]#device# associated with the USM allocation.  If
 [code]#ptr# points within a USM device or shared allocation for the context
@@ -11117,7 +11117,7 @@ size_t get(int dimension) const
 a@
 [source]
 ----
-size_t &operator[](int dimension)
+size_t& operator[](int dimension)
 ----
    a@ Return the l-value of the specified dimension of the
       [code]#range#.
@@ -11149,7 +11149,7 @@ size_t size() const
 a@
 [source]
 ----
-range operatorOP(const range &lhs, const range &rhs)
+range operatorOP(const range& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -11169,7 +11169,7 @@ is the cast to [code]#size_t#.
 a@
 [source]
 ----
-range operatorOP(const range &lhs, const size_t &rhs)
+range operatorOP(const range& lhs, const size_t& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -11189,7 +11189,7 @@ the operator returns a [code]#bool#, the result is the cast to
 a@
 [source]
 ----
-range &operatorOP(range &lhs, const range &rhs)
+range& operatorOP(range& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
@@ -11202,7 +11202,7 @@ to [code]#size_t#.
 a@
 [source]
 ----
-range &operatorOP(range &lhs, const size_t &rhs)
+range& operatorOP(range& lhs, const size_t& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
@@ -11215,7 +11215,7 @@ operator returns a [code]#bool#, the result is the cast to
 a@
 [source]
 ----
-range operatorOP(const size_t &lhs, const range &rhs)
+range operatorOP(const size_t& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -11235,7 +11235,7 @@ the [code]#lhs# [code]#size_t# and each element of the
 a@
 [source]
 ----
-range operatorOP(const range &rhs)
+range operatorOP(const range& rhs)
 ----
    a@ Where [code]#OP# is: unary [code]#pass:[+]#, unary [code]#-#.
 
@@ -11248,7 +11248,7 @@ the [code]#rhs# SYCL [code]#range#.
 a@
 [source]
 ----
-range & operatorOP(range &rhs)
+range&  operatorOP(range& rhs)
 ----
    a@ Where [code]#OP# is: prefix [code]#pass:[++]#, prefix [code]#--#.
 
@@ -11259,7 +11259,7 @@ of an element-wise [code]#OP# operator on each element of the [code]#rhs#
 a@
 [source]
 ----
-range operatorOP(range &lhs, int)
+range operatorOP(range& lhs, int)
 ----
    a@ Where [code]#OP# is: postfix [code]#pass:[++]#, postfix [code]#--#.
 
@@ -11434,14 +11434,14 @@ id(size_t dim0, size_t dim1, size_t dim2)
 a@
 [source]
 ----
-id(const range<Dimensions> &range)
+id(const range<Dimensions>& range)
 ----
    a@ Construct an [code]#id# from the dimensions of [code]#range#.
 
 a@
 [source]
 ----
-id(const item<Dimensions> &item)
+id(const item<Dimensions>& item)
 ----
    a@ Construct an [code]#id# from [code]#item.get_id()#.
 
@@ -11465,7 +11465,7 @@ size_t get(int dimension) const
 a@
 [source]
 ----
-size_t &operator[](int dimension)
+size_t& operator[](int dimension)
 ----
    a@ Return a reference to the requested dimension of the [code]#id#
       object.
@@ -11497,7 +11497,7 @@ Returns the same value as [code]#get(0)#.
 a@
 [source]
 ----
-id operatorOP(const id &lhs, const id &rhs)
+id operatorOP(const id& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -11513,7 +11513,7 @@ If the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id operatorOP(const id &lhs, const size_t &rhs)
+id operatorOP(const id& lhs, const size_t& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -11529,7 +11529,7 @@ operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id &operatorOP(id &lhs, const id &rhs)
+id& operatorOP(id& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -11544,7 +11544,7 @@ the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id &operatorOP(id &lhs, const size_t &rhs)
+id& operatorOP(id& lhs, const size_t& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -11558,7 +11558,7 @@ returns a [code]#bool# the result is the cast to [code]#size_t#.
 a@
 [source]
 ----
-id operatorOP(const size_t &lhs, const id &rhs)
+id operatorOP(const size_t& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -11574,7 +11574,7 @@ the [code]#lhs# [code]#size_t# and each element of the
 a@
 [source]
 ----
-id operatorOP(const id &rhs)
+id operatorOP(const id& rhs)
 ----
    a@ Where [code]#OP# is: unary [code]#pass:[+]#, unary [code]#-#.
 
@@ -11587,7 +11587,7 @@ the [code]#rhs# SYCL [code]#id#.
 a@
 [source]
 ----
-id & operatorOP(id &rhs)
+id& operatorOP(id& rhs)
 ----
    a@ Where [code]#OP# is: prefix [code]#pass:[++]#, prefix [code]#--#.
 
@@ -11598,7 +11598,7 @@ of an element-wise [code]#OP# operator on each element of the [code]#rhs#
 a@
 [source]
 ----
-id operatorOP(id &lhs, int)
+id operatorOP(id& lhs, int)
 ----
    a@ Where [code]#OP# is: postfix [code]#pass:[++]#, postfix [code]#--#.
 
@@ -12344,7 +12344,7 @@ a@
 [source]
 ----
 template <typename WorkItemFunctionT>
-    void parallel_for_work_item(const WorkItemFunctionT &func) const
+    void parallel_for_work_item(const WorkItemFunctionT& func) const
 ----
    a@ Launch the work-items for this work-group.
 
@@ -12367,7 +12367,7 @@ a@
 ----
 template <typename WorkItemFunctionT>
     void parallel_for_work_item(range<Dimensions>
-    logicalRange, const WorkItemFunctionT &func) const
+    logicalRange, const WorkItemFunctionT& func) const
 ----
    a@ Launch the work-items for this work-group using a logical local range.
       The function object [code]#func# is executed as if the kernel were
@@ -12681,7 +12681,7 @@ a@
 [source]
 ----
 reduction<BufferT, BinaryOperation>(BufferT vars, handler& cgh,
-BinaryOperation combiner, const property_list &propList = {})
+BinaryOperation combiner, const property_list& propList = {})
 ----
    a@ Construct an unspecified object representing a reduction
       of the variable(s) described by [code]#vars# using the combination
@@ -12694,7 +12694,7 @@ a@
 [source]
 ----
 reduction<T, BinaryOperation>(T* var,
-BinaryOperation combiner, const property_list &propList = {})
+BinaryOperation combiner, const property_list& propList = {})
 ----
    a@ Construct an unspecified object representing a reduction
       of the variable described by [code]#var# using the combination
@@ -12705,7 +12705,7 @@ a@
 [source]
 ----
 reduction<T, BinaryOperation>(span<T, Extent> vars,
-BinaryOperation combiner, const property_list &propList = {})
+BinaryOperation combiner, const property_list& propList = {})
 ----
    a@ Available only when [code]#Extent != sycl::dynamic_extent#.
       Construct an unspecified object representing a reduction
@@ -12718,7 +12718,7 @@ a@
 ----
 reduction<BufferT, BinaryOperation>(BufferT vars, handler& cgh,
 const BufferT::value_type& identity, BinaryOperation combiner,
-const property_list &propList = {})
+const property_list& propList = {})
 ----
    a@ Construct an unspecified object representing a reduction
       of the variable(s) described by [code]#vars# using the combination
@@ -12733,7 +12733,7 @@ a@
 [source]
 ----
 reduction<T, BinaryOperation>(T* var, const T& identity,
-BinaryOperation combiner, const property_list &propList = {})
+BinaryOperation combiner, const property_list& propList = {})
 ----
    a@ Construct an unspecified object representing a reduction
       of the variable described by [code]#var# using the combination
@@ -12746,7 +12746,7 @@ a@
 [source]
 ----
 reduction<T, BinaryOperation>(span<T, Extent> vars, const T& identity,
-BinaryOperation combiner, const property_list &propList = {})
+BinaryOperation combiner, const property_list& propList = {})
 ----
    a@ Available only when [code]#Extent != sycl::dynamic_extent#.
       Construct an unspecified object representing a reduction
@@ -13084,7 +13084,7 @@ by [code]#depEvent# must complete before executing this
 a@
 [source]
 ----
-void depends_on(const std::vector<event> &depEvents)
+void depends_on(const std::vector<event>& depEvents)
 ----
 a@ The <<command-group>> now has a *requirement* that the actions represented
 by each event in [code]#depEvents# must complete before executing this
@@ -13120,7 +13120,7 @@ a@
 [source]
 ----
 template <typename T>
-    void set_arg(int argIndex, T &&arg)
+    void set_arg(int argIndex, T&& arg)
 ----
    a@ This function must only be used to set arguments for a kernel that
       was constructed using a backend specific interoperability function
@@ -13133,7 +13133,7 @@ a@
 [source]
 ----
 template <typename... Ts>
-    void set_args(Ts &&... args)
+    void set_args(Ts&&... args)
 ----
    a@ Set all arguments for a given kernel, as if each argument in
       [code]#args# was passed to [code]#set_arg# in the same order and
@@ -13143,7 +13143,7 @@ a@
 [source]
 ----
 template <typename KernelName, typename KernelType>
-    void single_task(const KernelType &kernelFunc)
+    void single_task(const KernelType& kernelFunc)
 ----
    a@ Defines and invokes a <<sycl-kernel-function>> as a lambda function
       or a named function object type.
@@ -13187,7 +13187,7 @@ template <typename KernelName, int Dimensions, typename... Rest>
     void parallel_for(
     range<Dimensions> numWorkItems,
     id<Dimensions> workItemOffset,
-    const KernelType &kernelFunc)
+    const KernelType& kernelFunc)
 // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
@@ -13244,7 +13244,7 @@ a@
 template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
     void parallel_for_work_group(
     range<Dimensions> numWorkGroups,
-    const WorkgroupFunctionType &kernelFunc)
+    const WorkgroupFunctionType& kernelFunc)
 ----
    a@ Defines and invokes a hierarchical kernel as a lambda function
       or a named function object type,
@@ -13266,7 +13266,7 @@ template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
     void parallel_for_work_group(
     range<Dimensions> numWorkGroups,
     range<Dimensions> workGroupSize,
-    const WorkgroupFunctionType &kernelFunc)
+    const WorkgroupFunctionType& kernelFunc)
 ----
    a@ Defines and invokes a hierarchical kernel as a lambda function
       or a named function object type,
@@ -13285,7 +13285,7 @@ template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
 a@
 [source]
 ----
-void single_task(const kernel &kernelObject)
+void single_task(const kernel& kernelObject)
 ----
    a@ This function must only be used to invoke a kernel that was constructed
       using a backend specific interoperability function or to invoke a device
@@ -13308,7 +13308,7 @@ a@
 ----
 template <int Dimensions> void parallel_for(
     range<Dimensions> numWorkItems,
-    const kernel &kernelObject)
+    const kernel& kernelObject)
 ----
    a@ This function must only be used to invoke a kernel that was constructed
       using a backend specific interoperability function or to invoke a device
@@ -13331,7 +13331,7 @@ a@
 ----
 template <int Dimensions> void parallel_for(
     nd_range<Dimensions> executionRange,
-    const kernel &kernelObject)
+    const kernel& kernelObject)
 ----
    a@ This function must only be used to invoke a kernel that was constructed
       using a backend specific interoperability function or to invoke a device
@@ -13634,7 +13634,7 @@ include::{header_dir}/priv.h[lines=4..-1]
 a@
 [source]
 ----
-private_memory(const group<Dimensions> &)
+private_memory(const group<Dimensions>&)
 ----
    a@ Place an object of type [code]#T# in the underlying private memory of each <<work-item,work items>>.
       The type [code]#T# must be default constructible.
@@ -13650,7 +13650,7 @@ private_memory(const group<Dimensions> &)
 a@
 [source]
 ----
-T &operator()(const h_item<Dimensions> &id)
+T& operator()(const h_item<Dimensions>& id)
 ----
    a@ Retrieve a reference to the object for the <<work-item,work items>>.
 
@@ -13814,7 +13814,7 @@ template <typename SrcT, int SrcDims, access_mode SrcMode,
 void copy(accessor<SrcT, SrcDims,
                    SrcMode, SrcTgt,
                    IsPlaceholder> src,
-          DestT * dest)
+          DestT* dest)
 ----
 a@ Copies the contents of the memory object accessed by
 [code]#src# into the memory pointed to by [code]#dest#.
@@ -13827,7 +13827,7 @@ a@
 template <typename SrcT, typename DestT, int DestDims,
           access_mode DestMode, target DestTgt,
           access::placeholder IsPlaceholder>
-void copy(const SrcT * src,
+void copy(const SrcT* src,
           accessor<DestT, DestDims,
                    DestMode, DestTgt,
                    IsPlaceholder> dest)
@@ -14113,8 +14113,8 @@ specialization constant's default value.
 ----
 specialization_id(const specialization_id& rhs) = delete;            // (1)
 specialization_id(specialization_id&& rhs) = delete;                 // (2)
-specialization_id &operator=(const specialization_id& rhs) = delete; // (3)
-specialization_id &operator=(specialization_id&& rhs) = delete;      // (4)
+specialization_id& operator=(const specialization_id& rhs) = delete; // (3)
+specialization_id& operator=(specialization_id&& rhs) = delete;      // (4)
 ----
 
   . Deleted copy constructor.
@@ -14709,7 +14709,7 @@ include::{header_dir}/bundle/kernelIdClass.h[lines=4..-1]
 
 [source]
 ----
-const char *get_name() const noexcept;
+const char* get_name() const noexcept;
 ----
 
 _Returns:_ An implementation-defined null-terminated string containing the
@@ -14777,7 +14777,7 @@ specialization constants in the bundle will have their default values.
 [source]
 ----
 template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 ----
 
 _Returns:_ A kernel bundle in state [code]#State# which contains all of the
@@ -14813,8 +14813,8 @@ _Throws:_
 [source]
 ----
 template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs,
-                                       const std::vector<kernel_id> &kernelIds);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt, const std::vector<device>& devs,
+                                       const std::vector<kernel_id>& kernelIds);
 ----
 
 _Returns:_ A kernel bundle in state [code]#State# which contains all of the
@@ -14858,14 +14858,14 @@ _Throws:_
 [source]
 ----
 template<bundle_state State, typename Selector>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt,
-                                       const std::vector<device> &devs,
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<device>& devs,
                                        Selector selector);
 ----
 
 _Preconditions:_ The [code]#selector# must be a unary predicate whose return
 value is convertible to [code]#bool# and whose parameter is
-[code]#const device_image<State> &#.
+[code]#const device_image<State>&#.
 
 _Effects:_ The predicate function [code]#selector# is called once for every
 device image in the application of state [code]#State# which is compatible
@@ -14910,14 +14910,14 @@ several bundles together with [code]#join()#.
 [source]
 ----
 template<bundle_state State>                       // (1)
-kernel_bundle<State> get_kernel_bundle(const context &ctxt);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt);
 
 template<bundle_state State>                       // (2)
-kernel_bundle<State> get_kernel_bundle(const context &ctxt,
-                                       const std::vector<kernel_id> &kernelIds);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<kernel_id>& kernelIds);
 
 template<bundle_state State, typename Selector>    // (3)
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, Selector selector);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt, Selector selector);
 ----
 
   . Equivalent to [code]#get_kernel_bundle<State>(ctxt, ctxt.get_devices())#.
@@ -14929,10 +14929,10 @@ kernel_bundle<State> get_kernel_bundle(const context &ctxt, Selector selector);
 [source]
 ----
 template<typename KernelName, bundle_state State>  // (1)
-kernel_bundle<State> get_kernel_bundle(const context &ctxt);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt);
 
 template<typename KernelName, bundle_state State>  // (2)
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+kernel_bundle<State> get_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 ----
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
@@ -14958,7 +14958,7 @@ bundle with the requested characteristics exists.
 [source]
 ----
 template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 ----
 
 _Returns:_ [code]#true# only if all of the following are true:
@@ -14983,8 +14983,8 @@ _Throws:_
 [source]
 ----
 template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs,
-                       const std::vector<kernel_id> &kernelIds);
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs,
+                       const std::vector<kernel_id>& kernelIds);
 ----
 
 _Returns:_ [code]#true# only if all of the following are true:
@@ -15010,10 +15010,10 @@ _Throws:_
 [source]
 ----
 template<bundle_state State>                       // (1)
-bool has_kernel_bundle(const context &ctxt);
+bool has_kernel_bundle(const context& ctxt);
 
 template<bundle_state State>                       // (2)
-bool has_kernel_bundle(const context &ctxt, const std::vector<kernel_id> &kernelIds);
+bool has_kernel_bundle(const context& ctxt, const std::vector<kernel_id>& kernelIds);
 ----
 
   . Equivalent to [code]#has_kernel_bundle(ctxt, ctxt.get_devices())#.
@@ -15023,10 +15023,10 @@ bool has_kernel_bundle(const context &ctxt, const std::vector<kernel_id> &kernel
 [source]
 ----
 template<typename KernelName, bundle_state State>  // (1)
-bool has_kernel_bundle(const context &ctxt);
+bool has_kernel_bundle(const context& ctxt);
 
 template<typename KernelName, bundle_state State>  // (2)
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 ----
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
@@ -15060,7 +15060,7 @@ built-in.
 
 [source]
 ----
-bool is_compatible(const std::vector<kernel_id> &kernelIds, const device &dev);
+bool is_compatible(const std::vector<kernel_id>& kernelIds, const device& dev);
 ----
 
 _Returns:_ [code]#true# if all of the kernels identified by [code]#kernelIds#
@@ -15069,7 +15069,7 @@ are compatible with the device [code]#dev#.
 [source]
 ----
 template<typename KernelName>
-bool is_compatible(const device &dev);
+bool is_compatible(const device& dev);
 ----
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
@@ -15096,7 +15096,7 @@ creates a new bundle from the result.
 [source]
 ----
 template<bundle_state State>
-kernel_bundle<State> join(const std::vector<kernel_bundle<State>> &bundles);
+kernel_bundle<State> join(const std::vector<kernel_bundle<State>>& bundles);
 ----
 
 _Returns:_ A new kernel bundle that contains a copy of all the device images in
@@ -15133,9 +15133,9 @@ specify these properties as an extension.
 [source]
 ----
 kernel_bundle<bundle_state::object>
-compile(const kernel_bundle<bundle_state::input> &inputBundle,
-        const std::vector<device> &devs,
-        const property_list &propList = {});
+compile(const kernel_bundle<bundle_state::input>& inputBundle,
+        const std::vector<device>& devs,
+        const property_list& propList = {});
 ----
 
 _Effects:_ The device images from [code]#inputBundle# are translated into one
@@ -15164,9 +15164,9 @@ _Throws:_
 [source]
 ----
 kernel_bundle<bundle_state::executable>
-link(const std::vector<kernel_bundle<bundle_state::object>> &objectBundles,
-     const std::vector<device> &devs,
-     const property_list &propList = {});
+link(const std::vector<kernel_bundle<bundle_state::object>>& objectBundles,
+     const std::vector<device>& devs,
+     const property_list& propList = {});
 ----
 
 _Effects:_ Duplicate device images from [code]#objectBundles# are eliminated
@@ -15201,9 +15201,9 @@ _Throws:_
 [source]
 ----
 kernel_bundle<bundle_state::executable>
-build(const kernel_bundle<bundle_state::input> &inputBundle,
-      const std::vector<device> &devs,
-      const property_list &propList = {});
+build(const kernel_bundle<bundle_state::input>& inputBundle,
+      const std::vector<device>& devs,
+      const property_list& propList = {});
 ----
 
 _Effects:_ This function performs both an online compile and link operation,
@@ -15235,25 +15235,25 @@ _Throws:_
 [source]
 ----
 kernel_bundle<bundle_state::object>                               // (1)
-compile(const kernel_bundle<bundle_state::input> &inputBundle,
-        const property_list &propList = {});
+compile(const kernel_bundle<bundle_state::input>& inputBundle,
+        const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>                           // (2)
-link(const kernel_bundle<bundle_state::object> &objectBundle,
-     const std::vector<device> &devs,
-     const property_list &propList = {});
+link(const kernel_bundle<bundle_state::object>& objectBundle,
+     const std::vector<device>& devs,
+     const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>                           // (3)
-link(const std::vector<kernel_bundle<bundle_state::object>> &objectBundles,
-     const property_list &propList = {});
+link(const std::vector<kernel_bundle<bundle_state::object>>& objectBundles,
+     const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>                           // (4)
-link(const kernel_bundle<bundle_state::object> &objectBundle,
-     const property_list &propList = {});
+link(const kernel_bundle<bundle_state::object>& objectBundle,
+     const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>                           // (5)
-build(const kernel_bundle<bundle_state::input> &inputBundle,
-      const property_list &propList = {});
+build(const kernel_bundle<bundle_state::input>& inputBundle,
+      const property_list& propList = {});
 ----
 
   . Equivalent to
@@ -15327,8 +15327,8 @@ _Returns:_ The set of devices that is associated with the kernel bundle.
 
 [source]
 ----
-bool has_kernel(const kernel_id &kernelId) const noexcept;                     // (1)
-bool has_kernel(const kernel_id &kernelId, const device &dev) const noexcept;  // (2)
+bool has_kernel(const kernel_id& kernelId) const noexcept;                     // (1)
+bool has_kernel(const kernel_id& kernelId, const device& dev) const noexcept;  // (2)
 ----
 
   . _Returns:_ [code]#true# only if the kernel bundle contains the kernel
@@ -15343,7 +15343,7 @@ template<typename KernelName>
 bool has_kernel() const noexcept;                   // (1)
 
 template<typename KernelName>
-bool has_kernel(const device &dev) const noexcept;  // (2)
+bool has_kernel(const device& dev) const noexcept;  // (2)
 ----
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
@@ -15370,7 +15370,7 @@ the kernel bundle.
 
 [source]
 ----
-kernel get_kernel(const kernel_id &kernelId) const;
+kernel get_kernel(const kernel_id& kernelId) const;
 ----
 
 _Preconditions:_ This member function is only available if the kernel bundle's
@@ -15575,7 +15575,7 @@ which it is invoked.
 [source]
 ----
 template <typename Param>
-typename Param::return_type get_info(const device &dev) const;
+typename Param::return_type get_info(const device& dev) const;
 ----
 
 _Preconditions:_ The [code]#Param# must be one of the
@@ -15781,8 +15781,8 @@ There is no public constructor for this class.
 
 [source]
 ----
-bool has_kernel(const kernel_id &kernelId) const noexcept;                     // (1)
-bool has_kernel(const kernel_id &kernelId, const device &dev) const noexcept;  // (2)
+bool has_kernel(const kernel_id& kernelId) const noexcept;                     // (1)
+bool has_kernel(const kernel_id& kernelId, const device& dev) const noexcept;  // (2)
 ----
 
   . _Returns:_ [code]#true# only if the device image contains the kernel
@@ -16291,7 +16291,7 @@ const std::error_category& category() const noexcept
 a@
 [source]
 ----
-const char *what() const
+const char* what() const
 ----
    a@ Returns an implementation-defined non-null constant C-style string that describes the error that triggered the exception.
 
@@ -16612,7 +16612,7 @@ vec()
 a@
 [source]
 ----
-explicit constexpr vec(const DataT &arg)
+explicit constexpr vec(const DataT& arg)
 ----
    a@ Construct a vector of element type [code]#DataT# and
       [code]#NumElements# dimensions by setting each value to [code]#arg# by
@@ -16629,7 +16629,7 @@ constexpr vec(const ArgTN&... args)
 a@
 [source]
 ----
-constexpr vec(const vec<DataT, NumElements> &rhs)
+constexpr vec(const vec<DataT, NumElements>& rhs)
 ----
    a@ Construct a vector of element type [code]#DataT# and number of elements [code]#NumElements# by copy from another similar vector.
 
@@ -16863,28 +16863,28 @@ template <access::address_space AddressSpace, access::decorated IsDecorated>
 a@
 [source]
 ----
-DataT &operator[](int index)
+DataT& operator[](int index)
 ----
    a@ Returns a reference to the element stored within this SYCL [code]#vec# at the index specified by [code]#index#.
 
 a@
 [source]
 ----
-const DataT &operator[](int index) const
+const DataT& operator[](int index) const
 ----
    a@ Returns a const reference to the element stored within this SYCL [code]#vec# at the index specified by [code]#index#.
 
 a@
 [source]
 ----
-vec &operator=(const vec &rhs)
+vec& operator=(const vec& rhs)
 ----
    a@ Assign each element of the [code]#rhs# SYCL [code]#vec# to each element of this SYCL [code]#vec# and return a reference to this SYCL [code]#vec#.
 
 a@
 [source]
 ----
-vec &operator=(const DataT &rhs)
+vec& operator=(const DataT& rhs)
 ----
    a@ Assign each element of the [code]#rhs# scalar to each element of this SYCL [code]#vec# and return a reference to this SYCL [code]#vec#.
 
@@ -16900,7 +16900,7 @@ vec &operator=(const DataT &rhs)
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const vec &rhs)
+vec operatorOP(const vec& lhs, const vec& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16911,7 +16911,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const DataT &rhs)
+vec operatorOP(const vec& lhs, const DataT& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16922,7 +16922,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const vec &rhs)
+vec& operatorOP(vec& lhs, const vec& rhs)
 ----
    a@ If [code]#OP# is [code]#%=#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16933,7 +16933,7 @@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#, [code]#*=#, [code]#/=#, [cod
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const DataT &rhs)
+vec& operatorOP(vec& lhs, const DataT& rhs)
 ----
    a@ If [code]#OP# is [code]#%=#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16944,7 +16944,7 @@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#, [code]#*=#, [code]#/=#, [cod
 a@
 [source]
 ----
-vec &operatorOP(vec &v)
+vec& operatorOP(vec& v)
 ----
    a@ Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and return [code]#lhs# [code]#vec#.
 
@@ -16953,7 +16953,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-vec operatorOP(vec &v, int)
+vec operatorOP(vec& v, int)
 ----
    a@ Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and returns a copy of [code]#lhs# [code]#vec# before the operation is performed.
 
@@ -16962,7 +16962,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-vec operatorOP(const vec &v)
+vec operatorOP(const vec& v)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as this SYCL [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# unary arithmetic operation on each element of this SYCL [code]#vec#.
 
@@ -16971,7 +16971,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#.
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const vec &rhs)
+vec operatorOP(const vec& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16982,7 +16982,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const DataT &rhs)
+vec operatorOP(const vec& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -16993,7 +16993,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const vec &rhs)
+vec& operatorOP(vec& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17004,7 +17004,7 @@ Where [code]#OP# is: [code]#&=#, [code]#|=#, [code]#^=#.
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const DataT &rhs)
+vec& operatorOP(vec& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17015,7 +17015,7 @@ Where [code]#OP# is: [code]#&=#, [code]#|=#, [code]#^=#.
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const vec &lhs, const vec &rhs)
+vec<RET, NumElements> operatorOP(const vec& lhs, const vec& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as [code]#lhs# [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# logical operation between each element of [code]#lhs# [code]#vec# and each element of the [code]#rhs# SYCL [code]#vec#.
 
@@ -17026,7 +17026,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const vec &lhs, const DataT &rhs)
+vec<RET, NumElements> operatorOP(const vec& lhs, const DataT& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as this SYCL [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# logical operation between each element of [code]#lhs# [code]#vec# and the [code]#rhs# scalar.
 
@@ -17037,7 +17037,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const vec &rhs)
+vec operatorOP(const vec& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17048,7 +17048,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-vec operatorOP(const vec &lhs, const DataT &rhs)
+vec operatorOP(const vec& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17059,7 +17059,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const vec &rhs)
+vec& operatorOP(vec& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17070,7 +17070,7 @@ Where [code]#OP# is: [code]#+<<=+#, [code]#>>=#.
 a@
 [source]
 ----
-vec &operatorOP(vec &lhs, const DataT &rhs)
+vec& operatorOP(vec& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17081,7 +17081,7 @@ Where [code]#OP# is: [code]#+<<=+#, [code]#>>=#.
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const vec& lhs, const vec &rhs)
+vec<RET, NumElements> operatorOP(const vec& lhs, const vec& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the element type [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and each element of the [code]#rhs# SYCL [code]#vec#. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false#.  The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=# operations result in [code]#false# if either the [code]#lhs# element or the [code]#rhs# element is a NaN.  The [code]#!=# operation results in [code]#true# if either the [code]#lhs# element or the [code]#rhs# element is a NaN.
 
@@ -17092,7 +17092,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const vec &lhs, const DataT &rhs)
+vec<RET, NumElements> operatorOP(const vec& lhs, const DataT& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the [code]#DataT# parameter of [code]#RET# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#vec# and the [code]#rhs# scalar. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false#.  The [code]#==#, [code]#<#, [code]#>#, [code]#+<=+# and [code]#>=# operations result in [code]#false# if either the [code]#lhs# element or the [code]#rhs# is a NaN.  The [code]#!=# operation results in [code]#true# if either the [code]#lhs# element or the [code]#rhs# is a NaN.
 
@@ -17103,7 +17103,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-vec operatorOP(const DataT &lhs, const vec &rhs)
+vec operatorOP(const DataT& lhs, const vec& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17120,7 +17120,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
 a@
 [source]
 ----
-vec operatorOP(const DataT &lhs, const vec &rhs)
+vec operatorOP(const DataT& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17134,7 +17134,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const DataT &lhs, const vec &rhs)
+vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17150,7 +17150,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-vec operatorOP(const DataT &lhs, const vec &rhs)
+vec operatorOP(const DataT& lhs, const vec& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with
       the same template parameters as the [code]#rhs# SYCL [code]#vec#
@@ -17167,7 +17167,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-vec<RET, NumElements> operatorOP(const DataT &lhs, const vec &rhs)
+vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with
       the element type [code]#RET# with each element of the new SYCL
@@ -17198,7 +17198,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-vec &operator~(const vec &v)
+vec& operator~(const vec& v)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17207,7 +17207,7 @@ Construct a new instance of the SYCL [code]#vec# class template with the same te
 a@
 [source]
 ----
-vec<RET, NumElements> operator!(const vec &v)
+vec<RET, NumElements> operator!(const vec& v)
 ----
    a@ Construct a new instance of the SYCL [code]#vec# class template with the same template parameters as [code]#v# [code]#vec# with each element of the new SYCL [code]#vec# instance the result of an element-wise [code]#OP# logical operation on each element of [code]#v# [code]#vec#. Each element of the SYCL [code]#vec# that is returned must be [code]#-1# if the operation results in [code]#true# and [code]#0# if the operation results in [code]#false# or this SYCL [code]#vec# is a NaN.
 
@@ -17296,9 +17296,9 @@ For example: [code]#f4.xxxx() = fx.wzyx()# would not be valid.
     or escape the expression it was constructed in. For example
     [code]#auto x = f4.x()# would not be valid.
   * The [code]#+__swizzled_vec__+# class template should return
-    [code]#+__swizzled_vec__ &+# for each operator inherited from the
+    [code]#+__swizzled_vec__&+# for each operator inherited from the
     [code]#vec# class template interface which would return
-    [code]#vec<DataT, NumElements> &#.
+    [code]#vec<DataT, NumElements>&#.
 
 
 ==== Rounding modes
@@ -17441,7 +17441,7 @@ marray()
 a@
 [source]
 ----
-explicit constexpr marray(const DataT &arg)
+explicit constexpr marray(const DataT& arg)
 ----
    a@ Construct an array of element type [code]#DataT# and
       [code]#NumElements# dimensions by setting each value to [code]#arg# by
@@ -17458,14 +17458,14 @@ constexpr marray(const ArgTN&... args)
 a@
 [source]
 ----
-constexpr marray(const marray<DataT, NumElements> &rhs)
+constexpr marray(const marray<DataT, NumElements>& rhs)
 ----
    a@ Construct an array of element type [code]#DataT# and number of elements [code]#NumElements# by copy from another similar vector.
 
 a@
 [source]
 ----
-constexpr marray(marray<DataT, NumElements> &&rhs)
+constexpr marray(marray<DataT, NumElements>&& rhs)
 ----
    a@ Construct an array of element type [code]#DataT# and number of elements
       [code]#NumElements# by moving from another similar vector.
@@ -17504,28 +17504,28 @@ static constexpr std::size_t size() noexcept
 a@
 [source]
 ----
-DataT &operator[](std::size_t index)
+DataT& operator[](std::size_t index)
 ----
    a@ Returns a reference to the element stored within this SYCL [code]#marray# at the index specified by [code]#index#.
 
 a@
 [source]
 ----
-const DataT &operator[](std::size_t index) const
+const DataT& operator[](std::size_t index) const
 ----
    a@ Returns a const reference to the element stored within this SYCL [code]#marray# at the index specified by [code]#index#.
 
 a@
 [source]
 ----
-marray &operator=(const marray &rhs)
+marray& operator=(const marray& rhs)
 ----
    a@ Assign each element of the [code]#rhs# SYCL [code]#marray# to each element of this SYCL [code]#marray# and return a reference to this SYCL [code]#marray#.
 
 a@
 [source]
 ----
-marray &operator=(const DataT &rhs)
+marray& operator=(const DataT& rhs)
 ----
    a@ Assign each element of the [code]#rhs# scalar to each element of this SYCL [code]#marray# and return a reference to this SYCL [code]#marray#.
 
@@ -17570,7 +17570,7 @@ const_iterator end() const
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const marray &rhs)
+marray operatorOP(const marray& lhs, const marray& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17581,7 +17581,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const DataT &rhs)
+marray operatorOP(const marray& lhs, const DataT& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17592,7 +17592,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const marray &rhs)
+marray& operatorOP(marray& lhs, const marray& rhs)
 ----
    a@ If [code]#OP# is [code]#%=#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17603,7 +17603,7 @@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#, [code]#*=#, [code]#/=#, [cod
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const DataT &rhs)
+marray& operatorOP(marray& lhs, const DataT& rhs)
 ----
    a@ If [code]#OP# is [code]#%=#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17614,7 +17614,7 @@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#, [code]#*=#, [code]#/=#, [cod
 a@
 [source]
 ----
-marray &operatorOP(marray &v)
+marray& operatorOP(marray& v)
 ----
    a@ Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#lhs# [code]#marray#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#marray# and return [code]#lhs# [code]#marray#.
 
@@ -17623,7 +17623,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-marray operatorOP(marray &v, int)
+marray operatorOP(marray& v, int)
 ----
    a@ Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#lhs# [code]#marray#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#marray# and returns a copy of [code]#lhs# [code]#marray# before the operation is performed.
 
@@ -17632,7 +17632,7 @@ Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 a@
 [source]
 ----
-marray operatorOP(marray &v)
+marray operatorOP(marray& v)
 ----
    a@ Construct a new instance of the SYCL [code]#marray# class template with the same template parameters as this SYCL [code]#marray# with each element of the new SYCL [code]#marray# instance the result of an element-wise [code]#OP# unary arithmetic operation on each element of this SYCL [code]#marray#.
 
@@ -17641,7 +17641,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#.
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const marray &rhs)
+marray operatorOP(const marray& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17652,7 +17652,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const DataT &rhs)
+marray operatorOP(const marray& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17663,7 +17663,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const marray &rhs)
+marray& operatorOP(marray& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17674,7 +17674,7 @@ Where [code]#OP# is: [code]#&=#, [code]#|=#, [code]#^=#.
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const DataT &rhs)
+marray& operatorOP(marray& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17685,7 +17685,7 @@ Where [code]#OP# is: [code]#&=#, [code]#|=#, [code]#^=#.
 a@
 [source]
 ----
-marray<bool, NumElements> operatorOP(const marray &lhs, const marray &rhs)
+marray<bool, NumElements> operatorOP(const marray& lhs, const marray& rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray# with each element of the new [code]#marray# instance the result of an element-wise [code]#OP# logical operation between each element of [code]#lhs# [code]#marray# and each element of the [code]#rhs# [code]#marray#.
 
@@ -17694,7 +17694,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-marray<bool, NumElements> operatorOP(const marray &lhs, const DataT &rhs)
+marray<bool, NumElements> operatorOP(const marray& lhs, const DataT& rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray# with each element of the new [code]#marray# instance the result of an element-wise [code]#OP# logical operation between each element of [code]#lhs# [code]#marray# and the [code]#rhs# scalar.
 
@@ -17703,7 +17703,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const marray &rhs)
+marray operatorOP(const marray& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17714,7 +17714,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-marray operatorOP(const marray &lhs, const DataT &rhs)
+marray operatorOP(const marray& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17725,7 +17725,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const marray &rhs)
+marray& operatorOP(marray& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17736,7 +17736,7 @@ Where [code]#OP# is: [code]#+<<=+#, [code]#>>=#.
 a@
 [source]
 ----
-marray &operatorOP(marray &lhs, const DataT &rhs)
+marray& operatorOP(marray& lhs, const DataT& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17747,7 +17747,7 @@ Where [code]#OP# is: [code]#+<<=+#, [code]#>>=#.
 a@
 [source]
 ----
-marray<bool, NumElements> operatorOP(const marray& lhs, const marray &rhs)
+marray<bool, NumElements> operatorOP(const marray& lhs, const marray& rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
       with each element of the new [code]#marray# instance is the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#marray#
@@ -17763,7 +17763,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-marray<bool, NumElements> operatorOP(const marray &lhs, const DataT &rhs)
+marray<bool, NumElements> operatorOP(const marray& lhs, const DataT& rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
       with each element of the new [code]#marray# instance the result of an element-wise [code]#OP# relational operation between each element of [code]#lhs# [code]#marray#
@@ -17779,7 +17779,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-marray operatorOP(const DataT &lhs, const marray &rhs)
+marray operatorOP(const DataT& lhs, const marray& rhs)
 ----
    a@ If [code]#OP# is [code]#%#, available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17796,7 +17796,7 @@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
 a@
 [source]
 ----
-marray operatorOP(const DataT &lhs, const marray &rhs)
+marray operatorOP(const DataT& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17810,7 +17810,7 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-marray<RET, NumElements> operatorOP(const DataT &lhs, const marray &rhs)
+marray<RET, NumElements> operatorOP(const DataT& lhs, const marray& rhs)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17824,7 +17824,7 @@ Where [code]#OP# is: [code]#&&#, [code]#||#.
 a@
 [source]
 ----
-marray operatorOP(const DataT &lhs, const marray &rhs)
+marray operatorOP(const DataT& lhs, const marray& rhs)
 ----
    a@ Construct a new instance of the SYCL [code]#marray# class template with
       the same template parameters as the [code]#rhs# SYCL [code]#marray#
@@ -17841,7 +17841,7 @@ Where [code]#OP# is: [code]#<<#, [code]#>>#.
 a@
 [source]
 ----
-marray<bool, NumElements> operatorOP(const DataT &lhs, const marray &rhs)
+marray<bool, NumElements> operatorOP(const DataT& lhs, const marray& rhs)
 ----
    a@ Construct a new instance of the [code]#marray# class template with
       [code]#DataT = bool# and same NumElements as [code]#lhs# [code]#marray#
@@ -17858,7 +17858,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-marray &operator~(const marray &v)
+marray& operator~(const marray& v)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -17867,7 +17867,7 @@ Construct a new instance of the SYCL [code]#marray# class template with the same
 a@
 [source]
 ----
-marray<bool, NumElements> operator!(const marray &v)
+marray<bool, NumElements> operator!(const marray& v)
 ----
    a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and same NumElements as [code]#v# [code]#marray#
       with each element of the new [code]#marray# instance the result of an element-wise logical [code]#!# operation on each element of [code]#v# [code]#marray#.
@@ -18181,7 +18181,7 @@ T exchange(T operand,
 a@
 [source]
 ----
-bool compare_exchange_weak(T &expected, T desired,
+bool compare_exchange_weak(T& expected, T desired,
     memory_order success,
     memory_order failure,
     memory_scope scope = default_scope) const
@@ -18204,7 +18204,7 @@ This function is only supported for 64-bit data types on devices that have
 a@
 [source]
 ----
-bool compare_exchange_weak(T &expected, T desired,
+bool compare_exchange_weak(T& expected, T desired,
     memory_order order = default_read_modify_write_order,
     memory_scope scope = default_scope) const
 ----
@@ -18213,7 +18213,7 @@ bool compare_exchange_weak(T &expected, T desired,
 a@
 [source]
 ----
-bool compare_exchange_strong(T &expected, T desired,
+bool compare_exchange_strong(T& expected, T desired,
     memory_order success,
     memory_order failure,
     memory_scope scope = default_scope) const
@@ -18235,7 +18235,7 @@ This function is only supported for 64-bit data types on devices that have
 a@
 [source]
 ----
-bool compare_exchange_strong(T &expected, T desired,
+bool compare_exchange_strong(T& expected, T desired,
     memory_order order =
     default_read_modify_write_order) const
 ----
@@ -18665,7 +18665,7 @@ types on devices that have [code]#aspect::atomic64#.
 a@
 [source]
 ----
-bool compare_exchange_strong(T &expected, T desired,
+bool compare_exchange_strong(T& expected, T desired,
     memory_order successMemoryOrder =
     memory_order::relaxed,
     memory_order failMemoryOrder =
@@ -18863,7 +18863,7 @@ a@
 ----
 template <typename T, access::address_space AddressSpace>
 bool atomic_compare_exchange_strong(
-    atomic<T, AddressSpace> object, T &expected, T desired,
+    atomic<T, AddressSpace> object, T& expected, T desired,
     memory_order successMemoryOrder =
     memory_order::relaxed
     memory_order failMemoryOrder =
@@ -19041,14 +19041,14 @@ float, double, half
 a@
 [source]
 ----
-char *, const char *
+char*, const char*
 ----
    a@ Outputs the string.
 
 a@
 [source]
 ----
-T *, const T *, multi_ptr
+T*, const T*, multi_ptr
 ----
    a@ Outputs the address of the pointer as a stream of characters.
 
@@ -19198,7 +19198,7 @@ a@
 stream(size_t totalBufferSize,
        size_t workItemBufferSize,
        handler& cgh,
-       const property_list &propList = {})
+       const property_list& propList = {})
 ----
    a@ Constructs a SYCL [code]#stream# instance associated with the command group
       specified by [code]#cgh#, with a maximum buffer size in bytes per kernel
@@ -19255,7 +19255,7 @@ size_t get_max_statement_size() const
 a@
 [source]
 ----
-template <typename T> const stream& operator<<(const stream& os, const T &rhs)
+template <typename T> const stream& operator<<(const stream& os, const T& rhs)
 ----
    a@ Outputs any valid values (see <<table.operands.stream>>) as a stream of characters and applies any valid manipulator (see <<table.manipulators.stream>>) to the current stream.
 

--- a/adoc/code/algorithms.cpp
+++ b/adoc/code/algorithms.cpp
@@ -9,30 +9,27 @@ buffer<int> outputBuf { 2 };
   std::iota(a.begin(), a.end(), 0);
 }
 
-myQueue.submit([&](handler & cgh) {
-
+myQueue.submit([&](handler& cgh) {
   accessor inputValues { inputBuf, cgh, read_only };
   accessor outputValues { outputBuf, cgh, write_only, no_init };
 
-  cgh.parallel_for(nd_range<1>(range<1>(16), range<1>(16)),
-    [=] (nd_item<1> it) {
+  cgh.parallel_for(nd_range<1>(range<1>(16), range<1>(16)), [=](nd_item<1> it) {
+    // Apply a group algorithm to any number of values, described by an iterator
+    // range. The work-group reduces all inputValues and each work-item works on
+    // part of the range.
+    int* first = inputValues.get_pointer();
+    int* last = first + 1024;
+    int sum = joint_reduce(it.get_group(), first, last, plus<>());
+    outputValues[0] = sum;
 
-      // Apply a group algorithm to any number of values, described by an iterator range.
-      // The work-group reduces all inputValues and each work-item works on part of the
-      // range.
-      int* first = inputValues.get_pointer();
-      int* last = first + 1024;
-      int sum = joint_reduce(it.get_group(), first, last, plus<>());
-      outputValues[0] = sum;
-
-      // Apply a group algorithm to a set of values held directly by work-items.
-      // The work-group reduces a number of values equal to the size of the group and each
-      // work-item provides one value.
-      int partial_sum =
-        reduce_over_group(it.get_group(), inputValues[it.get_global_linear_id()], plus<>());
-      outputValues[1] = partial_sum;
-
-    });
+    // Apply a group algorithm to a set of values held directly by work-items.
+    // The work-group reduces a number of values equal to the size of the group
+    // and each work-item provides one value.
+    int partial_sum = reduce_over_group(
+        it.get_group(), inputValues[it.get_global_linear_id()], plus<>());
+    outputValues[1] = partial_sum;
+  });
 });
 
-assert(outputBuf.get_host_access()[0] == 523776 && outputBuf.get_host_access()[1] == 120);
+assert(outputBuf.get_host_access()[0] == 523776 &&
+       outputBuf.get_host_access()[1] == 120);

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -6,7 +6,7 @@
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
-  int data[1024];  // Allocate data to be worked on
+  int data[1024]; // Allocate data to be worked on
 
   // Create a default queue to enqueue work to the default device
   queue myQueue;
@@ -27,9 +27,9 @@ int main() {
       cgh.parallel_for(1024, [=](id<1> idx) {
         // Initialize each buffer element with its own rank number starting at 0
         writeResult[idx] = idx;
-      });  // End of the kernel function
-    });    // End of our commands for this queue
-  }        // End of scope, so we wait for work producing resultBuf to complete
+      }); // End of the kernel function
+    });   // End of our commands for this queue
+  }       // End of scope, so we wait for work producing resultBuf to complete
 
   // Print result
   for (int i = 0; i < 1024; i++)

--- a/adoc/code/aspectTraitExample.cpp
+++ b/adoc/code/aspectTraitExample.cpp
@@ -6,8 +6,7 @@ using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 constexpr int N = 512;
 
-template<bool HasFp16>
-class MyKernel {
+template <bool HasFp16> class MyKernel {
  public:
   void operator()(id<1> i) {
     if constexpr (HasFp16) {
@@ -23,9 +22,11 @@ int main() {
   myQueue.submit([&](handler& cgh) {
     device dev = myQueue.get_device();
     if (dev.has(aspect::fp16)) {
-      cgh.parallel_for(range{N}, MyKernel<any_device_has_v<aspect::fp16>>{});
+      cgh.parallel_for(range { N },
+                       MyKernel<any_device_has_v<aspect::fp16>> {});
     } else {
-      cgh.parallel_for(range{N}, MyKernel<all_devices_have_v<aspect::fp16>>{});
+      cgh.parallel_for(range { N },
+                       MyKernel<all_devices_have_v<aspect::fp16>> {});
     }
   });
 

--- a/adoc/code/attributes.cpp
+++ b/adoc/code/attributes.cpp
@@ -2,25 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Kernel defined as a lambda
-myQueue.submit([&](handler &h) {
- h.parallel_for( range<1>(16),
-      [=] (item<1> it) [[sycl::reqd_work_group_size(16)]] {
-        //[kernel code]
-      });
+myQueue.submit([&](handler& h) {
+  h.parallel_for(range<1>(16),
+                 [=](item<1> it) [[sycl::reqd_work_group_size(16)]] {
+                   //[kernel code]
+                 });
 });
 
 // Kernel defined as a named function object
 class KernelFunctor1 {
-  public:
-  [[sycl::reqd_work_group_size(16)]]
-  void operator() (item<1> it) const {
+ public:
+  [[sycl::reqd_work_group_size(16)]] void operator()(item<1> it) const {
     //[kernel code]
   };
 };
 
 // Kernel defined as a named function object
 class KernelFunctor2 {
-  public:
+ public:
   void operator() [[sycl::reqd_work_group_size(16)]] (item<1> it) const {
     //[kernel code]
   };

--- a/adoc/code/basicParallelForGeneric.cpp
+++ b/adoc/code/basicParallelForGeneric.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-    auto acc = myBuffer.get_access<access_mode::write>(cgh);
+myQueue.submit([&](handler& cgh) {
+  auto acc = myBuffer.get_access<access_mode::write>(cgh);
 
-    cgh.parallel_for(range<1>(numWorkItems),
-                     [=] (auto item) {
-        // kernel argument type is auto treated as an item
-        size_t index = item.get_linear_id();
-        acc[index] = index;
-    });
+  cgh.parallel_for(range<1>(numWorkItems), [=](auto item) {
+    // kernel argument type is auto treated as an item
+    size_t index = item.get_linear_id();
+    acc[index] = index;
+  });
 });

--- a/adoc/code/basicParallelForIntegral.cpp
+++ b/adoc/code/basicParallelForIntegral.cpp
@@ -1,12 +1,11 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-    auto acc = myBuffer.get_access<access_mode::write>(cgh);
+myQueue.submit([&](handler& cgh) {
+  auto acc = myBuffer.get_access<access_mode::write>(cgh);
 
-    cgh.parallel_for(range<1>(numWorkItems),
-                     [=] (size_t index) {
-        // kernel argument type is size_t
-        acc[index] = index;
-    });
+  cgh.parallel_for(range<1>(numWorkItems), [=](size_t index) {
+    // kernel argument type is size_t
+    acc[index] = index;
+  });
 });

--- a/adoc/code/basicParallelForItem.cpp
+++ b/adoc/code/basicParallelForItem.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-    accessor acc { myBuffer, cgh, write_only };
+myQueue.submit([&](handler& cgh) {
+  accessor acc { myBuffer, cgh, write_only };
 
-    cgh.parallel_for(range<1>(numWorkItems),
-                     [=] (item<1> item) {
-        // kernel argument type is item
-        size_t index = item.get_linear_id();
-        acc[index] = index;
-    });
+  cgh.parallel_for(range<1>(numWorkItems), [=](item<1> item) {
+    // kernel argument type is item
+    size_t index = item.get_linear_id();
+    acc[index] = index;
+  });
 });

--- a/adoc/code/basicParallelForNumber.cpp
+++ b/adoc/code/basicParallelForNumber.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-    auto acc = myBuffer.get_access<access_mode::write>(cgh);
+myQueue.submit([&](handler& cgh) {
+  auto acc = myBuffer.get_access<access_mode::write>(cgh);
 
-    // parallel_for may be called with number (with numWorkItems)
-    cgh.parallel_for(numWorkItems,
-                     [=] (auto item) {
-        size_t index = item.get_linear_id();
-        acc[index] = index;
-    });
+  // parallel_for may be called with number (with numWorkItems)
+  cgh.parallel_for(numWorkItems, [=](auto item) {
+    size_t index = item.get_linear_id();
+    acc[index] = index;
+  });
 });

--- a/adoc/code/basicparallelfor.cpp
+++ b/adoc/code/basicparallelfor.cpp
@@ -1,11 +1,9 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-    accessor acc { myBuffer, cgh, write_only };
+myQueue.submit([&](handler& cgh) {
+  accessor acc { myBuffer, cgh, write_only };
 
-    cgh.parallel_for(range<1>(numWorkItems),
-                     [=] (id<1> index) {
-        acc[index] = 42.0f;
-    });
+  cgh.parallel_for(range<1>(numWorkItems),
+                   [=](id<1> index) { acc[index] = 42.0f; });
 });

--- a/adoc/code/bundle-builtin-kernel.cpp
+++ b/adoc/code/bundle-builtin-kernel.cpp
@@ -15,7 +15,7 @@ int main() {
   // Get an executable kernel_bundle containing all the built-in kernels
   // supported by the device.
   kernel_bundle<bundle_state::executable> myBundle =
-      get_kernel_bundle(myContext, {myDevice}, builtinKernelIds);
+      get_kernel_bundle(myContext, { myDevice }, builtinKernelIds);
 
   // Retrieve a kernel object that can be used to query for more information
   // about the built-in kernel or to submit it to a command group.  We assume
@@ -23,10 +23,10 @@ int main() {
   kernel builtinKernel = myBundle.get_kernel(builtinKernelIds[0]);
 
   // Submit the built-in kernel.
-  myQueue.submit([&](handler &cgh) {
+  myQueue.submit([&](handler& cgh) {
     // Setting the arguments depends on the backend and the exact kernel used.
     cgh.set_args(...);
-    cgh.parallel_for(range{1024}, builtinKernel);
+    cgh.parallel_for(range { 1024 }, builtinKernel);
   });
 
   myQueue.wait();

--- a/adoc/code/bundle-kernel-introspection.cpp
+++ b/adoc/code/bundle-kernel-introspection.cpp
@@ -14,27 +14,29 @@ int main() {
 
   // Get an executable kernel bundle containing our kernel.
   kernel_id kernelId = get_kernel_id<MyKernel>();
-  auto myBundle = get_kernel_bundle<bundle_state::executable>(myContext, {kernelId});
+  auto myBundle =
+      get_kernel_bundle<bundle_state::executable>(myContext, { kernelId });
 
   // Get the kernel's maximum work group size when running on our device.
   kernel myKernel = myBundle.get_kernel(kernelId);
-  size_t maxWgSize = myKernel.get_info<info::kernel_device_specific::work_group_size>(myDev);
+  size_t maxWgSize =
+      myKernel.get_info<info::kernel_device_specific::work_group_size>(myDev);
 
   // Compute a good ND-range to use for iteration in the kernel
   // based on the maximum work group size.
-  std::array<size_t, 11> divisors = {1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1};
-  size_t wgSize = *std::find_if(divisors.begin(), divisors.end(), [=](auto d) {
-    return (d <= maxWgSize);
-  });
-  nd_range myRange {range{N}, range{wgSize}};
+  std::array<size_t, 11> divisors = { 1024, 512, 256, 128, 64, 32,
+                                      16,   8,   4,   2,   1 };
+  size_t wgSize = *std::find_if(divisors.begin(), divisors.end(),
+                                [=](auto d) { return (d <= maxWgSize); });
+  nd_range myRange { range { N }, range { wgSize } };
 
   myQueue.submit([&](handler& cgh) {
     // Use the kernel bundle we queried, so we are sure the queried work-group
     // size matches the kernel we run.
     cgh.use_kernel_bundle(myBundle);
     cgh.parallel_for<MyKernel>(myRange, ([=](nd_item<1> index) {
-      // kernel code
-    }));
+                                 // kernel code
+                               }));
   });
 
   myQueue.wait();

--- a/adoc/code/bundle-pre-compile.cpp
+++ b/adoc/code/bundle-pre-compile.cpp
@@ -18,9 +18,9 @@ int main() {
     // pre-compiled kernel from "myBundle".
     cgh.use_kernel_bundle(myBundle);
 
-    cgh.parallel_for(range{1024}, ([=](item index) {
-      // kernel code
-    }));
+    cgh.parallel_for(range { 1024 }, ([=](item index) {
+                       // kernel code
+                     }));
   });
 
   myQueue.wait();

--- a/adoc/code/bundle-spec-constants.cpp
+++ b/adoc/code/bundle-spec-constants.cpp
@@ -21,8 +21,9 @@ int main() {
 
   // Get the identifiers for our kernels, then get an input kernel bundle that
   // contains our two kernels.
-  auto kernelIds = {get_kernel_id<MyKernel1>(), get_kernel_id<MyKernel2>()};
-  auto inputBundle = get_kernel_bundle<bundle_state::input>(myContext, kernelIds);
+  auto kernelIds = { get_kernel_id<MyKernel1>(), get_kernel_id<MyKernel2>() };
+  auto inputBundle =
+      get_kernel_bundle<bundle_state::input>(myContext, kernelIds);
 
   // Set the values of the specialization constants.
   inputBundle.set_specialization_constant<width>(get_width());
@@ -35,20 +36,22 @@ int main() {
   myQueue.submit([&](handler& cgh) {
     // Use the kernel bundle we built in this command group.
     cgh.use_kernel_bundle(exeBundle);
-    cgh.parallel_for<MyKernel1>(range{1024}, ([=](item index, kernel_handler kh) {
-      // Read the value of the specialization constant.
-      int w = kh.get_specialization_constant<width>();
-      // ...
-    }));
+    cgh.parallel_for<MyKernel1>(
+        range { 1024 }, ([=](item index, kernel_handler kh) {
+          // Read the value of the specialization constant.
+          int w = kh.get_specialization_constant<width>();
+          // ...
+        }));
   });
 
   myQueue.submit([&](handler& cgh) {
     // This command group uses the same kernel bundle.
     cgh.use_kernel_bundle(exeBundle);
-    cgh.parallel_for<MyKernel2>(range{1024}, ([=](item index, kernel_handler kh) {
-      int h = kh.get_specialization_constant<height>();
-      // ...
-    }));
+    cgh.parallel_for<MyKernel2>(
+        range { 1024 }, ([=](item index, kernel_handler kh) {
+          int h = kh.get_specialization_constant<height>();
+          // ...
+        }));
   });
 
   myQueue.wait();

--- a/adoc/code/deviceHas.cpp
+++ b/adoc/code/deviceHas.cpp
@@ -3,21 +3,20 @@
 
 class KernelFunctor {
  public:
-  [[sycl::device_has(aspect::fp16)]]
-  void operator()(item<1> it) const {
+  [[sycl::device_has(aspect::fp16)]] void operator()(item<1> it) const {
     foo();
     bar();
   };
 
  private:
   void foo() const {
-    half fp = 1.0;  // No compiler diagnostic here
+    half fp = 1.0; // No compiler diagnostic here
   }
 
   void bar() const {
     sycl::atomic_ref longAtomic(longValue);
-    longAtomic.fetchAdd(1);   // ERROR: Compiler issues diagnostic because
-                              // "aspect::atomic64" missing from "device_has()"
+    longAtomic.fetchAdd(1); // ERROR: Compiler issues diagnostic because
+                            // "aspect::atomic64" missing from "device_has()"
   }
 };
 
@@ -25,7 +24,6 @@ class KernelFunctor {
 // actually supports the required features.  Therefore, the host code should
 // still check the device's aspects before submitting the kernel.
 if (myQueue.get_device().has(aspect::fp16)) {
-  myQueue.submit([&](handler &h) {
-    h.parallel_for(range{16}, KernelFunctor{});
-  });
+  myQueue.submit(
+      [&](handler& h) { h.parallel_for(range { 16 }, KernelFunctor {}); });
 }

--- a/adoc/code/explicitcopy.cpp
+++ b/adoc/code/explicitcopy.cpp
@@ -13,7 +13,7 @@ sycl::buffer<int, 1> b { range<1>(nElems) };
 // Create a queue
 queue myQueue;
 
-myQueue.submit([&](handler &cgh) {
+myQueue.submit([&](handler& cgh) {
   // Retrieve a ranged write accessor to a global buffer with access to the
   // first half of the buffer
   accessor acc { b, cgh, range<1>(nElems / 2), id<1>(0), write_only };

--- a/adoc/code/handlingBackendErrorCode.cpp
+++ b/adoc/code/handlingBackendErrorCode.cpp
@@ -4,23 +4,20 @@
 void catch_backend_errors(sycl::context const& ctx) {
   try {
     do_something_to_invoke_error(ctx);
-  }
-  catch(sycl::exception const& e) {
-    if(e.category() == sycl::error_category_for<sycl::backend::opencl>()) {
-      switch(e.code().value()) {
-        case CL_INVALID_PROGRAM:
-          std::cerr << "OpenCL invalid program error: " << e.what();
+  } catch (sycl::exception const& e) {
+    if (e.category() == sycl::error_category_for<sycl::backend::opencl>()) {
+      switch (e.code().value()) {
+      case CL_INVALID_PROGRAM:
+        std::cerr << "OpenCL invalid program error: " << e.what();
         /* ...*/
       }
       else {
         throw;
       }
-    }
-    else {
-      if(e.code() == sycl::errc::invalid) {
+    } else {
+      if (e.code() == sycl::errc::invalid) {
         std::cerr << "Invalid error: " << e.what();
-      }
-      else {
+      } else {
         throw;
       }
     }

--- a/adoc/code/handlingErrorCode.cpp
+++ b/adoc/code/handlingErrorCode.cpp
@@ -4,12 +4,10 @@
 void catch_invalid_errors(sycl::context const& ctx) {
   try {
     do_something_to_invoke_error(ctx);
-  }
-  catch(sycl::exception const& e) {
-    if(e.code() == sycl::errc::invalid) {
+  } catch (sycl::exception const& e) {
+    if (e.code() == sycl::errc::invalid) {
       std::cerr << "Invalid error: " << e.what();
-    }
-    else {
+    } else {
       throw;
     }
   }

--- a/adoc/code/handlingException.cpp
+++ b/adoc/code/handlingException.cpp
@@ -4,8 +4,7 @@
 void catch_any_errors(sycl::context const& ctx) {
   try {
     do_something_to_invoke_error(ctx);
-  }
-  catch(sycl::exception const& e) {
+  } catch (sycl::exception const& e) {
     std::cerr << e.what();
   }
 }

--- a/adoc/code/lambdaNameExamples.cpp
+++ b/adoc/code/lambdaNameExamples.cpp
@@ -4,54 +4,52 @@
 // Explicit kernel names can be optionally forward declared at namespace scope
 class MyForwardDeclName;
 
-template <typename T>
-class MyTemplatedKernelName;
+template <typename T> class MyTemplatedKernelName;
 
 // Define and launch templated kernel
-template <typename T>
-void templatedFunction() {
+template <typename T> void templatedFunction() {
   queue myQueue;
 
   // Launch A: No explicit kernel name
   myQueue.submit([&](handler& h) {
-      h.single_task([=]{
-          // [kernel code that depends on type T]
-          });
-      });
+    h.single_task([=] {
+      // [kernel code that depends on type T]
+    });
+  });
 
   // Launch B: Name the kernel when invoking (this is optional)
   myQueue.submit([&](handler& h) {
-      h.single_task<MyTemplatedKernelName<T>>([=]{
-          // The provided kernel name (MyTemplatedKernelName<T>) depends on T
-          // because the kernel does.  T must also be forward declarable at
-          // namespace scope.
+    h.single_task<MyTemplatedKernelName<T>>([=] {
+      // The provided kernel name (MyTemplatedKernelName<T>) depends on T
+      // because the kernel does.  T must also be forward declarable at
+      // namespace scope.
 
-          // [kernel code that depends on type T]
-          });
-      });
+      // [kernel code that depends on type T]
+    });
+  });
 }
 
 int main() {
   queue myQueue;
 
   myQueue.submit([&](handler& h) {
-      // Declare MyKernel within this kernel invocation.  Legal because
-      // forward declaration at namespace scope is optional
-      h.single_task<class MyKernel>([=]{
-          // [kernel code]
-          });
-      });
+    // Declare MyKernel within this kernel invocation.  Legal because
+    // forward declaration at namespace scope is optional
+    h.single_task<class MyKernel>([=] {
+      // [kernel code]
+    });
+  });
 
   myQueue.submit([&](handler& h) {
-      // Use kernel name that was forward declared at namespace scope
-      h.single_task<MyForwardDeclName>([=]{
-          // [kernel code]
-          });
-      });
+    // Use kernel name that was forward declared at namespace scope
+    h.single_task<MyForwardDeclName>([=] {
+      // [kernel code]
+    });
+  });
 
-  templatedFunction<int>();  // OK
+  templatedFunction<int>(); // OK
 
-  templatedFunction<std::complex<float>>();  // Launch A is OK, Launch B illegal
+  templatedFunction<std::complex<float>>(); // Launch A is OK, Launch B illegal
   // because std::complex is not forward declarable according to C++, and was
   // used in an explicit kernel name which must be forward declarable.
 }

--- a/adoc/code/largesample.cpp
+++ b/adoc/code/largesample.cpp
@@ -14,9 +14,9 @@ int main() {
   queue myQueue;
 
   // Create some 2D buffers of float for our matrices
-  buffer<float, 2> a { range<2>{N, M} };
-  buffer<float, 2> b { range<2>{N, M} };
-  buffer<float, 2> c { range<2>{N, M} };
+  buffer<float, 2> a { range<2> { N, M } };
+  buffer<float, 2> b { range<2> { N, M } };
+  buffer<float, 2> c { range<2> { N, M } };
 
   // Launch an asynchronous kernel to initialize a
   myQueue.submit([&](handler& cgh) {
@@ -24,9 +24,8 @@ int main() {
     accessor A { a, cgh, write_only };
 
     // Enqueue a parallel kernel iterating on a N*M 2D iteration space
-    cgh.parallel_for(range<2> {N, M}, [=](id<2> index) {
-      A[index] = index[0] * 2 + index[1];
-    });
+    cgh.parallel_for(range<2> { N, M },
+                     [=](id<2> index) { A[index] = index[0] * 2 + index[1]; });
   });
 
   // Launch an asynchronous kernel to initialize b
@@ -39,7 +38,7 @@ int main() {
     // scheduled independently
 
     // Enqueue a parallel kernel iterating on a N*M 2D iteration space
-    cgh.parallel_for(range<2> {N, M}, [=](id<2> index) {
+    cgh.parallel_for(range<2> { N, M }, [=](id<2> index) {
       B[index] = index[0] * 2014 + index[1] * 42;
     });
   });
@@ -55,10 +54,9 @@ int main() {
     // this kernel is run, the kernels computing a and b have completed
 
     // Enqueue a parallel kernel iterating on a N*M 2D iteration space
-    cgh.parallel_for(range<2> {N, M}, [=](id<2> index) {
-        C[index] = A[index] + B[index];
-     });
-    });
+    cgh.parallel_for(range<2> { N, M },
+                     [=](id<2> index) { C[index] = A[index] + B[index]; });
+  });
 
   // Ask for an accessor to read c from application scope.  The SYCL runtime
   // waits for c to be ready before returning from the constructor

--- a/adoc/code/myfunctor.cpp
+++ b/adoc/code/myfunctor.cpp
@@ -18,10 +18,10 @@ class RandomFiller {
 };
 
 void workFunction(buffer<int, 1>& b, queue& q, const range<1> r) {
-    myQueue.submit([&](handler& cgh) {
-      accessor ptr { buf, cgh };
-      RandomFiller filler { ptr };
+  myQueue.submit([&](handler& cgh) {
+    accessor ptr { buf, cgh };
+    RandomFiller filler { ptr };
 
-      cgh.parallel_for(r, filler);
-    });
+    cgh.parallel_for(r, filler);
+  });
 }

--- a/adoc/code/mykernel.cpp
+++ b/adoc/code/mykernel.cpp
@@ -5,16 +5,15 @@
 class MyKernel;
 
 myQueue.submit([&](handler& h) {
-
   // Explicitly name kernel with previously forward declared type
-  h.single_task<MyKernel>([=]{
+  h.single_task<MyKernel>([=] {
     // [kernel code]
   });
 
   // Explicitly name kernel without forward declaring type at
   // namespace scope.  Must still be forward declarable at
   // namespace scope, even if not declared at that scope
-  h.single_task<class MyOtherKernel>([=]{
+  h.single_task<class MyOtherKernel>([=] {
     // [kernel code]
   });
 });

--- a/adoc/code/parallelForWithKernelHandler.cpp
+++ b/adoc/code/parallelForWithKernelHandler.cpp
@@ -1,20 +1,19 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
- cgh.parallel_for(
-    range<3>(3,3,3), // global range
-      [=] (item<3> it, kernel_handler kh) {
-        //[kernel code]
-      });
+myQueue.submit([&](handler& cgh) {
+  cgh.parallel_for(range<3>(3, 3, 3), // global range
+                   [=](item<3> it, kernel_handler kh) {
+                     //[kernel code]
+                   });
 });
 
-// This form of parallel_for with the "offset" parameter is deprecated in SYCL 2020
-myQueue.submit([&](handler & cgh) {
- cgh.parallel_for(
-    range<3>(3,3,3), // global range
-    id<3>(1,1,1), // offset
-      [=] (item<3> it, kernel_handler kh) {
-        //[kernel code]
-      });
+// This form of parallel_for with the "offset" parameter is deprecated in SYCL
+// 2020
+myQueue.submit([&](handler& cgh) {
+  cgh.parallel_for(range<3>(3, 3, 3), // global range
+                   id<3>(1, 1, 1),    // offset
+                   [=](item<3> it, kernel_handler kh) {
+                     //[kernel code]
+                   });
 });

--- a/adoc/code/parallelForWorkGroupWithKernelHandler.cpp
+++ b/adoc/code/parallelForWorkGroupWithKernelHandler.cpp
@@ -1,33 +1,33 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
+myQueue.submit([&](handler& cgh) {
   // Issue 8 work-groups of 8 work-items each
   cgh.parallel_for_work_group(
-      range<3>(2, 2, 2), range<3>(2, 2, 2), [=](group<3> myGroup,
-      kernel_handler kh) {
+      range<3>(2, 2, 2), range<3>(2, 2, 2),
+      [=](group<3> myGroup, kernel_handler kh) {
+        //[workgroup code]
+        int myLocal; // this variable is shared between workitems
+        // this variable will be instantiated for each work-item separately
+        private_memory<int> myPrivate(myGroup);
 
-    //[workgroup code]
-    int myLocal;  // this variable is shared between workitems
-    // this variable will be instantiated for each work-item separately
-    private_memory<int> myPrivate(myGroup);
+        // Issue parallel work-items.  The number issued per work-group is
+        // determined by the work-group size range of parallel_for_work_group.
+        // In this case, 8 work-items will execute the parallel_for_work_item
+        // body for each of the 8 work-groups, resulting in 64 executions
+        // globally/total.
+        myGroup.parallel_for_work_item([&](h_item<3> myItem) {
+          //[work-item code]
+          myPrivate(myItem) = 0;
+        });
 
-    // Issue parallel work-items.  The number issued per work-group is determined
-    // by the work-group size range of parallel_for_work_group.  In this case,
-    // 8 work-items will execute the parallel_for_work_item body for each of the
-    // 8 work-groups, resulting in 64 executions globally/total.
-    myGroup.parallel_for_work_item([&](h_item<3> myItem) {
-      //[work-item code]
-      myPrivate(myItem) = 0;
-    });
+        // Implicit work-group barrier
 
-    // Implicit work-group barrier
-
-    // Carry private value across loops
-    myGroup.parallel_for_work_item([&](h_item<3> myItem) {
-      //[work-item code]
-      output[myItem.get_global_id()] = myPrivate(myItem);
-    });
-    //[workgroup code]
-  });
+        // Carry private value across loops
+        myGroup.parallel_for_work_item([&](h_item<3> myItem) {
+          //[work-item code]
+          output[myItem.get_global_id()] = myPrivate(myItem);
+        });
+        //[workgroup code]
+      });
 });

--- a/adoc/code/parallelfor.cpp
+++ b/adoc/code/parallelfor.cpp
@@ -1,20 +1,19 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
- cgh.parallel_for(
-    range<3>(3,3,3), // global range
-      [=] (item<3> it) {
-        //[kernel code]
-      });
+myQueue.submit([&](handler& cgh) {
+  cgh.parallel_for(range<3>(3, 3, 3), // global range
+                   [=](item<3> it) {
+                     //[kernel code]
+                   });
 });
 
-// This form of parallel_for with the "offset" parameter is deprecated in SYCL 2020
-myQueue.submit([&](handler & cgh) {
- cgh.parallel_for(
-    range<3>(3,3,3), // global range
-    id<3>(1,1,1), // offset
-      [=] (item<3> it) {
-        //[kernel code]
-      });
+// This form of parallel_for with the "offset" parameter is deprecated in SYCL
+// 2020
+myQueue.submit([&](handler& cgh) {
+  cgh.parallel_for(range<3>(3, 3, 3), // global range
+                   id<3>(1, 1, 1),    // offset
+                   [=](item<3> it) {
+                     //[kernel code]
+                   });
 });

--- a/adoc/code/parallelforbarrier.cpp
+++ b/adoc/code/parallelforbarrier.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-  cgh.parallel_for(
-      nd_range<3>(range<3>(4, 4, 4), range<3>(2, 2, 2)), [=](nd_item<3> item) {
-        //[kernel code]
-        // Internal synchronization
-        group_barrier(item.get_group());
-        //[kernel code]
-      });
+myQueue.submit([&](handler& cgh) {
+  cgh.parallel_for(nd_range<3>(range<3>(4, 4, 4), range<3>(2, 2, 2)),
+                   [=](nd_item<3> item) {
+                     //[kernel code]
+                     // Internal synchronization
+                     group_barrier(item.get_group());
+                     //[kernel code]
+                   });
 });

--- a/adoc/code/parallelforworkgroup.cpp
+++ b/adoc/code/parallelforworkgroup.cpp
@@ -1,32 +1,32 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
+myQueue.submit([&](handler& cgh) {
   // Issue 8 work-groups of 8 work-items each
   cgh.parallel_for_work_group(
       range<3>(2, 2, 2), range<3>(2, 2, 2), [=](group<3> myGroup) {
+        //[workgroup code]
+        int myLocal; // this variable is shared between workitems
+        // this variable will be instantiated for each work-item separately
+        private_memory<int> myPrivate(myGroup);
 
-    //[workgroup code]
-    int myLocal;  // this variable is shared between workitems
-    // this variable will be instantiated for each work-item separately
-    private_memory<int> myPrivate(myGroup);
+        // Issue parallel work-items.  The number issued per work-group is
+        // determined by the work-group size range of parallel_for_work_group.
+        // In this case, 8 work-items will execute the parallel_for_work_item
+        // body for each of the 8 work-groups, resulting in 64 executions
+        // globally/total.
+        myGroup.parallel_for_work_item([&](h_item<3> myItem) {
+          //[work-item code]
+          myPrivate(myItem) = 0;
+        });
 
-    // Issue parallel work-items.  The number issued per work-group is determined
-    // by the work-group size range of parallel_for_work_group.  In this case,
-    // 8 work-items will execute the parallel_for_work_item body for each of the
-    // 8 work-groups, resulting in 64 executions globally/total.
-    myGroup.parallel_for_work_item([&](h_item<3> myItem) {
-      //[work-item code]
-      myPrivate(myItem) = 0;
-    });
+        // Implicit work-group barrier
 
-    // Implicit work-group barrier
-
-    // Carry private value across loops
-    myGroup.parallel_for_work_item([&](h_item<3> myItem) {
-      //[work-item code]
-      output[myItem.get_global_id()] = myPrivate(myItem);
-    });
-    //[workgroup code]
-  });
+        // Carry private value across loops
+        myGroup.parallel_for_work_item([&](h_item<3> myItem) {
+          //[work-item code]
+          output[myItem.get_global_id()] = myPrivate(myItem);
+        });
+        //[workgroup code]
+      });
 });

--- a/adoc/code/parallelforworkgroup2.cpp
+++ b/adoc/code/parallelforworkgroup2.cpp
@@ -1,24 +1,25 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
-  // Issue 8 work-groups.  The work-group size is chosen by the runtime because unspecified
-  cgh.parallel_for_work_group(
-      range<3>(2, 2, 2), [=](group<3> myGroup) {
-
-    // Launch a set of work-items for each work-group.  The number of work-items is chosen
-    // by the runtime because the work-group size was not specified to parallel_for_work_group
-    // and a logical range is not specified to parallel_for_work_item.
+myQueue.submit([&](handler& cgh) {
+  // Issue 8 work-groups.  The work-group size is chosen by the runtime because
+  // unspecified
+  cgh.parallel_for_work_group(range<3>(2, 2, 2), [=](group<3> myGroup) {
+    // Launch a set of work-items for each work-group.  The number of work-items
+    // is chosen by the runtime because the work-group size was not specified to
+    // parallel_for_work_group and a logical range is not specified to
+    // parallel_for_work_item.
     myGroup.parallel_for_work_item([=](h_item<3> myItem) {
       //[work-item code]
     });
 
     // Implicit work-group barrier
 
-    // Launch 512 logical work-items that will be executed by the underlying work-group size
-    // chosen by the runtime.  myItem allows the logical and physical work-item IDs to be
-    // queried.  512 logical work-items will execute for each work-group, and the parallel_for
-    // body will therefore be executed 8*512 = 4096 times globally/total.
+    // Launch 512 logical work-items that will be executed by the underlying
+    // work-group size chosen by the runtime.  myItem allows the logical and
+    // physical work-item IDs to be queried.  512 logical work-items will
+    // execute for each work-group, and the parallel_for body will therefore be
+    // executed 8*512 = 4096 times globally/total.
     myGroup.parallel_for_work_item(range<3>(8, 8, 8), [=](h_item<3> myItem) {
       //[work-item code]
     });

--- a/adoc/code/propertyExample.cpp
+++ b/adoc/code/propertyExample.cpp
@@ -5,12 +5,12 @@
   context myContext;
 
   std::vector<buffer<int, 1>> bufferList {
-    buffer<int, 1>{ptr, rng},
-    buffer<int, 1>{ptr, rng, property::use_host_ptr{}},
-    buffer<int, 1>{ptr, rng, property::context_bound{myContext}}
+    buffer<int, 1> { ptr, rng },
+    buffer<int, 1> { ptr, rng, property::use_host_ptr {} },
+    buffer<int, 1> { ptr, rng, property::context_bound { myContext } }
   };
 
-  for(auto& buf : bufferList) {
+  for (auto& buf : bufferList) {
     if (buf.has_property<property::context_bound>()) {
       auto prop = buf.get_property<property::context_bound>();
       assert(myContext == prop.get_context());

--- a/adoc/code/queueShortcuts.cpp
+++ b/adoc/code/queueShortcuts.cpp
@@ -7,14 +7,14 @@ queue myQueue;
 auto usmPtr = malloc_device<int>(1024, myQueue); // USM pointer
 
 int* data = /* pointer to some data */;
-buffer buf{data, 1024};
-accessor acc{buf}; // Placeholder accessor
+buffer buf { data, 1024 };
+accessor acc { buf }; // Placeholder accessor
 
 // Queue shortcut for a kernel invocation
 myQueue.single_task<MyKernel>([=] {
-    // Allowed to use USM pointers,
-    // not allowed to use accessors
-    usmPtr[0] = 0;
+  // Allowed to use USM pointers,
+  // not allowed to use accessors
+  usmPtr[0] = 0;
 });
 
 // Placeholder accessor will automatically be registered

--- a/adoc/code/reduction.cpp
+++ b/adoc/code/reduction.cpp
@@ -15,7 +15,6 @@ int maxResult = 0;
 buffer<int> maxBuf { &maxResult, 1 };
 
 myQueue.submit([&](handler& cgh) {
-
   // Input values to reductions are standard accessors
   auto inputValues = valuesBuf.get_access<access_mode::read>(cgh);
 
@@ -27,16 +26,18 @@ myQueue.submit([&](handler& cgh) {
   // For each reduction variable, the implementation:
   // - Creates a corresponding reducer
   // - Passes a reference to the reducer to the lambda as a parameter
-  cgh.parallel_for(range<1>{1024},
-    sumReduction, maxReduction,
-    [=](id<1> idx, auto& sum, auto& max) {
-      // plus<>() corresponds to += operator, so sum can be updated via += or combine()
-      sum += inputValues[idx];
+  cgh.parallel_for(range<1> { 1024 }, sumReduction, maxReduction,
+                   [=](id<1> idx, auto& sum, auto& max) {
+                     // plus<>() corresponds to += operator, so sum can be
+                     // updated via += or combine()
+                     sum += inputValues[idx];
 
-      // maximum<>() has no shorthand operator, so max can only be updated via combine()
-      max.combine(inputValues[idx]);
-  });
+                     // maximum<>() has no shorthand operator, so max can only
+                     // be updated via combine()
+                     max.combine(inputValues[idx]);
+                   });
 });
 
 // sumBuf and maxBuf contain the reduction results once the kernel completes
-assert(maxBuf.get_host_access()[0] == 1023 && sumBuf.get_host_access()[0] == 523776);
+assert(maxBuf.get_host_access()[0] == 1023 &&
+       sumBuf.get_host_access()[0] == 523776);

--- a/adoc/code/singleTaskWithKernelHandler.cpp
+++ b/adoc/code/singleTaskWithKernelHandler.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
+myQueue.submit([&](handler& cgh) {
 cgh.single_task(
     [=] (kernel_handler kh) {
-      // [kernel code]
+    // [kernel code]
     }));
 });

--- a/adoc/code/singletask.cpp
+++ b/adoc/code/singletask.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-myQueue.submit([&](handler & cgh) {
+myQueue.submit([&](handler& cgh) {
 cgh.single_task(
     [=] () {
-      // [kernel code]
+    // [kernel code]
     }));
 });

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -4,46 +4,49 @@
 #include <sycl/sycl.hpp>
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
-struct Compound {int i; float f;};
+struct Compound {
+  int i;
+  float f;
+};
 
-constexpr specialization_id<int> a{1};            // OK
-constexpr specialization_id<Compound> b{2, 3.14}; // OK
-inline constexpr specialization_id<int> c{3};     // OK
-static constexpr specialization_id<int> d{4};     // OK
-specialization_id<int> e{5};                      // ILLEGAL: not constexpr
+constexpr specialization_id<int> a { 1 };            // OK
+constexpr specialization_id<Compound> b { 2, 3.14 }; // OK
+inline constexpr specialization_id<int> c { 3 };     // OK
+static constexpr specialization_id<int> d { 4 };     // OK
+specialization_id<int> e { 5 };                      // ILLEGAL: not constexpr
 
 struct Bar {
-  static constexpr specialization_id<int> f{6};   // OK
+  static constexpr specialization_id<int> f { 6 }; // OK
 };
 struct Baz {
   struct Inner {
-    static constexpr specialization_id<int> g{7}; // OK
+    static constexpr specialization_id<int> g { 7 }; // OK
   };
 };
 class Boo {
-  static constexpr specialization_id<int> h{8};   // ILLEGAL: not public member
+  static constexpr specialization_id<int> h { 8 }; // ILLEGAL: not public member
 };
 
 void Func() {
-  static constexpr specialization_id<int> i{9};   // ILLEGAL: not at namespace or
-                                                  // class scope
+  static constexpr specialization_id<int> i { 9 }; // ILLEGAL: not at namespace
+                                                   // or class scope
   /* ... */
 }
 
-constexpr specialization_id<int> same_name{10};   // OK
+constexpr specialization_id<int> same_name { 10 }; // OK
 namespace foo {
-  constexpr specialization_id<int> same_name{11}; // OK
+constexpr specialization_id<int> same_name { 11 }; // OK
 }
 namespace {
-  constexpr specialization_id<int> same_name{12}; // OK
+constexpr specialization_id<int> same_name { 12 }; // OK
 }
 inline namespace other {
-  int same_name;                                  // ILLEGAL: shadows "specialization_id"
-                                                  // variable with same name in enclosing
-                                                  // namespace scope
+int same_name; // ILLEGAL: shadows "specialization_id"
+               // variable with same name in enclosing
+               // namespace scope
 }
 inline namespace {
-  namespace foo {                                 // ILLEGAL: namespace name shadows "::foo"
-  }                                               // namespace which contains
-                                                  // "specialization_id" variable.
-}
+namespace foo { // ILLEGAL: namespace name shadows "::foo"
+} // namespace foo
+  // "specialization_id" variable.
+} // namespace

--- a/adoc/code/subbuffer.cpp
+++ b/adoc/code/subbuffer.cpp
@@ -1,16 +1,19 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-buffer<int,2> parent_buffer { range<2>{ 8,8 } };  // Create 2-d buffer with 8x8 ints
+buffer<int, 2> parent_buffer { range<2> {
+    8, 8 } }; // Create 2-d buffer with 8x8 ints
 
 // OK: Contiguous region from middle of buffer
-buffer<int,2> sub_buf1 { parent_buffer, /*offset*/ range<2>{ 2,0 }, /*size*/ range<2>{ 2,8 } };
+buffer<int, 2> sub_buf1 { parent_buffer, /*offset*/ range<2> { 2, 0 },
+                          /*size*/ range<2> { 2, 8 } };
 
 // invalid exception: Non-contiguous regions of 2-d buffer
-buffer<int,2> sub_buf2 { parent_buffer, /*offset*/ range<2>{ 2,0 }, /*size*/ range<2>{ 2,2 } };
-buffer<int,2> sub_buf3 { parent_buffer, /*offset*/ range<2>{ 2,2 }, /*size*/ range<2>{ 2,6 } };
+buffer<int, 2> sub_buf2 { parent_buffer, /*offset*/ range<2> { 2, 0 },
+                          /*size*/ range<2> { 2, 2 } };
+buffer<int, 2> sub_buf3 { parent_buffer, /*offset*/ range<2> { 2, 2 },
+                          /*size*/ range<2> { 2, 6 } };
 
 // invalid exception: Out-of-bounds size
-buffer<int,2> sub_buf4 { parent_buffer, /*offset*/ range<2>{ 2,2 }, /*size*/ range<2>{ 2,8 } };
-
-
+buffer<int, 2> sub_buf4 { parent_buffer, /*offset*/ range<2> { 2, 2 },
+                          /*size*/ range<2> { 2, 8 } };

--- a/adoc/code/sycl-external.cpp
+++ b/adoc/code/sycl-external.cpp
@@ -5,7 +5,8 @@
 
 SYCL_EXTERNAL void Foo();
 
-SYCL_EXTERNAL void Bar() { /* ... */ }
+SYCL_EXTERNAL void Bar() { /* ... */
+}
 
 SYCL_EXTERNAL extern void Baz();
 

--- a/adoc/code/twoOptionalFeatures.cpp
+++ b/adoc/code/twoOptionalFeatures.cpp
@@ -3,8 +3,8 @@
 
 queue q1(dev1);
 if (dev1.has(aspect::fp16)) {
-  q1.submit([&](handler &cgh) {
-    cgh.parallel_for<KernelA>(range{N}, [=](id i) {
+  q1.submit([&](handler& cgh) {
+    cgh.parallel_for<KernelA>(range { N }, [=](id i) {
       half fpShort = 1.0;
       /* ... */
     });
@@ -13,8 +13,8 @@ if (dev1.has(aspect::fp16)) {
 
 queue q2(dev2);
 if (dev2.has(aspect::atomic64)) {
-  q2.submit([&](handler &cgh) {
-    cgh.parallel_for<KernelB>(range{N}, [=](id i) {
+  q2.submit([&](handler& cgh) {
+    cgh.parallel_for<KernelB>(range { N }, [=](id i) {
       /* ... */
       sycl::atomic_ref longAtomic(longValue);
       longAtomic.fetch_add(1);

--- a/adoc/code/usingSpecConstants.cpp
+++ b/adoc/code/usingSpecConstants.cpp
@@ -15,7 +15,7 @@ constexpr specialization_id<coeff_t> coeff_id;
 void do_conv(buffer<float, 2> in, buffer<float, 2> out) {
   queue myQueue;
 
-  myQueue.submit([&](handler &cgh) {
+  myQueue.submit([&](handler& cgh) {
     accessor in_acc { in, cgh, read_only };
     accessor out_acc { out, cgh, write_only };
 
@@ -23,24 +23,23 @@ void do_conv(buffer<float, 2> in, buffer<float, 2> out) {
     // This will build a specific kernel the coefficient available as literals.
     cgh.set_specialization_constant<coeff_id>(get_coefficients());
 
-    cgh.parallel_for<class Convolution>(
-        in.get_range(), [=](item<2> item_id, kernel_handler h) {
-          float acc = 0;
-          coeff_t coeff = h.get_specialization_constant<coeff_id>();
-          for (int i = -1; i <= 1; i++) {
-            if (item_id[0] + i < 0 || item_id[0] + i >= in_acc.get_range()[0])
-              continue;
-            for (int j = -1; j <= 1; j++) {
-              if (item_id[1] + j < 0 || item_id[1] + j >= in_acc.get_range()[1])
-                continue;
-              // The underlying JIT can see all the values of the array returned
-              // by coeff.get().
-              acc += coeff[i + 1][j + 1] *
-                     in_acc[item_id[0] + i][item_id[1] + j];
-            }
-          }
-          out_acc[item_id] = acc;
-        });
+    cgh.parallel_for<class Convolution>(in.get_range(), [=](item<2> item_id,
+                                                            kernel_handler h) {
+      float acc = 0;
+      coeff_t coeff = h.get_specialization_constant<coeff_id>();
+      for (int i = -1; i <= 1; i++) {
+        if (item_id[0] + i < 0 || item_id[0] + i >= in_acc.get_range()[0])
+          continue;
+        for (int j = -1; j <= 1; j++) {
+          if (item_id[1] + j < 0 || item_id[1] + j >= in_acc.get_range()[1])
+            continue;
+          // The underlying JIT can see all the values of the array returned
+          // by coeff.get().
+          acc += coeff[i + 1][j + 1] * in_acc[item_id[0] + i][item_id[1] + j];
+        }
+      }
+      out_acc[item_id] = acc;
+    });
   });
 
   myQueue.wait();

--- a/adoc/code/usm_device.cpp
+++ b/adoc/code/usm_device.cpp
@@ -9,8 +9,9 @@ int main() {
   // Create a default queue to enqueue work to the default device
   queue myQueue;
 
-  // Allocate shared memory bound to the device and context associated to the queue
-  int *data = sycl::malloc_device<int>(1024, myQueue);
+  // Allocate shared memory bound to the device and context associated to the
+  // queue
+  int* data = sycl::malloc_device<int>(1024, myQueue);
 
   myQueue.parallel_for(1024, [=](id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
@@ -23,13 +24,13 @@ int main() {
   // Create an array to receive the device content
   int hostData[1024];
   // Receive the content from the device
-  myQueue.memcpy(hostData, data, 1024*sizeof(int));
+  myQueue.memcpy(hostData, data, 1024 * sizeof(int));
   // Wait for the copy to complete
   myQueue.wait();
 
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout <<"hostData["<< i << "] = " << hostData[i] << std::endl;
+    std::cout << "hostData[" << i << "] = " << hostData[i] << std::endl;
 
   return 0;
 }

--- a/adoc/code/usm_shared.cpp
+++ b/adoc/code/usm_shared.cpp
@@ -9,10 +9,10 @@ int main() {
   //  Create a default queue to enqueue work to the default device
   queue myQueue;
 
-  // Allocate shared memory bound to the device and context associated to the queue
-  // Replacing malloc_shared with malloc_host would yield a correct program that
-  // allocated device-visible memory on the host.
-  int *data = sycl::malloc_shared<int>(1024, myQueue);
+  // Allocate shared memory bound to the device and context associated to the
+  // queue Replacing malloc_shared with malloc_host would yield a correct
+  // program that allocated device-visible memory on the host.
+  int* data = sycl::malloc_shared<int>(1024, myQueue);
 
   myQueue.parallel_for(1024, [=](id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
@@ -24,7 +24,7 @@ int main() {
 
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout <<"data["<< i << "] = " << data[i] << std::endl;
+    std::cout << "data[" << i << "] = " << data[i] << std::endl;
 
   return 0;
 }

--- a/adoc/headers/accessMode.h
+++ b/adoc/headers/accessMode.h
@@ -13,8 +13,8 @@ enum class access_mode : /* unspecified */ {
 };
 
 namespace access {
-  // The legacy type "access::mode" is deprecated.
-  using mode = sycl::access_mode;
-}  // namespace access
+// The legacy type "access::mode" is deprecated.
+using mode = sycl::access_mode;
+} // namespace access
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessProperties.h
+++ b/adoc/headers/accessProperties.h
@@ -3,8 +3,8 @@
 
 namespace sycl {
 namespace property {
-  struct no_init {};
-}  // namespace property
+struct no_init {};
+} // namespace property
 
 inline constexpr property::no_init no_init;
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessTags.h
+++ b/adoc/headers/accessTags.h
@@ -10,4 +10,4 @@ inline constexpr __unspecified__ read_only_host_task;
 inline constexpr __unspecified__ read_write_host_task;
 inline constexpr __unspecified__ write_only_host_task;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -6,131 +6,130 @@ namespace sycl {
 enum class target : /* unspecified */ {
   device,
   host_task,
-  constant_buffer,                    // Deprecated
-  local,                              // Deprecated
-  host_buffer,                        // Deprecated
-  global_buffer = device              // Deprecated
+  constant_buffer,       // Deprecated
+  local,                 // Deprecated
+  host_buffer,           // Deprecated
+  global_buffer = device // Deprecated
 };
 
 namespace access {
-  // The legacy type "access::target" is deprecated.
-  using sycl::target;
+// The legacy type "access::target" is deprecated.
+using sycl::target;
 
 enum class placeholder : /* unspecified */ { // Deprecated
   false_t,
   true_t
 };
 
-}  // namespace access
+} // namespace access
 
-
-template <typename DataT,
-          int Dimensions = 1,
+template <typename DataT, int Dimensions = 1,
           access_mode AccessMode =
-            (std::is_const_v<DataT> ? access_mode::read
-                                    : access_mode::read_write),
+              (std::is_const_v<DataT> ? access_mode::read
+                                      : access_mode::read_write),
           target AccessTarget = target::device,
           access::placeholder isPlaceholder = access::placeholder::false_t>
 class accessor {
  public:
-  using value_type =             // const DataT for read-only accessors, DataT otherwise
+  using value_type = // const DataT for read-only accessors, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
   template <access::decorated IsDecorated>
-      using accessor_ptr =       // multi_ptr to value_type with target address space,
-          __pointer_class__;     //   unspecified for access_mode::host_task
+  using accessor_ptr =   // multi_ptr to value_type with target address space,
+      __pointer_class__; //   unspecified for access_mode::host_task
   using iterator = __unspecified_iterator__<value_type>;
   using const_iterator = __unspecified_iterator__<const value_type>;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using difference_type = typename std::iterator_traits<iterator>::difference_type;
+  using difference_type =
+      typename std::iterator_traits<iterator>::difference_type;
   using size_type = size_t;
 
   accessor();
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, const property_list &propList = {});
+  accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef, TagT tag,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef, TagT tag,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, TagT tag,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, TagT tag,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           range<Dimensions> accessRange, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           range<Dimensions> accessRange, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
            range<Dimensions> accessRange, TagT tag,
-           const property_list &propList = {});
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
            range<Dimensions> accessRange, id<Dimensions> accessOffset,
-           const property_list &propList = {});
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           range<Dimensions> accessRange, id<Dimensions> accessOffset,
-           TagT tag, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           range<Dimensions> accessRange, id<Dimensions> accessOffset, TagT tag,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
-           TagT tag, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
+           TagT tag, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
-           id<Dimensions> accessOffset, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
+           id<Dimensions> accessOffset, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
            id<Dimensions> accessOffset, TagT tag,
-           const property_list &propList = {});
+           const property_list& propList = {});
 
   /* -- common interface members -- */
 
-  void swap(accessor &other);
+  void swap(accessor& other);
 
   bool is_placeholder() const;
 
@@ -163,17 +162,19 @@ class accessor {
   /* Available only when: (Dimensions > 1) */
   __unspecified__ operator[](size_t index) const;
 
-  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 1) */
+  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 1)
+   */
   reference operator[](size_t index) const;
 
   /* Deprecated
-  Available only when: (AccessMode == access_mode::atomic && Dimensions ==  0) */
-  operator cl::sycl::atomic<DataT, access::address_space::global_space> () const;
+  Available only when: (AccessMode == access_mode::atomic && Dimensions ==  0)
+*/
+  operator cl::sycl::atomic<DataT, access::address_space::global_space>() const;
 
   /* Deprecated
   Available only when: (AccessMode == access_mode::atomic && Dimensions == 1) */
-  cl::sycl::atomic<DataT, access::address_space::global_space> operator[](
-    id<Dimensions> index) const;
+  cl::sycl::atomic<DataT, access::address_space::global_space>
+  operator[](id<Dimensions> index) const;
 
   std::add_pointer_t<value_type> get_pointer() const noexcept;
 
@@ -197,4 +198,4 @@ class accessor {
   const_reverse_iterator crend() const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorDeprecatedConstant.h
+++ b/adoc/headers/accessorDeprecatedConstant.h
@@ -3,59 +3,56 @@
 
 namespace sycl {
 
-template <typename DataT,
-          int Dimensions,
-          access_mode AccessMode,
-          target AccessTarget,
-          access::placeholder IsPlaceholder>
+template <typename DataT, int Dimensions, access_mode AccessMode,
+          target AccessTarget, access::placeholder IsPlaceholder>
 class accessor {
  public:
   using value_type = const DataT;
-  using reference = const DataT &;
-  using const_reference = const DataT &;
+  using reference = const DataT&;
+  using const_reference = const DataT&;
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, const property_list &propList = {});
+  accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           range<Dimensions> accessRange, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           range<Dimensions> accessRange, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
            range<Dimensions> accessRange, id<Dimensions> accessOffset,
-           const property_list &propList = {});
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           handler &commandGroupHandlerRef, range<Dimensions> accessRange,
-           id<Dimensions> accessOffset, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           handler& commandGroupHandlerRef, range<Dimensions> accessRange,
+           id<Dimensions> accessOffset, const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -86,4 +83,4 @@ class accessor {
   constant_ptr<DataT> get_pointer() const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorDeprecatedHost.h
+++ b/adoc/headers/accessorDeprecatedHost.h
@@ -3,38 +3,35 @@
 
 namespace sycl {
 
-template <typename DataT,
-          int Dimensions,
-          access_mode AccessMode,
-          target AccessTarget,
-          access::placeholder IsPlaceholder>
+template <typename DataT, int Dimensions, access_mode AccessMode,
+          target AccessTarget, access::placeholder IsPlaceholder>
 class accessor {
  public:
-  using value_type =             // const DataT for access_mode::read, DataT otherwise
+  using value_type = // const DataT for access_mode::read, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-           range<Dimensions> accessRange, const property_list &propList = {});
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+           range<Dimensions> accessRange, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
            range<Dimensions> accessRange, id<Dimensions> accessOffset,
-           const property_list &propList = {});
+           const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -65,4 +62,4 @@ class accessor {
   std::add_pointer_t<value_type> get_pointer() const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorDeprecatedLocal.h
+++ b/adoc/headers/accessorDeprecatedLocal.h
@@ -3,24 +3,20 @@
 
 namespace sycl {
 
-template <typename DataT,
-          int Dimensions,
-          access_mode AccessMode,
-          target AccessTarget,
-          access::placeholder IsPlaceholder>
+template <typename DataT, int Dimensions, access_mode AccessMode,
+          target AccessTarget, access::placeholder IsPlaceholder>
 class accessor {
  public:
   using value_type = DataT;
-  using reference = DataT &;
-  using const_reference = const DataT &;
+  using reference = DataT&;
+  using const_reference = const DataT&;
 
   /* Available only when: (Dimensions == 0) */
-  accessor(handler &commandGroupHandlerRef,
-           const property_list &propList = {});
+  accessor(handler& commandGroupHandlerRef, const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
-  accessor(range<Dimensions> allocationSize, handler &commandGroupHandlerRef,
-           const property_list &propList = {});
+  accessor(range<Dimensions> allocationSize, handler& commandGroupHandlerRef,
+           const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -31,28 +27,36 @@ class accessor {
   /* Available only when: (Dimensions > 0) */
   range<Dimensions> get_range() const;
 
-  /* Available only when: (AccessMode == access_mode::read_write && Dimensions == 0) */
+  /* Available only when: (AccessMode == access_mode::read_write && Dimensions
+   * == 0) */
   operator reference() const;
 
-  /* Available only when: (AccessMode == access_mode::read_write && Dimensions > 0) */
+  /* Available only when: (AccessMode == access_mode::read_write && Dimensions >
+   * 0) */
   reference operator[](id<Dimensions> index) const;
 
   /* Available only when: (Dimensions > 1) */
   __unspecified__ operator[](size_t index) const;
 
-  /* Available only when: (AccessMode == access_mode::read_write && Dimensions == 1) */
+  /* Available only when: (AccessMode == access_mode::read_write && Dimensions
+   * == 1) */
   reference operator[](size_t index) const;
 
-  /* Available only when: (AccessMode == access_mode::atomic && Dimensions == 0) */
-  operator atomic<DataT, access::address_space::local_space> () const;
+  /* Available only when: (AccessMode == access_mode::atomic && Dimensions == 0)
+   */
+  operator atomic<DataT, access::address_space::local_space>() const;
 
-  /* Available only when: (AccessMode == access_mode::atomic && Dimensions > 0) */
-  atomic<DataT, access::address_space::local_space> operator[](id<Dimensions> index) const;
+  /* Available only when: (AccessMode == access_mode::atomic && Dimensions > 0)
+   */
+  atomic<DataT, access::address_space::local_space>
+  operator[](id<Dimensions> index) const;
 
-  /* Available only when: (AccessMode == access_mode::atomic && Dimensions == 1) */
-  atomic<DataT, access::address_space::local_space> operator[](size_t index) const;
+  /* Available only when: (AccessMode == access_mode::atomic && Dimensions == 1)
+   */
+  atomic<DataT, access::address_space::local_space>
+  operator[](size_t index) const;
 
   local_ptr<DataT> get_pointer() const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -2,67 +2,68 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <typename DataT,
-          int Dimensions = 1,
+template <typename DataT, int Dimensions = 1,
           access_mode AccessMode =
-            (std::is_const_v<DataT> ? access_mode::read
-                                    : access_mode::read_write)>
+              (std::is_const_v<DataT> ? access_mode::read
+                                      : access_mode::read_write)>
 class host_accessor {
  public:
-  using value_type =             // const DataT for read-only accessors, DataT otherwise
+  using value_type = // const DataT for read-only accessors, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
   using iterator = __unspecified_iterator__<value_type>;
   using const_iterator = __unspecified_iterator__<const value_type>;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using difference_type = typename std::iterator_traits<iterator>::difference_type;
+  using difference_type =
+      typename std::iterator_traits<iterator>::difference_type;
   using size_type = size_t;
 
   host_accessor();
 
   /* Available only when: (Dimensions == 0) */
   template <typename AllocatorT>
-  host_accessor(buffer<DataT, 1, AllocatorT> &bufferRef,
-                const property_list &propList = {});
+  host_accessor(buffer<DataT, 1, AllocatorT>& bufferRef,
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-                const property_list &propList = {});
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef, TagT tag,
-                const property_list &propList = {});
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef, TagT tag,
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
-                range<Dimensions> accessRange, const property_list &propList = {});
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
+                range<Dimensions> accessRange,
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
                 range<Dimensions> accessRange, TagT tag,
-                const property_list &propList = {});
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
                 range<Dimensions> accessRange, id<Dimensions> accessOffset,
-                const property_list &propList = {});
+                const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
   template <typename AllocatorT, typename TagT>
-  host_accessor(buffer<DataT, Dimensions, AllocatorT> &bufferRef,
+  host_accessor(buffer<DataT, Dimensions, AllocatorT>& bufferRef,
                 range<Dimensions> accessRange, id<Dimensions> accessOffset,
-                TagT tag, const property_list &propList = {});
+                TagT tag, const property_list& propList = {});
 
   /* -- common interface members -- */
 
-  void swap(host_accessor &other);
+  void swap(host_accessor& other);
 
   size_type byte_size() const noexcept;
 
@@ -108,4 +109,4 @@ class host_accessor {
 
   const_reverse_iterator crend() const noexcept;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -2,36 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <typename DataT, int Dimensions = 1>
-class local_accessor {
+template <typename DataT, int Dimensions = 1> class local_accessor {
  public:
-  using value_type =             // const DataT for read-only accessors, DataT otherwise
+  using value_type = // const DataT for read-only accessors, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
   template <access::decorated IsDecorated>
-      using accessor_ptr =
-          multi_ptr<value_type, access::address_space::local_space, IsDecorated>;
+  using accessor_ptr =
+      multi_ptr<value_type, access::address_space::local_space, IsDecorated>;
   using iterator = __unspecified_iterator__<value_type>;
   using const_iterator = __unspecified_iterator__<const value_type>;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using difference_type = typename std::iterator_traits<iterator>::difference_type;
+  using difference_type =
+      typename std::iterator_traits<iterator>::difference_type;
   using size_type = size_t;
 
   local_accessor();
 
   /* Available only when: (Dimensions == 0) */
-  local_accessor(handler &commandGroupHandlerRef,
-                 const property_list &propList = {});
+  local_accessor(handler& commandGroupHandlerRef,
+                 const property_list& propList = {});
 
   /* Available only when: (Dimensions > 0) */
-  local_accessor(range<Dimensions> allocationSize, handler &commandGroupHandlerRef,
-                 const property_list &propList = {});
+  local_accessor(range<Dimensions> allocationSize,
+                 handler& commandGroupHandlerRef,
+                 const property_list& propList = {});
 
   /* -- common interface members -- */
 
-  void swap(accessor &other);
+  void swap(accessor& other);
 
   size_type byte_size() const noexcept;
 
@@ -76,4 +77,4 @@ class local_accessor {
 
   const_reverse_iterator crend() const noexcept;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorSampledImage.h
+++ b/adoc/headers/accessorSampledImage.h
@@ -3,29 +3,25 @@
 
 namespace sycl {
 
-enum class image_target : /* unspecified */ {
-  device,
-  host_task
-};
+enum class image_target : /* unspecified */ { device, host_task };
 
-template <typename DataT,
-          int Dimensions,
+template <typename DataT, int Dimensions,
           image_target AccessTarget = image_target::device>
 class sampled_image_accessor {
  public:
   using value_type = const DataT;
-  using reference = const DataT &;
-  using const_reference = const DataT &;
+  using reference = const DataT&;
+  using const_reference = const DataT&;
 
   template <typename AllocatorT>
-  sampled_image_accessor(sampled_image<Dimensions, AllocatorT> &imageRef,
-                         handler &commandGroupHandlerRef,
-                         const property_list &propList = {});
+  sampled_image_accessor(sampled_image<Dimensions, AllocatorT>& imageRef,
+                         handler& commandGroupHandlerRef,
+                         const property_list& propList = {});
 
   template <typename AllocatorT, typename TagT>
-  sampled_image_accessor(sampled_image<Dimensions, AllocatorT> &imageRef,
-                         handler &commandGroupHandlerRef, TagT tag,
-                         const property_list &propList = {});
+  sampled_image_accessor(sampled_image<Dimensions, AllocatorT>& imageRef,
+                         handler& commandGroupHandlerRef, TagT tag,
+                         const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -36,20 +32,18 @@ class sampled_image_accessor {
   /* if Dimensions == 1, CoordT = float
      if Dimensions == 2, CoordT = float2
      if Dimensions == 3, CoordT = float4 */
-  template <typename CoordT>
-  DataT read(const CoordT &coords) const noexcept;
+  template <typename CoordT> DataT read(const CoordT& coords) const noexcept;
 };
 
-template <typename DataT, int Dimensions>
-class host_sampled_image_accessor {
+template <typename DataT, int Dimensions> class host_sampled_image_accessor {
  public:
   using value_type = const DataT;
-  using reference = const DataT &;
-  using const_reference = const DataT &;
+  using reference = const DataT&;
+  using const_reference = const DataT&;
 
   template <typename AllocatorT>
-  host_sampled_image_accessor(sampled_image<Dimensions, AllocatorT> &imageRef,
-                              const property_list &propList = {});
+  host_sampled_image_accessor(sampled_image<Dimensions, AllocatorT>& imageRef,
+                              const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -60,8 +54,7 @@ class host_sampled_image_accessor {
   /* if Dimensions == 1, CoordT = float
      if Dimensions == 2, CoordT = float2
      if Dimensions == 3, CoordT = float4 */
-  template <typename CoordT>
-  DataT read(const CoordT &coords) const noexcept;
+  template <typename CoordT> DataT read(const CoordT& coords) const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/accessorUnsampledImage.h
+++ b/adoc/headers/accessorUnsampledImage.h
@@ -3,31 +3,26 @@
 
 namespace sycl {
 
-enum class image_target : /* unspecified */ {
-  device,
-  host_task
-};
+enum class image_target : /* unspecified */ { device, host_task };
 
-template <typename DataT,
-          int Dimensions,
-          access_mode AccessMode,
+template <typename DataT, int Dimensions, access_mode AccessMode,
           image_target AccessTarget = image_target::device>
 class unsampled_image_accessor {
  public:
-  using value_type =             // const DataT for read-only accessors, DataT otherwise
+  using value_type = // const DataT for read-only accessors, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
 
   template <typename AllocatorT>
-  unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT> &imageRef,
-                           handler &commandGroupHandlerRef,
-                           const property_list &propList = {});
+  unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT>& imageRef,
+                           handler& commandGroupHandlerRef,
+                           const property_list& propList = {});
 
   template <typename AllocatorT, typename TagT>
-  unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT> &imageRef,
-                           handler &commandGroupHandlerRef, TagT tag,
-                           const property_list &propList = {});
+  unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT>& imageRef,
+                           handler& commandGroupHandlerRef, TagT tag,
+                           const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -39,36 +34,36 @@ class unsampled_image_accessor {
   if Dimensions == 1, CoordT = int
   if Dimensions == 2, CoordT = int2
   if Dimensions == 3, CoordT = int4 */
-  template <typename CoordT>
-  DataT read(const CoordT &coords) const noexcept;
+  template <typename CoordT> DataT read(const CoordT& coords) const noexcept;
 
   /* Available only when: AccessMode == access_mode::write
   if Dimensions == 1, CoordT = int
   if Dimensions == 2, CoordT = int2
   if Dimensions == 3, CoordT = int4 */
   template <typename CoordT>
-  void write(const CoordT &coords, const DataT &color) const;
+  void write(const CoordT& coords, const DataT& color) const;
 };
 
-template <typename DataT,
-          int Dimensions = 1,
+template <typename DataT, int Dimensions = 1,
           access_mode AccessMode =
-            (std::is_const_v<DataT> ? access_mode::read
-                                    : access_mode::read_write)>
+              (std::is_const_v<DataT> ? access_mode::read
+                                      : access_mode::read_write)>
 class host_unsampled_image_accessor {
  public:
-  using value_type =             // const DataT for read-only accessors, DataT otherwise
+  using value_type = // const DataT for read-only accessors, DataT otherwise
       __value_type__;
-  using reference = value_type &;
-  using const_reference = const DataT &;
+  using reference = value_type&;
+  using const_reference = const DataT&;
 
   template <typename AllocatorT>
-  host_unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT> &imageRef,
-                                const property_list &propList = {});
+  host_unsampled_image_accessor(
+      unsampled_image<Dimensions, AllocatorT>& imageRef,
+      const property_list& propList = {});
 
   template <typename AllocatorT, typename TagT>
-  host_unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT> &imageRef,
-                                TagT tag, const property_list &propList = {});
+  host_unsampled_image_accessor(
+      unsampled_image<Dimensions, AllocatorT>& imageRef, TagT tag,
+      const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -81,8 +76,7 @@ class host_unsampled_image_accessor {
   if Dimensions == 1, CoordT = int
   if Dimensions == 2, CoordT = int2
   if Dimensions == 3, CoordT = int4 */
-  template <typename CoordT>
-  DataT read(const CoordT &coords) const noexcept;
+  template <typename CoordT> DataT read(const CoordT& coords) const noexcept;
 
   /* Available only when: (AccessMode == access_mode::write ||
                            AccessMode == access_mode::read_write)
@@ -90,7 +84,7 @@ class host_unsampled_image_accessor {
   if Dimensions == 2, CoordT = int2
   if Dimensions == 3, CoordT = int4 */
   template <typename CoordT>
-  void write(const CoordT &coords, const DataT &color) const;
+  void write(const CoordT& coords, const DataT& color) const;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/algorithms/all_of.h
+++ b/adoc/headers/algorithms/all_of.h
@@ -7,5 +7,4 @@ bool joint_all_of(Group g, Ptr first, Ptr last, Predicate pred); // (1)
 template <typename Group, typename T, typename Predicate>
 bool all_of_group(Group g, T x, Predicate pred); // (2)
 
-template <typename Group>
-bool all_of_group(Group g, bool pred); // (3)
+template <typename Group> bool all_of_group(Group g, bool pred); // (3)

--- a/adoc/headers/algorithms/any_of.h
+++ b/adoc/headers/algorithms/any_of.h
@@ -7,5 +7,4 @@ bool joint_any_of(Group g, Ptr first, Ptr last, Predicate pred); // (1)
 template <typename Group, typename T, typename Predicate>
 bool any_of_group(Group g, T x, Predicate pred); // (2)
 
-template <typename Group>
-bool any_of_group(Group g, bool pred); // (3)
+template <typename Group> bool any_of_group(Group g, bool pred); // (3)

--- a/adoc/headers/algorithms/exclusive_scan.h
+++ b/adoc/headers/algorithms/exclusive_scan.h
@@ -1,14 +1,19 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
-template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperation>
-OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op); // (1)
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation>
+OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            BinaryOperation binary_op); // (1)
 
-template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation>
-OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init, BinaryOperation binary_op); // (2)
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation>
+OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            T init, BinaryOperation binary_op); // (2)
 
 template <typename Group, typename T, typename BinaryOperation>
 T exclusive_scan_over_group(Group g, T x, BinaryOperation binary_op); // (3)
 
 template <typename Group, typename V, typename T, typename BinaryOperation>
-T exclusive_scan_over_group(Group g, V x, T init, BinaryOperation binary_op); // (4)
+T exclusive_scan_over_group(Group g, V x, T init,
+                            BinaryOperation binary_op); // (4)

--- a/adoc/headers/algorithms/inclusive_scan.h
+++ b/adoc/headers/algorithms/inclusive_scan.h
@@ -1,14 +1,19 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
-template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperation>
-OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op); // (1)
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation>
+OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            BinaryOperation binary_op); // (1)
 
-template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation>
-OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, BinaryOperation binary_op, T init); // (2)
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation>
+OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            BinaryOperation binary_op, T init); // (2)
 
 template <typename Group, typename T, typename BinaryOperation>
 T inclusive_scan_over_group(Group g, T x, BinaryOperation binary_op); // (3)
 
 template <typename Group, typename V, typename T, typename BinaryOperation>
-T inclusive_scan_over_group(Group g, V x, BinaryOperation binary_op, T init); // (4)
+T inclusive_scan_over_group(Group g, V x, BinaryOperation binary_op,
+                            T init); // (4)

--- a/adoc/headers/algorithms/is_group.h
+++ b/adoc/headers/algorithms/is_group.h
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 namespace sycl {
-  template <class T>
-  struct is_group;
+template <class T> struct is_group;
 
-  template <class T>
-  inline constexpr bool is_group_v = is_group<T>::value;
-}
+template <class T> inline constexpr bool is_group_v = is_group<T>::value;
+} // namespace sycl

--- a/adoc/headers/algorithms/none_of.h
+++ b/adoc/headers/algorithms/none_of.h
@@ -7,5 +7,4 @@ bool joint_none_of(Group g, Ptr first, Ptr last, Predicate pred); // (1)
 template <typename Group, typename T, typename Predicate>
 bool none_of_group(Group g, T x, Predicate pred); // (2)
 
-template <typename Group>
-bool none_of_group(Group g, bool pred); // (3)
+template <typename Group> bool none_of_group(Group g, bool pred); // (3)

--- a/adoc/headers/algorithms/reduce.h
+++ b/adoc/headers/algorithms/reduce.h
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename Ptr, typename BinaryOperation>
-std::iterator_traits<Ptr>::value_type joint_reduce(Group g, Ptr first, Ptr last, BinaryOperation binary_op); // (1)
+std::iterator_traits<Ptr>::value_type
+joint_reduce(Group g, Ptr first, Ptr last, BinaryOperation binary_op); // (1)
 
 template <typename Group, typename Ptr, typename T, typename BinaryOperation>
-T joint_reduce(Group g, Ptr first, Ptr last, T init, BinaryOperation binary_op); // (2)
+T joint_reduce(Group g, Ptr first, Ptr last, T init,
+               BinaryOperation binary_op); // (2)
 
 template <typename Group, typename T, typename BinaryOperation>
 T reduce_over_group(Group g, T x, BinaryOperation binary_op); // (3)

--- a/adoc/headers/aspectTraits.h
+++ b/adoc/headers/aspectTraits.h
@@ -6,7 +6,9 @@ namespace sycl {
 template <aspect Aspect> struct any_device_has;
 template <aspect Aspect> struct all_devices_have;
 
-template <aspect A> inline constexpr bool any_device_has_v = any_device_has<A>::value;
-template <aspect A> inline constexpr bool all_devices_have_v = all_devices_have<A>::value;
+template <aspect A>
+inline constexpr bool any_device_has_v = any_device_has<A>::value;
+template <aspect A>
+inline constexpr bool all_devices_have_v = all_devices_have<A>::value;
 
-}
+} // namespace sycl

--- a/adoc/headers/atomic.h
+++ b/adoc/headers/atomic.h
@@ -5,59 +5,49 @@ namespace cl {
 namespace sycl {
 
 /* Deprecated in SYCL 2020 */
-enum class memory_order : /* unspecified */ {
-  relaxed
-};
+enum class memory_order : /* unspecified */ { relaxed };
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace =
-  access::address_space::global_space>
+                          access::address_space::global_space>
 class atomic {
  public:
   template <typename PointerT, access::decorated IsDecorated>
   atomic(multi_ptr<PointerT, AddressSpace, IsDecorated> ptr);
 
-  void store(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  void store(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   T load(memory_order memoryOrder = memory_order::relaxed) const;
 
-  T exchange(T operand, memory_order memoryOrder =
-   memory_order::relaxed);
+  T exchange(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  bool compare_exchange_strong(T &expected, T desired,
-    memory_order successMemoryOrder = memory_order::relaxed,
-    memory_order failMemoryOrder = memory_order::relaxed);
+  bool compare_exchange_strong(
+      T& expected, T desired,
+      memory_order successMemoryOrder = memory_order::relaxed,
+      memory_order failMemoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_add(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_add(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_sub(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_sub(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_and(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_and(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_or(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_or(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_xor(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_xor(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_min(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_min(T operand, memory_order memoryOrder = memory_order::relaxed);
 
   /* Available only when: T != float */
-  T fetch_max(T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+  T fetch_max(T operand, memory_order memoryOrder = memory_order::relaxed);
 };
 
-}  // namespace sycl
-}  // namespace cl
+} // namespace sycl
+} // namespace cl

--- a/adoc/headers/atomicoperations.h
+++ b/adoc/headers/atomicoperations.h
@@ -5,58 +5,59 @@ namespace cl {
 namespace sycl {
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-void atomic_store(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+void atomic_store(atomic<T, AddressSpace> object, T operand,
+                  memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_load(atomic<T, AddressSpace> object, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_load(atomic<T, AddressSpace> object,
+              memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_exchange(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_exchange(atomic<T, AddressSpace> object, T operand,
+                  memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-bool atomic_compare_exchange_strong(atomic<T, AddressSpace> object, T &expected, T desired,
+bool atomic_compare_exchange_strong(
+    atomic<T, AddressSpace> object, T& expected, T desired,
     memory_order successMemoryOrder = memory_order::relaxed,
     memory_order failMemoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_add(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-    memory_order::relaxed);
+T atomic_fetch_add(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_sub(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_fetch_sub(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_and(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_fetch_and(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_or(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_fetch_or(atomic<T, AddressSpace> object, T operand,
+                  memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_xor(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_fetch_xor(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_min(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
+T atomic_fetch_min(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
 
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
-T atomic_fetch_max(atomic<T, AddressSpace> object, T operand, memory_order memoryOrder =
-  memory_order::relaxed);
-}  // namespace sycl
-}  // namespace cl
+T atomic_fetch_max(atomic<T, AddressSpace> object, T operand,
+                   memory_order memoryOrder = memory_order::relaxed);
+} // namespace sycl
+} // namespace cl

--- a/adoc/headers/atomicref.h
+++ b/adoc/headers/atomicref.h
@@ -4,36 +4,34 @@
 namespace sycl {
 
 // Exposition only
-template <memory_order ReadModifyWriteOrder>
-struct memory_order_traits;
+template <memory_order ReadModifyWriteOrder> struct memory_order_traits;
 
-template <>
-struct memory_order_traits<memory_order::relaxed> {
+template <> struct memory_order_traits<memory_order::relaxed> {
   static constexpr memory_order read_order = memory_order::relaxed;
   static constexpr memory_order write_order = memory_order::relaxed;
 };
 
-template <>
-struct memory_order_traits<memory_order::acq_rel> {
+template <> struct memory_order_traits<memory_order::acq_rel> {
   static constexpr memory_order read_order = memory_order::acquire;
   static constexpr memory_order write_order = memory_order::release;
 };
 
-template <>
-struct memory_order_traits<memory_order::seq_cst> {
+template <> struct memory_order_traits<memory_order::seq_cst> {
   static constexpr memory_order read_order = memory_order::seq_cst;
   static constexpr memory_order write_order = memory_order::seq_cst;
 };
 
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope, access::address_space Space = access::address_space::generic_space>
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space = access::address_space::generic_space>
 class atomic_ref {
  public:
-
   using value_type = T;
   static constexpr size_t required_alignment = /* implementation-defined */;
   static constexpr bool is_always_lock_free = /* implementation-defined */;
-  static constexpr memory_order default_read_order = memory_order_traits<DefaultOrder>::read_order;
-  static constexpr memory_order default_write_order = memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
   static constexpr memory_order default_read_modify_write_order = DefaultOrder;
   static constexpr memory_scope default_scope = DefaultScope;
 
@@ -43,42 +41,42 @@ class atomic_ref {
   atomic_ref(const atomic_ref&) noexcept;
   atomic_ref& operator=(const atomic_ref&) = delete;
 
-  void store(T operand,
-    memory_order order = default_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  void store(T operand, memory_order order = default_write_order,
+             memory_scope scope = default_scope) const noexcept;
 
   T operator=(T desired) const noexcept;
 
   T load(memory_order order = default_read_order,
-    memory_scope scope = default_scope) const noexcept;
+         memory_scope scope = default_scope) const noexcept;
 
   operator T() const noexcept;
 
-  T exchange(T operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  T exchange(T operand, memory_order order = default_read_modify_write_order,
+             memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_weak(T &expected, T desired,
-    memory_order success,
-    memory_order failure,
-    memory_scope scope = default_scope) const noexcept;
+  bool compare_exchange_weak(T& expected, T desired, memory_order success,
+                             memory_order failure,
+                             memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_weak(T &expected, T desired,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_weak(T& expected, T desired,
+                        memory_order order = default_read_modify_write_order,
+                        memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_strong(T &expected, T desired,
-    memory_order success,
-    memory_order failure,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_strong(T& expected, T desired, memory_order success,
+                          memory_order failure,
+                          memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_strong(T &expected, T desired,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_strong(T& expected, T desired,
+                          memory_order order = default_read_modify_write_order,
+                          memory_scope scope = default_scope) const noexcept;
 };
 
 // Partial specialization for integral types
-template <memory_order DefaultOrder, memory_scope DefaultScope, access::address_space Space = access::address_space::generic_space>
+template <memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space = access::address_space::generic_space>
 class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
 
   /* All other members from atomic_ref<T> are available */
@@ -86,28 +84,28 @@ class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
   using difference_type = value_type;
 
   Integral fetch_add(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Integral fetch_sub(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Integral fetch_and(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Integral fetch_or(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                    memory_order order = default_read_modify_write_order,
+                    memory_scope scope = default_scope) const noexcept;
 
   Integral fetch_min(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Integral fetch_max(Integral operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Integral operator++(int) const noexcept;
   Integral operator--(int) const noexcept;
@@ -118,11 +116,11 @@ class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
   Integral operator&=(Integral) const noexcept;
   Integral operator|=(Integral) const noexcept;
   Integral operator^=(Integral) const noexcept;
-
 };
 
 // Partial specialization for floating-point types
-template <memory_order DefaultOrder, memory_scope DefaultScope, access::address_space Space = access::address_space::generic_space>
+template <memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space = access::address_space::generic_space>
 class atomic_ref<Floating, DefaultOrder, DefaultScope, Space> {
 
   /* All other members from atomic_ref<T> are available */
@@ -130,36 +128,38 @@ class atomic_ref<Floating, DefaultOrder, DefaultScope, Space> {
   using difference_type = value_type;
 
   Floating fetch_add(Floating operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Floating fetch_sub(Floating operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Floating fetch_min(Floating operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Floating fetch_max(Floating operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
 
   Floating operator+=(Floating) const noexcept;
   Floating operator-=(Floating) const noexcept;
-
 };
 
 // Partial specialization for pointers
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope, access::address_space Space = access::address_space::generic_space>
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space = access::address_space::generic_space>
 class atomic_ref<T*, DefaultOrder, DefaultScope, Space> {
 
   using value_type = T*;
   using difference_type = ptrdiff_t;
   static constexpr size_t required_alignment = /* implementation-defined */;
   static constexpr bool is_always_lock_free = /* implementation-defined */;
-  static constexpr memory_order default_read_order = memory_order_traits<DefaultOrder>::read_order;
-  static constexpr memory_order default_write_order = memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
   static constexpr memory_order default_read_modify_write_order = DefaultOrder;
   static constexpr memory_scope default_scope = DefaultScope;
 
@@ -169,46 +169,45 @@ class atomic_ref<T*, DefaultOrder, DefaultScope, Space> {
   atomic_ref(const atomic_ref&) noexcept;
   atomic_ref& operator=(const atomic_ref&) = delete;
 
-  void store(T* operand,
-    memory_order order = default_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  void store(T* operand, memory_order order = default_write_order,
+             memory_scope scope = default_scope) const noexcept;
 
   T* operator=(T* desired) const noexcept;
 
   T* load(memory_order order = default_read_order,
-    memory_scope scope = default_scope) const noexcept;
+          memory_scope scope = default_scope) const noexcept;
 
   operator T*() const noexcept;
 
-  T* exchange(T* operand,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  T* exchange(T* operand, memory_order order = default_read_modify_write_order,
+              memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_weak(T* &expected, T* desired,
-    memory_order success,
-    memory_order failure,
-    memory_scope scope = default_scope) const noexcept;
+  bool compare_exchange_weak(T*& expected, T* desired, memory_order success,
+                             memory_order failure,
+                             memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_weak(T* &expected, T* desired,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_weak(T*& expected, T* desired,
+                        memory_order order = default_read_modify_write_order,
+                        memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_strong(T* &expected, T* desired,
-    memory_order success,
-    memory_order failure,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_strong(T*& expected, T* desired, memory_order success,
+                          memory_order failure,
+                          memory_scope scope = default_scope) const noexcept;
 
-  bool compare_exchange_strong(T* &expected, T* desired,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+  bool
+  compare_exchange_strong(T*& expected, T* desired,
+                          memory_order order = default_read_modify_write_order,
+                          memory_scope scope = default_scope) const noexcept;
 
   T* fetch_add(difference_type,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+               memory_order order = default_read_modify_write_order,
+               memory_scope scope = default_scope) const noexcept;
 
   T* fetch_sub(difference_type,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept;
+               memory_order order = default_read_modify_write_order,
+               memory_scope scope = default_scope) const noexcept;
 
   T* operator++(int) const noexcept;
   T* operator--(int) const noexcept;
@@ -216,7 +215,6 @@ class atomic_ref<T*, DefaultOrder, DefaultScope, Space> {
   T* operator--() const noexcept;
   T* operator+=(difference_type) const noexcept;
   T* operator-=(difference_type) const noexcept;
-
 };
 
 } // namespace sycl

--- a/adoc/headers/backends.h
+++ b/adoc/headers/backends.h
@@ -5,4 +5,4 @@ namespace sycl {
 enum class backend : /* unspecified */ {
   /* see below */
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/buffer.h
+++ b/adoc/headers/buffer.h
@@ -5,94 +5,94 @@ namespace sycl {
 namespace property {
 namespace buffer {
 class use_host_ptr {
-  public:
-    use_host_ptr() = default;
+ public:
+  use_host_ptr() = default;
 };
 
 class use_mutex {
-  public:
-    use_mutex(std::mutex &mutexRef);
+ public:
+  use_mutex(std::mutex& mutexRef);
 
-    std::mutex *get_mutex_ptr() const;
+  std::mutex* get_mutex_ptr() const;
 };
 
 class context_bound {
-  public:
-    context_bound(context boundContext);
+ public:
+  context_bound(context boundContext);
 
-    context get_context() const;
+  context get_context() const;
 };
-}  // namespace buffer
-}  // namespace property
+} // namespace buffer
+} // namespace property
 
 template <typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 class buffer {
  public:
   using value_type = T;
-  using reference = value_type &;
-  using const_reference = const value_type &;
+  using reference = value_type&;
+  using const_reference = const value_type&;
   using allocator_type = AllocatorT;
 
-  buffer(const range<Dimensions> &bufferRange,
-         const property_list &propList = {});
+  buffer(const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
-  buffer(const range<Dimensions> &bufferRange, AllocatorT allocator,
-         const property_list &propList = {});
+  buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
 
-  buffer(T *hostData, const range<Dimensions> &bufferRange,
-         const property_list &propList = {});
+  buffer(T* hostData, const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
-  buffer(T *hostData, const range<Dimensions> &bufferRange,
-         AllocatorT allocator, const property_list &propList = {});
+  buffer(T* hostData, const range<Dimensions>& bufferRange,
+         AllocatorT allocator, const property_list& propList = {});
 
-  buffer(const T *hostData, const range<Dimensions> &bufferRange,
-         const property_list &propList = {});
+  buffer(const T* hostData, const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
-  buffer(const T *hostData, const range<Dimensions> &bufferRange,
-         AllocatorT allocator, const property_list &propList = {});
-
-  /* Available only if Container is a contiguous container:
-       - std::data(container) and std::size(container) are well formed
-       - return type of std::data(container) is convertible to T*
-     and Dimensions == 1 */
-  template <typename Container>
-  buffer(Container &container, AllocatorT allocator,
-         const property_list &propList = {});
+  buffer(const T* hostData, const range<Dimensions>& bufferRange,
+         AllocatorT allocator, const property_list& propList = {});
 
   /* Available only if Container is a contiguous container:
        - std::data(container) and std::size(container) are well formed
        - return type of std::data(container) is convertible to T*
      and Dimensions == 1 */
   template <typename Container>
-  buffer(Container &container, const property_list &propList = {});
+  buffer(Container& container, AllocatorT allocator,
+         const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T> &hostData,
-         const range<Dimensions> &bufferRange, AllocatorT allocator,
-         const property_list &propList = {});
+  /* Available only if Container is a contiguous container:
+       - std::data(container) and std::size(container) are well formed
+       - return type of std::data(container) is convertible to T*
+     and Dimensions == 1 */
+  template <typename Container>
+  buffer(Container& container, const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T> &hostData,
-         const range<Dimensions> &bufferRange,
-         const property_list &propList = {});
+  buffer(const std::shared_ptr<T>& hostData,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]> &hostData,
-         const range<Dimensions> &bufferRange, AllocatorT allocator,
-         const property_list &propList = {});
+  buffer(const std::shared_ptr<T>& hostData,
+         const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]> &hostData,
-         const range<Dimensions> &bufferRange,
-         const property_list &propList = {});
+  buffer(const std::shared_ptr<T[]>& hostData,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T[]>& hostData,
+         const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
   template <class InputIterator>
   buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
-               const property_list &propList = {});
+               const property_list& propList = {});
 
   template <class InputIterator>
   buffer<T, 1>(InputIterator first, InputIterator last,
-               const property_list &propList = {});
+               const property_list& propList = {});
 
-  buffer(buffer &b, const id<Dimensions> &baseIndex,
-         const range<Dimensions> &subRange);
+  buffer(buffer& b, const id<Dimensions>& baseIndex,
+         const range<Dimensions>& subRange);
 
   /* -- common interface members -- */
 
@@ -112,29 +112,28 @@ class buffer {
 
   AllocatorT get_allocator() const;
 
-  template <access_mode Mode = access_mode::read_write, target Targ = target::device>
-  accessor<T, Dimensions, Mode, Targ> get_access(
-      handler &commandGroupHandler);
+  template <access_mode Mode = access_mode::read_write,
+            target Targ = target::device>
+  accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler);
 
   // Deprecated
   template <access_mode Mode>
   accessor<T, Dimensions, Mode, target::host_buffer> get_access();
 
-  template <access_mode Mode = access_mode::read_write, target Targ = target::device>
-  accessor<T, Dimensions, Mode, Targ> get_access(
-      handler &commandGroupHandler, range<Dimensions> accessRange,
-      id<Dimensions> accessOffset = {});
+  template <access_mode Mode = access_mode::read_write,
+            target Targ = target::device>
+  accessor<T, Dimensions, Mode, Targ>
+  get_access(handler& commandGroupHandler, range<Dimensions> accessRange,
+             id<Dimensions> accessOffset = {});
 
   // Deprecated
   template <access_mode Mode>
-  accessor<T, Dimensions, Mode, target::host_buffer> get_access(
-    range<Dimensions> accessRange, id<Dimensions> accessOffset = {});
+  accessor<T, Dimensions, Mode, target::host_buffer>
+  get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {});
 
-  template<typename... Ts>
-  auto get_access(Ts...);
+  template <typename... Ts> auto get_access(Ts...);
 
-  template<typename... Ts>
-  auto get_host_access(Ts...);
+  template <typename... Ts> auto get_host_access(Ts...);
 
   template <typename Destination = std::nullptr_t>
   void set_final_data(Destination finalData = nullptr);
@@ -161,29 +160,28 @@ class buffer {
 
 // Deduction guides
 template <class InputIterator, class AllocatorT>
-buffer(InputIterator, InputIterator, AllocatorT, const property_list & = {})
+buffer(InputIterator, InputIterator, AllocatorT, const property_list& = {})
     -> buffer<typename std::iterator_traits<InputIterator>::value_type, 1,
-             AllocatorT>;
+              AllocatorT>;
 
 template <class InputIterator>
-buffer(InputIterator, InputIterator, const property_list & = {})
+buffer(InputIterator, InputIterator, const property_list& = {})
     -> buffer<typename std::iterator_traits<InputIterator>::value_type, 1>;
 
 template <class T, int Dimensions, class AllocatorT>
-buffer(const T *, const range<Dimensions> &, AllocatorT,
-       const property_list & = {})
-    -> buffer<T, Dimensions, AllocatorT>;
+buffer(const T*, const range<Dimensions>&, AllocatorT,
+       const property_list& = {}) -> buffer<T, Dimensions, AllocatorT>;
 
 template <class T, int Dimensions>
-buffer(const T *, const range<Dimensions> &, const property_list & = {})
+buffer(const T*, const range<Dimensions>&, const property_list& = {})
     -> buffer<T, Dimensions>;
 
 template <class Container, class AllocatorT>
-buffer(Container &, AllocatorT, const property_list & = {})
-    ->buffer<typename Container::value_type, 1, AllocatorT>;
+buffer(Container&, AllocatorT, const property_list& = {})
+    -> buffer<typename Container::value_type, 1, AllocatorT>;
 
 template <class Container>
-buffer(Container &, const property_list & = {})
-    ->buffer<typename Container::value_type, 1>;
+buffer(Container&, const property_list& = {})
+    -> buffer<typename Container::value_type, 1>;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/bundle/deviceImageClass.h
+++ b/adoc/headers/bundle/deviceImageClass.h
@@ -3,14 +3,13 @@
 
 namespace sycl {
 
-template<bundle_state State>
-class device_image {
+template <bundle_state State> class device_image {
  public:
   device_image() = delete;
 
-  bool has_kernel(const kernel_id &kernelId) const noexcept;
+  bool has_kernel(const kernel_id& kernelId) const noexcept;
 
-  bool has_kernel(const kernel_id &kernelId, const device &dev) const noexcept;
+  bool has_kernel(const kernel_id& kernelId, const device& dev) const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/bundle/freeFunctions.h
+++ b/adoc/headers/bundle/freeFunctions.h
@@ -3,117 +3,105 @@
 
 namespace sycl {
 
-enum class bundle_state : /* unspecified */ {
-  input,
-  object,
-  executable
+enum class bundle_state : /* unspecified */ { input, object, executable };
+
+class kernel_id { /* ... */
 };
 
+template <bundle_state State> class kernel_bundle { /* ... */
+};
 
-class kernel_id { /* ... */ };
-
-template<bundle_state State>
-class kernel_bundle { /* ... */ };
-
-
-template <typename KernelName>
-kernel_id get_kernel_id();
+template <typename KernelName> kernel_id get_kernel_id();
 
 std::vector<kernel_id> get_kernel_ids();
 
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt);
 
-template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt);
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<kernel_id>& kernelIds);
 
-template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt,
-                                       const std::vector<kernel_id> &kernelIds);
+template <typename KernelName, bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt);
 
-template<typename KernelName, bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt);
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<device>& devs);
 
-template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+template <bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<device>& devs,
+                                       const std::vector<kernel_id>& kernelIds);
 
-template<bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs,
-                                       const std::vector<kernel_id> &kernelIds);
+template <typename KernelName, bundle_state State>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<device>& devs);
 
-template<typename KernelName, bundle_state State>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+template <bundle_state State, typename Selector>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt, Selector selector);
 
-template<bundle_state State, typename Selector>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, Selector selector);
-
-template<bundle_state State, typename Selector>
-kernel_bundle<State> get_kernel_bundle(const context &ctxt, const std::vector<device> &devs,
+template <bundle_state State, typename Selector>
+kernel_bundle<State> get_kernel_bundle(const context& ctxt,
+                                       const std::vector<device>& devs,
                                        Selector selector);
 
+template <bundle_state State> bool has_kernel_bundle(const context& ctxt);
 
-template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt);
+template <bundle_state State>
+bool has_kernel_bundle(const context& ctxt,
+                       const std::vector<kernel_id>& kernelIds);
 
-template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<kernel_id> &kernelIds);
+template <typename KernelName, bundle_state State>
+bool has_kernel_bundle(const context& ctxt);
 
-template<typename KernelName, bundle_state State>
-bool has_kernel_bundle(const context &ctxt);
+template <bundle_state State>
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 
-template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+template <bundle_state State>
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs,
+                       const std::vector<kernel_id>& kernelIds);
 
-template<bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs,
-                       const std::vector<kernel_id> &kernelIds);
+template <typename KernelName, bundle_state State>
+bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 
-template<typename KernelName, bundle_state State>
-bool has_kernel_bundle(const context &ctxt, const std::vector<device> &devs);
+bool is_compatible(const std::vector<kernel_id>& kernelIds, const device& dev);
 
+template <typename KernelName> bool is_compatible(const device& dev);
 
-bool is_compatible(const std::vector<kernel_id> &kernelIds, const device &dev);
-
-template<typename KernelName>
-bool is_compatible(const device &dev);
-
-
-template<bundle_state State>
-kernel_bundle<State> join(const std::vector<kernel_bundle<State>> &bundles);
-
+template <bundle_state State>
+kernel_bundle<State> join(const std::vector<kernel_bundle<State>>& bundles);
 
 kernel_bundle<bundle_state::object>
-compile(const kernel_bundle<bundle_state::input> &inputBundle,
-        const property_list &propList = {});
+compile(const kernel_bundle<bundle_state::input>& inputBundle,
+        const property_list& propList = {});
 
 kernel_bundle<bundle_state::object>
-compile(const kernel_bundle<bundle_state::input> &inputBundle,
-        const std::vector<device> &devs,
-        const property_list &propList = {});
+compile(const kernel_bundle<bundle_state::input>& inputBundle,
+        const std::vector<device>& devs, const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-link(const kernel_bundle<bundle_state::object> &objectBundle,
-     const property_list &propList = {});
+link(const kernel_bundle<bundle_state::object>& objectBundle,
+     const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-link(const std::vector<kernel_bundle<bundle_state::object>> &objectBundles,
-     const property_list &propList = {});
+link(const std::vector<kernel_bundle<bundle_state::object>>& objectBundles,
+     const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-link(const kernel_bundle<bundle_state::object> &objectBundle,
-     const std::vector<device> &devs,
-     const property_list &propList = {});
+link(const kernel_bundle<bundle_state::object>& objectBundle,
+     const std::vector<device>& devs, const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-link(const std::vector<kernel_bundle<bundle_state::object>> &objectBundles,
-     const std::vector<device> &devs,
-     const property_list &propList = {});
+link(const std::vector<kernel_bundle<bundle_state::object>>& objectBundles,
+     const std::vector<device>& devs, const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-build(const kernel_bundle<bundle_state::input> &inputBundle,
-      const property_list &propList = {});
+build(const kernel_bundle<bundle_state::input>& inputBundle,
+      const property_list& propList = {});
 
 kernel_bundle<bundle_state::executable>
-build(const kernel_bundle<bundle_state::input> &inputBundle,
-      const std::vector<device> &devs,
-      const property_list &propList = {});
+build(const kernel_bundle<bundle_state::input>& inputBundle,
+      const std::vector<device>& devs, const property_list& propList = {});
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/bundle/kernelBundleClass.h
+++ b/adoc/headers/bundle/kernelBundleClass.h
@@ -3,10 +3,10 @@
 
 namespace sycl {
 
-class kernel { /* ... */ };
+class kernel { /* ... */
+};
 
-template<bundle_state State>
-class kernel_bundle {
+template <bundle_state State> class kernel_bundle {
  public:
   using device_image_iterator = __unspecified__;
 
@@ -20,38 +20,35 @@ class kernel_bundle {
 
   std::vector<device> get_devices() const noexcept;
 
-  bool has_kernel(const kernel_id &kernelId) const noexcept;
+  bool has_kernel(const kernel_id& kernelId) const noexcept;
 
-  bool has_kernel(const kernel_id &kernelId, const device &dev) const noexcept;
+  bool has_kernel(const kernel_id& kernelId, const device& dev) const noexcept;
 
-  template<typename KernelName>
-  bool has_kernel() const noexcept;
+  template <typename KernelName> bool has_kernel() const noexcept;
 
-  template<typename KernelName>
-  bool has_kernel(const device &dev) const noexcept;
+  template <typename KernelName>
+  bool has_kernel(const device& dev) const noexcept;
 
   std::vector<kernel_id> get_kernel_ids() const;
 
   /* Available only when: (State == bundle_state::executable) */
-  kernel get_kernel(const kernel_id &kernelId) const;
+  kernel get_kernel(const kernel_id& kernelId) const;
 
   /* Available only when: (State == bundle_state::executable) */
-  template<typename KernelName>
-  kernel get_kernel() const;
+  template <typename KernelName> kernel get_kernel() const;
 
   bool contains_specialization_constants() const noexcept;
 
   bool native_specialization_constant() const noexcept;
 
-  template<auto& SpecName>
-  bool has_specialization_constant() const noexcept;
+  template <auto& SpecName> bool has_specialization_constant() const noexcept;
 
   /* Available only when: (State == bundle_state::input) */
-  template<auto& SpecName>
+  template <auto& SpecName>
   void set_specialization_constant(
-    typename std::remove_reference_t<decltype(SpecName)>::value_type value);
+      typename std::remove_reference_t<decltype(SpecName)>::value_type value);
 
-  template<auto& SpecName>
+  template <auto& SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant() const;
 
@@ -60,4 +57,4 @@ class kernel_bundle {
   device_image_iterator end() const;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/bundle/kernelClass.h
+++ b/adoc/headers/bundle/kernelClass.h
@@ -13,14 +13,13 @@ class kernel {
 
   kernel_bundle<bundle_state::executable> get_kernel_bundle() const;
 
-  template <typename Param>
-  typename Param::return_type get_info() const;
+  template <typename Param> typename Param::return_type get_info() const;
 
   template <typename Param>
-  typename Param::return_type get_info(const device &dev) const;
+  typename Param::return_type get_info(const device& dev) const;
 
   template <typename Param>
   typename Param::return_type get_backend_info() const;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/bundle/kernelIdClass.h
+++ b/adoc/headers/bundle/kernelIdClass.h
@@ -7,7 +7,7 @@ class kernel_id {
  public:
   kernel_id() = delete;
 
-  const char *get_name() const noexcept;
+  const char* get_name() const noexcept;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/commandGroup.h
+++ b/adoc/headers/commandGroup.h
@@ -5,11 +5,11 @@ namespace sycl {
 class command_group {
  public:
   template <typename FunctorT>
-  command_group(queue &primaryQueue, const FunctorT &lambda);
+  command_group(queue& primaryQueue, const FunctorT& lambda);
 
   template <typename FunctorT>
-  command_group(queue &primaryQueue, queue &secondaryQueue,
-                const FunctorT &lambda);
+  command_group(queue& primaryQueue, queue& secondaryQueue,
+                const FunctorT& lambda);
 
   ~command_group();
 
@@ -19,4 +19,4 @@ class command_group {
 
   event complete_event();
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -5,28 +5,24 @@ namespace sycl {
 
 class handler {
  private:
-
   // implementation defined constructor
   handler(___unspecified___);
 
  public:
-
   template <typename DataT, int Dimensions, access_mode AccessMode,
-    target AccessTarget, access::placeholder IsPlaceholder>
-  void require(accessor<DataT, Dimensions, AccessMode, AccessTarget,
-               IsPlaceholder> acc);
+            target AccessTarget, access::placeholder IsPlaceholder>
+  void require(
+      accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder> acc);
 
   void depends_on(event depEvent);
 
-  void depends_on(const std::vector<event> &depEvents);
+  void depends_on(const std::vector<event>& depEvents);
 
   //----- Backend interoperability interface
   //
-  template <typename T>
-  void set_arg(int argIndex, T && arg);
+  template <typename T> void set_arg(int argIndex, T&& arg);
 
-  template <typename... Ts>
-  void set_args(Ts &&... args);
+  template <typename... Ts> void set_args(Ts&&... args);
 
   //------ Kernel dispatch API
   //
@@ -34,12 +30,12 @@ class handler {
   // "typename KernelName" is optional.
   //
   template <typename KernelName, typename KernelType>
-  void single_task(const KernelType &kernelFunc);
+  void single_task(const KernelType& kernelFunc);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dimensions, typename... Rest>
-  void parallel_for(range<Dimensions> numWorkItems,
-                    Rest&&... rest);
+  void parallel_for(range<Dimensions> numWorkItems, Rest&&... rest);
 
   // Deprecated in SYCL 2020.
   template <typename KernelName, typename KernelType, int Dimensions>
@@ -47,89 +43,90 @@ class handler {
                     id<Dimensions> workItemOffset,
                     const KernelType& kernelFunc);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dimensions, typename... Rest>
-  void parallel_for(nd_range<Dimensions> executionRange,
-                    Rest&&... rest);
+  void parallel_for(nd_range<Dimensions> executionRange, Rest&&... rest);
 
   template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
   void parallel_for_work_group(range<Dimensions> numWorkGroups,
-                               const WorkgroupFunctionType &kernelFunc);
+                               const WorkgroupFunctionType& kernelFunc);
 
   template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
   void parallel_for_work_group(range<Dimensions> numWorkGroups,
                                range<Dimensions> workGroupSize,
-                               const WorkgroupFunctionType &kernelFunc);
+                               const WorkgroupFunctionType& kernelFunc);
 
-  void single_task(const kernel &kernelObject);
-
-  template <int Dimensions>
-  void parallel_for(range<Dimensions> numWorkItems, const kernel &kernelObject);
+  void single_task(const kernel& kernelObject);
 
   template <int Dimensions>
-  void parallel_for(nd_range<Dimensions> ndRange, const kernel &kernelObject);
+  void parallel_for(range<Dimensions> numWorkItems, const kernel& kernelObject);
 
+  template <int Dimensions>
+  void parallel_for(nd_range<Dimensions> ndRange, const kernel& kernelObject);
 
   //------ USM functions
   //
 
-  void memcpy(void *dest, const void *src, size_t numBytes);
+  void memcpy(void* dest, const void* src, size_t numBytes);
 
-  template <typename T>
-  void copy(const T *src, T *dest, size_t count);
+  template <typename T> void copy(const T* src, T* dest, size_t count);
 
-  void memset(void *ptr, int value, size_t numBytes);
+  void memset(void* ptr, int value, size_t numBytes);
 
-  template <typename T>
-  void fill(void *ptr, const T &pattern, size_t count);
+  template <typename T> void fill(void* ptr, const T& pattern, size_t count);
 
-  void prefetch(void *ptr, size_t numBytes);
+  void prefetch(void* ptr, size_t numBytes);
 
-  void mem_advise(void *ptr, size_t numBytes, int advice);
-
+  void mem_advise(void* ptr, size_t numBytes, int advice);
 
   //------ Explicit memory operation APIs
   //
-  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt, access::placeholder IsPlaceholder,
-            typename DestT>
+  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt,
+            access::placeholder IsPlaceholder, typename DestT>
   void copy(accessor<SrcT, SrcDim, SrcMode, SrcTgt, IsPlaceholder> src,
             std::shared_ptr<DestT> dest);
 
-  template <typename SrcT,
-            typename DestT, int DestDim, access_mode DestMode, target DestTgt, access::placeholder IsPlaceholder>
+  template <typename SrcT, typename DestT, int DestDim, access_mode DestMode,
+            target DestTgt, access::placeholder IsPlaceholder>
   void copy(std::shared_ptr<SrcT> src,
             accessor<DestT, DestDim, DestMode, DestTgt, IsPlaceholder> dest);
 
-  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt, access::placeholder IsPlaceholder,
-            typename DestT>
+  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt,
+            access::placeholder IsPlaceholder, typename DestT>
   void copy(accessor<SrcT, SrcDim, SrcMode, SrcTgt, IsPlaceholder> src,
-            DestT *dest);
+            DestT* dest);
 
-  template <typename SrcT,
-            typename DestT, int DestDim, access_mode DestMode, target DestTgt, access::placeholder IsPlaceholder>
-  void copy(const SrcT *src,
+  template <typename SrcT, typename DestT, int DestDim, access_mode DestMode,
+            target DestTgt, access::placeholder IsPlaceholder>
+  void copy(const SrcT* src,
             accessor<DestT, DestDim, DestMode, DestTgt, IsPlaceholder> dest);
 
-  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt, access::placeholder SrcIsPlaceholder,
-            typename DestT, int DestDim, access_mode DestMode, target DestTgt, access::placeholder DestIsPlaceholder>
-  void copy(accessor<SrcT, SrcDim, SrcMode, SrcTgt, SrcIsPlaceholder> src,
-            accessor<DestT, DestDim , DestMode, DestTgt, DestIsPlaceholder> dest);
+  template <typename SrcT, int SrcDim, access_mode SrcMode, target SrcTgt,
+            access::placeholder SrcIsPlaceholder, typename DestT, int DestDim,
+            access_mode DestMode, target DestTgt,
+            access::placeholder DestIsPlaceholder>
+  void
+  copy(accessor<SrcT, SrcDim, SrcMode, SrcTgt, SrcIsPlaceholder> src,
+       accessor<DestT, DestDim, DestMode, DestTgt, DestIsPlaceholder> dest);
 
-  template <typename T, int Dim, access_mode Mode, target Tgt, access::placeholder IsPlaceholder>
+  template <typename T, int Dim, access_mode Mode, target Tgt,
+            access::placeholder IsPlaceholder>
   void update_host(accessor<T, Dim, Mode, Tgt, IsPlaceholder> acc);
 
-  template <typename T, int Dim, access_mode Mode, target Tgt, access::placeholder IsPlaceholder>
+  template <typename T, int Dim, access_mode Mode, target Tgt,
+            access::placeholder IsPlaceholder>
   void fill(accessor<T, Dim, Mode, Tgt, IsPlaceholder> dest, const T& src);
 
-  void use_kernel_bundle(const kernel_bundle<bundle_state::executable> &execBundle);
+  void
+  use_kernel_bundle(const kernel_bundle<bundle_state::executable>& execBundle);
 
-  template<auto& SpecName>
+  template <auto& SpecName>
   void set_specialization_constant(
       typename std::remove_reference_t<decltype(SpecName)>::value_type value);
 
-  template<auto& SpecName>
+  template <auto& SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant();
-
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/common-byval.h
+++ b/adoc/headers/common-byval.h
@@ -6,29 +6,32 @@ namespace sycl {
 class T {
   ...
 
- public:
-  // If any of the following five special member functions are not
-  // public, inline or defaulted, then all five of them should be
-  // explicitly declared (see rule of five).
-  // Otherwise, none of them should be explicitly declared
-  // (see rule of zero).
+      public
+      :
+      // If any of the following five special member functions are not
+      // public, inline or defaulted, then all five of them should be
+      // explicitly declared (see rule of five).
+      // Otherwise, none of them should be explicitly declared
+      // (see rule of zero).
 
-  // T(const T &rhs);
+      // T(const T &rhs);
 
-  // T(T &&rhs);
+      // T(T &&rhs);
 
-  // T &operator=(const T &rhs);
+      // T &operator=(const T &rhs);
 
-  // T &operator=(T &&rhs);
+      // T &operator=(T &&rhs);
 
-  // ~T();
+      // ~T();
 
-  ...
+      ...
 
-  friend bool operator==(const T &lhs, const T &rhs) { /* ... */ }
+      friend bool
+      operator==(const T& lhs, const T& rhs) { /* ... */
+  }
 
-  friend bool operator!=(const T &lhs, const T &rhs) { /* ... */ }
+  friend bool operator!=(const T& lhs, const T& rhs) { /* ... */ }
 
   ...
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/common-reference.h
+++ b/adoc/headers/common-reference.h
@@ -6,23 +6,24 @@ namespace sycl {
 class T {
   ...
 
- public:
-  T(const T &rhs);
+      public : T(const T& rhs);
 
-  T(T &&rhs);
+  T(T&& rhs);
 
-  T &operator=(const T &rhs);
+  T& operator=(const T& rhs);
 
-  T &operator=(T &&rhs);
+  T& operator=(T&& rhs);
 
   ~T();
 
   ...
 
-  friend bool operator==(const T &lhs, const T &rhs) { /* ... */ }
+      friend bool
+      operator==(const T& lhs, const T& rhs) { /* ... */
+  }
 
-  friend bool operator!=(const T &lhs, const T &rhs) { /* ... */ }
+  friend bool operator!=(const T& lhs, const T& rhs) { /* ... */ }
 
   ...
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/context.h
+++ b/adoc/headers/context.h
@@ -4,22 +4,22 @@
 namespace sycl {
 class context {
  public:
-  explicit context(const property_list &propList = {});
+  explicit context(const property_list& propList = {});
 
   explicit context(async_handler asyncHandler,
-                   const property_list &propList = {});
+                   const property_list& propList = {});
 
-  explicit context(const device &dev, const property_list &propList = {});
+  explicit context(const device& dev, const property_list& propList = {});
 
-  explicit context(const device &dev, async_handler asyncHandler,
-                   const property_list &propList = {});
+  explicit context(const device& dev, async_handler asyncHandler,
+                   const property_list& propList = {});
 
-  explicit context(const std::vector<device> &deviceList,
-                   const property_list &propList = {});
+  explicit context(const std::vector<device>& deviceList,
+                   const property_list& propList = {});
 
-  explicit context(const std::vector<device> &deviceList,
+  explicit context(const std::vector<device>& deviceList,
                    async_handler asyncHandler,
-                   const property_list &propList = {});
+                   const property_list& propList = {});
 
   /* -- property interface members -- */
 
@@ -36,4 +36,4 @@ class context {
   template <typename Param>
   typename Param::return_type get_backend_info() const;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/contextInfo.h
+++ b/adoc/headers/contextInfo.h
@@ -12,6 +12,6 @@ struct atomic_fence_order_capabilities;
 struct atomic_memory_scope_capabilities;
 struct atomic_fence_scope_capabilities;
 
-}  // namespace context
-}  // info
-}  // sycl
+} // namespace context
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/device.h
+++ b/adoc/headers/device.h
@@ -8,7 +8,7 @@ class device {
   device();
 
   template <typename DeviceSelector>
-  explicit device(const DeviceSelector &deviceSelector);
+  explicit device(const DeviceSelector& deviceSelector);
 
   /* -- common interface members -- */
 
@@ -29,7 +29,7 @@ class device {
 
   bool has(aspect asp) const;
 
-  bool has_extension(const std::string &extension) const; // Deprecated
+  bool has_extension(const std::string& extension) const; // Deprecated
 
   // Available only when Prop == info::partition_property::partition_equally
   template <info::partition_property Prop>
@@ -37,13 +37,16 @@ class device {
 
   // Available only when Prop == info::partition_property::partition_by_counts
   template <info::partition_property Prop>
-  std::vector<device> create_sub_devices(const std::vector<size_t> &counts) const;
+  std::vector<device>
+  create_sub_devices(const std::vector<size_t>& counts) const;
 
-  // Available only when Prop == info::partition_property::partition_by_affinity_domain
+  // Available only when Prop ==
+  // info::partition_property::partition_by_affinity_domain
   template <info::partition_property Prop>
-  std::vector<device> create_sub_devices(info::partition_affinity_domain affinityDomain) const;
+  std::vector<device>
+  create_sub_devices(info::partition_affinity_domain affinityDomain) const;
 
-  static std::vector<device> get_devices(
-      info::device_type deviceType = info::device_type::all);
+  static std::vector<device>
+  get_devices(info::device_type deviceType = info::device_type::all);
 };
 } // namespace sycl

--- a/adoc/headers/deviceEvent.h
+++ b/adoc/headers/deviceEvent.h
@@ -9,4 +9,4 @@ class device_event {
  public:
   void wait() noexcept;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/deviceInfo.h
+++ b/adoc/headers/deviceInfo.h
@@ -9,7 +9,7 @@ struct device_type;
 struct vendor_id;
 struct max_compute_units;
 struct max_work_item_dimensions;
-template<int Dimensions = 3> struct max_work_item_sizes;
+template <int Dimensions = 3> struct max_work_item_sizes;
 struct max_work_group_size;
 struct preferred_vector_width_char;
 struct preferred_vector_width_short;
@@ -48,7 +48,7 @@ struct global_mem_cache_line_size;
 struct global_mem_cache_size;
 struct global_mem_size;
 struct max_constant_buffer_size; // Deprecated
-struct max_constant_args; // Deprecated
+struct max_constant_args;        // Deprecated
 struct local_mem_type;
 struct local_mem_size;
 struct error_correction_support;
@@ -61,9 +61,9 @@ struct profiling_timer_resolution;
 struct is_endian_little;
 struct is_available;
 struct is_compiler_available; // Deprecated
-struct is_linker_available; // Deprecated
+struct is_linker_available;   // Deprecated
 struct execution_capabilities;
-struct queue_profiling; // Deprecated
+struct queue_profiling;  // Deprecated
 struct built_in_kernels; // Deprecated
 struct built_in_kernel_ids;
 struct platform;
@@ -84,7 +84,7 @@ struct partition_affinity_domains;
 struct partition_type_property;
 struct partition_type_affinity_domain;
 
-}  // namespace device
+} // namespace device
 
 enum class device_type : /* unspecified */ {
   cpu,         // Maps to OpenCL CL_DEVICE_TYPE_CPU
@@ -93,7 +93,7 @@ enum class device_type : /* unspecified */ {
   custom,      // Maps to OpenCL CL_DEVICE_TYPE_CUSTOM
   automatic,   // Maps to OpenCL CL_DEVICE_TYPE_DEFAULT
   host,
-  all          // Maps to OpenCL CL_DEVICE_TYPE_ALL
+  all // Maps to OpenCL CL_DEVICE_TYPE_ALL
 };
 
 enum class partition_property : /* unspecified */ {
@@ -113,11 +113,7 @@ enum class partition_affinity_domain : /* unspecified */ {
   next_partitionable
 };
 
-enum class local_mem_type : /* unspecified */ {
-  none,
-  local,
-  global
-};
+enum class local_mem_type : /* unspecified */ { none, local, global };
 
 enum class fp_config : /* unspecified */ {
   denorm,
@@ -141,5 +137,5 @@ enum class execution_capability : /* unspecified */ {
   exec_native_kernel
 };
 
-}  // namespace info
-}  // namespace sycl
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/deviceSelector.h
+++ b/adoc/headers/deviceSelector.h
@@ -16,12 +16,11 @@ using gpu_selector = __unspecified__;
 using accelerator_selector = __unspecified__;
 
 // Returns a selector that selects a device based on desired aspects
-__unspecified_callable__ aspect_selector(
-  const std::vector<aspect> &aspectList,
-  const std::vector<aspect> &denyList = {});
+__unspecified_callable__
+aspect_selector(const std::vector<aspect>& aspectList,
+                const std::vector<aspect>& denyList = {});
 template <class... AspectList>
 __unspecified_callable__ aspect_selector(AspectList... aspectList);
-template <aspect... AspectList>
-__unspecified_callable__ aspect_selector();
+template <aspect... AspectList> __unspecified_callable__ aspect_selector();
 
 } // namespace sycl

--- a/adoc/headers/event.h
+++ b/adoc/headers/event.h
@@ -15,11 +15,11 @@ class event {
 
   void wait();
 
-  static void wait(const std::vector<event> &eventList);
+  static void wait(const std::vector<event>& eventList);
 
   void wait_and_throw();
 
-  static void wait_and_throw(const std::vector<event> &eventList);
+  static void wait_and_throw(const std::vector<event>& eventList);
 
   template <typename Param> typename Param::return_type get_info() const;
 
@@ -30,4 +30,4 @@ class event {
   typename Param::return_type get_profiling_info() const;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/eventInfo.h
+++ b/adoc/headers/eventInfo.h
@@ -7,7 +7,7 @@ namespace event {
 
 struct command_execution_status;
 
-}  // namespace event
+} // namespace event
 
 enum class event_command_status : /* unspecified */ {
   submitted,
@@ -21,6 +21,6 @@ struct command_submit;
 struct command_start;
 struct command_end;
 
-}  // namespace event_profiling
-}  // namespace info
-}  // namespace sycl
+} // namespace event_profiling
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/exception.h
+++ b/adoc/headers/exception.h
@@ -7,27 +7,30 @@ using async_handler = std::function<void(sycl::exception_list)>;
 
 class exception : public virtual std::exception {
  public:
-    exception(std::error_code ec, const std::string& what_arg);
-    exception(std::error_code ec, const char * what_arg);
-    exception(std::error_code ec);
-    exception(int ev, const std::error_category& ecat, const std::string& what_arg);
-    exception(int ev, const std::error_category& ecat, const char* what_arg);
-    exception(int ev, const std::error_category& ecat);
+  exception(std::error_code ec, const std::string& what_arg);
+  exception(std::error_code ec, const char* what_arg);
+  exception(std::error_code ec);
+  exception(int ev, const std::error_category& ecat,
+            const std::string& what_arg);
+  exception(int ev, const std::error_category& ecat, const char* what_arg);
+  exception(int ev, const std::error_category& ecat);
 
-    exception(context ctx, std::error_code ec, const std::string& what_arg);
-    exception(context ctx, std::error_code ec, const char* what_arg);
-    exception(context ctx, std::error_code ec);
-    exception(context ctx, int ev, const std::error_category& ecat, const std::string& what_arg);
-    exception(context ctx, int ev, const std::error_category& ecat, const char* what_arg);
-    exception(context ctx, int ev, const std::error_category& ecat);
+  exception(context ctx, std::error_code ec, const std::string& what_arg);
+  exception(context ctx, std::error_code ec, const char* what_arg);
+  exception(context ctx, std::error_code ec);
+  exception(context ctx, int ev, const std::error_category& ecat,
+            const std::string& what_arg);
+  exception(context ctx, int ev, const std::error_category& ecat,
+            const char* what_arg);
+  exception(context ctx, int ev, const std::error_category& ecat);
 
-    const std::error_code& code() const noexcept;
-    const std::error_category& category() const noexcept;
+  const std::error_code& code() const noexcept;
+  const std::error_category& category() const noexcept;
 
-    const char *what() const;
+  const char* what() const;
 
-    bool has_context() const noexcept;
-    context get_context() const;
+  bool has_context() const noexcept;
+  context get_context() const;
 };
 
 class exception_list {
@@ -41,8 +44,8 @@ class exception_list {
   using const_iterator = /*unspecified*/;
 
   size_type size() const;
-  iterator begin() const;  // first asynchronous exception
-  iterator end() const;    // refer to past-the-end last asynchronous exception
+  iterator begin() const; // first asynchronous exception
+  iterator end() const;   // refer to past-the-end last asynchronous exception
 };
 
 enum class errc : /* unspecified */ {
@@ -63,21 +66,18 @@ enum class errc : /* unspecified */ {
   backend_mismatch
 };
 
-template<backend b>
-using errc_for = typename backend_traits<b>::errc;
+template <backend b> using errc_for = typename backend_traits<b>::errc;
 
 std::error_code make_error_code(errc e) noexcept;
 
 const std::error_category& sycl_category() noexcept;
 
-template<backend b>
-const std::error_category& error_category_for() noexcept;
+template <backend b> const std::error_category& error_category_for() noexcept;
 
-}  // namespace sycl
+} // namespace sycl
 
 namespace std {
 
-  template <>
-  struct is_error_code_enum</* see below */> : true_type {};
+template <> struct is_error_code_enum</* see below */> : true_type {};
 
-}  // namespace std
+} // namespace std

--- a/adoc/headers/expressingParallelism/classKernelHandler.h
+++ b/adoc/headers/expressingParallelism/classKernelHandler.h
@@ -5,9 +5,9 @@ namespace sycl {
 
 class kernel_handler {
  public:
-  template<auto& SpecName>
+  template <auto& SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant();
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/expressingParallelism/classSpecializationId.h
+++ b/adoc/headers/expressingParallelism/classSpecializationId.h
@@ -3,18 +3,16 @@
 
 namespace sycl {
 
-template <typename T>
-class specialization_id {
+template <typename T> class specialization_id {
  public:
   using value_type = T;
 
-  template<class... Args >
-  explicit constexpr specialization_id(Args&&... args);
+  template <class... Args> explicit constexpr specialization_id(Args&&... args);
 
   specialization_id(const specialization_id& rhs) = delete;
   specialization_id(specialization_id&& rhs) = delete;
-  specialization_id &operator=(const specialization_id& rhs) = delete;
-  specialization_id &operator=(specialization_id&& rhs) = delete;
+  specialization_id& operator=(const specialization_id& rhs) = delete;
+  specialization_id& operator=(specialization_id&& rhs) = delete;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
+++ b/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
@@ -5,15 +5,12 @@ namespace sycl {
 
 class kernel_handler {
  private:
-
   kernel_handler(__unspecified__);
 
  public:
-
-  template<auto& SpecName>
+  template <auto& SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant();
-
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/functional.h
+++ b/adoc/headers/functional.h
@@ -3,48 +3,39 @@
 
 namespace sycl {
 
-template <typename T=void>
-struct plus {
+template <typename T = void> struct plus {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct multiplies {
+template <typename T = void> struct multiplies {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct bit_and {
+template <typename T = void> struct bit_and {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct bit_or {
+template <typename T = void> struct bit_or {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct bit_xor {
+template <typename T = void> struct bit_xor {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct logical_and {
+template <typename T = void> struct logical_and {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct logical_or {
+template <typename T = void> struct logical_or {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct minimum {
+template <typename T = void> struct minimum {
   T operator()(const T& x, const T& y) const;
 };
 
-template <typename T=void>
-struct maximum {
+template <typename T = void> struct maximum {
   T operator()(const T& x, const T& y) const;
 };
 

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1>
-class group {
-public:
-
+template <int Dimensions = 1> class group {
+ public:
   using id_type = id<Dimensions>;
   using range_type = range<Dimensions>;
   using linear_id_type = size_t;
   static constexpr int dimensions = Dimensions;
   static constexpr memory_scope fence_scope = memory_scope::work_group;
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
   id<Dimensions> get_group_id() const;
 
@@ -44,30 +42,35 @@ public:
 
   bool leader() const;
 
-  template<typename WorkItemFunctionT>
-  void parallel_for_work_item(const WorkItemFunctionT &func) const;
+  template <typename WorkItemFunctionT>
+  void parallel_for_work_item(const WorkItemFunctionT& func) const;
 
-  template<typename WorkItemFunctionT>
+  template <typename WorkItemFunctionT>
   void parallel_for_work_item(range<Dimensions> logicalRange,
-    const WorkItemFunctionT &func) const;
+                              const WorkItemFunctionT& func) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-    decorated_global_ptr<DataT> src, size_t numElements) const;
+                                     decorated_global_ptr<DataT> src,
+                                     size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-    decorated_local_ptr<DataT> src, size_t numElements) const;
+                                     decorated_local_ptr<DataT> src,
+                                     size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-    decorated_global_ptr<DataT> src, size_t numElements, size_t srcStride) const;
+                                     decorated_global_ptr<DataT> src,
+                                     size_t numElements,
+                                     size_t srcStride) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-    decorated_local_ptr<DataT> src, size_t numElements, size_t destStride) const;
+                                     decorated_local_ptr<DataT> src,
+                                     size_t numElements,
+                                     size_t destStride) const;
 
-  template <typename... EventTN>
-  void wait_for(EventTN... events) const;
+  template <typename... EventTN> void wait_for(EventTN... events) const;
 };
-}  // sycl
+} // namespace sycl

--- a/adoc/headers/groups/barrier.h
+++ b/adoc/headers/groups/barrier.h
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 template <typename Group>
-void group_barrier(Group g, memory_scope fence_scope = Group::fence_scope); // (1)
+void group_barrier(Group g,
+                   memory_scope fence_scope = Group::fence_scope); // (1)

--- a/adoc/headers/groups/broadcast.h
+++ b/adoc/headers/groups/broadcast.h
@@ -1,8 +1,7 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
-template <typename Group, typename T>
-T group_broadcast(Group g, T x); // (1)
+template <typename Group, typename T> T group_broadcast(Group g, T x); // (1)
 
 template <typename Group, typename T>
 T group_broadcast(Group g, T x, Group::linear_id_type local_linear_id); // (2)

--- a/adoc/headers/handler/useKernelBundle.h
+++ b/adoc/headers/handler/useKernelBundle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
-void use_kernel_bundle(const kernel_bundle<bundle_state::executable> &execBundle);
+void use_kernel_bundle(
+    const kernel_bundle<bundle_state::executable>& execBundle);

--- a/adoc/headers/hitem.h
+++ b/adoc/headers/hitem.h
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions>
-class h_item {
-public:
+template <int Dimensions> class h_item {
+ public:
   h_item() = delete;
 
   /* -- common interface members -- */
@@ -48,6 +47,5 @@ public:
   id<Dimensions> get_physical_local_id() const;
 
   size_t get_physical_local_id(int dimension) const;
-
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/hostTask/classHandler/hostTask.h
+++ b/adoc/headers/hostTask/classHandler/hostTask.h
@@ -4,9 +4,10 @@
 class handler {
   ...
 
- public:
-  template <typename T>
-  void host_task(T &&hostTaskCallable); // (1)
+      public
+      : template <typename T>
+        void
+        host_task(T&& hostTaskCallable); // (1)
 
   ...
 };

--- a/adoc/headers/hostTask/classInteropHandle/constructors.h
+++ b/adoc/headers/hostTask/classInteropHandle/constructors.h
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 private:
-
- interop_handle(__unspecified__); // (1)
+interop_handle(__unspecified__); // (1)
 
 public:
-
- interop_handle() = delete; // (2)
+interop_handle() = delete; // (2)

--- a/adoc/headers/hostTask/classInteropHandle/getnativeX.h
+++ b/adoc/headers/hostTask/classInteropHandle/getnativeX.h
@@ -1,28 +1,29 @@
-headers/hostTask/classInteropHandle/getnativeX.h
-// Copyright (c) 2011-2022 The Khronos Group, Inc.
-// SPDX-License-Identifier: MIT
+headers / hostTask / classInteropHandle /
+    getnativeX.h
+    // Copyright (c) 2011-2022 The Khronos Group, Inc.
+    // SPDX-License-Identifier: MIT
 
-template <backend Backend, typename DataT, int Dims, access_mode AccMode,
-          target AccTarget, access::placeholder IsPlaceholder>
-backend_return_t<Backend, buffer<DataT, Dims>>
-get_native_mem(const accessor<DataT, Dims, AccMode, AccTarget,                // (1)
-                              IsPlaceholder> &bufferAcc) const;
+    template <backend Backend, typename DataT, int Dims, access_mode AccMode,
+              target AccTarget, access::placeholder IsPlaceholder>
+    backend_return_t<Backend, buffer<DataT, Dims>>
+    get_native_mem(const accessor<DataT, Dims, AccMode, AccTarget, // (1)
+                                  IsPlaceholder>& bufferAcc) const;
 
 template <backend Backend, typename DataT, int Dims, access_mode AccMode>
-backend_return_t<Backend, unsampled_image<Dims>>
-get_native_mem(                                                               // (2)
-  const unsampled_image_accessor<DataT, Dims, AccMode, image_target::device> &imageAcc) const;
+backend_return_t<Backend, unsampled_image<Dims>> get_native_mem( // (2)
+    const unsampled_image_accessor<DataT, Dims, AccMode, image_target::device>&
+        imageAcc) const;
 
 template <backend Backend, typename DataT, int Dims>
-backend_return_t<Backend, sampled_image<Dims>>
-get_native_mem(                                                               // (3)
-  const sampled_image_accessor<DataT, Dims, image_target::device> &imageAcc) const;
+backend_return_t<Backend, sampled_image<Dims>> get_native_mem( // (3)
+    const sampled_image_accessor<DataT, Dims, image_target::device>& imageAcc)
+    const;
 
 template <backend Backend>
-backend_return_t<Backend, queue> get_native_queue() const;         // (4)
+backend_return_t<Backend, queue> get_native_queue() const; // (4)
 
 template <backend Backend>
-backend_return_t<Backend, device> get_native_device() const;       // (5)
+backend_return_t<Backend, device> get_native_device() const; // (5)
 
 template <backend Backend>
-backend_return_t<Backend, context> get_native_context() const;     // (6)
+backend_return_t<Backend, context> get_native_context() const; // (6)

--- a/adoc/headers/hostTask/hostTaskSynopsis.h
+++ b/adoc/headers/hostTask/hostTaskSynopsis.h
@@ -5,11 +5,9 @@ namespace sycl {
 
 class interop_handle {
  private:
-
   interop_handle(__unspecified__);
 
  public:
-
   interop_handle() = delete;
 
   backend get_backend() const noexcept;
@@ -18,18 +16,16 @@ class interop_handle {
             target AccessTarget, access::placeholder isPlaceholder>
   backend_return_t<Backend, buffer<DataT, Dims>>
   get_native_mem(const accessor<DataT, Dims, AccessMode, AccessTarget,
-                                isPlaceholder> &bufferAccessor) const;
+                                isPlaceholder>& bufferAccessor) const;
 
   template <backend Backend, typename DataT, int Dims, access_mode AccMode>
-  backend_return_t<Backend, unsampled_image<Dims>>
-  get_native_mem(
-      const unsampled_image_accessor<DataT, Dims, AccMode, image_target::device>
-          &imageAcc) const;
+  backend_return_t<Backend, unsampled_image<Dims>> get_native_mem(
+      const unsampled_image_accessor<DataT, Dims, AccMode,
+                                     image_target::device>& imageAcc) const;
 
   template <backend Backend, typename DataT, int Dims>
-  backend_return_t<Backend, sampled_image<Dims>>
-  get_native_mem(
-      const sampled_image_accessor<DataT, Dims, image_target::device> &imageAcc)
+  backend_return_t<Backend, sampled_image<Dims>> get_native_mem(
+      const sampled_image_accessor<DataT, Dims, image_target::device>& imageAcc)
       const;
 
   template <backend Backend>
@@ -40,18 +36,19 @@ class interop_handle {
 
   template <backend Backend>
   backend_return_t<Backend, context> get_native_context() const;
-
 };
 
 class handler {
   ...
 
- public:
+      public
+      :
 
-  template <typename T>
-  void host_task(T &&hostTaskCallable);
+      template <typename T>
+      void
+      host_task(T&& hostTaskCallable);
 
   ...
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1>
-class id {
-public:
+template <int Dimensions = 1> class id {
+ public:
   id();
 
   /* The following constructor is only available in the id class
@@ -17,43 +16,50 @@ public:
    * specialization where: Dimensions==3 */
   id(size_t dim0, size_t dim1, size_t dim2);
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
-  id(const range<Dimensions> &range);
-  id(const item<Dimensions> &item);
+  id(const range<Dimensions>& range);
+  id(const item<Dimensions>& item);
 
   size_t get(int dimension) const;
-  size_t &operator[](int dimension);
+  size_t& operator[](int dimension);
   size_t operator[](int dimension) const;
 
   // only available if Dimensions == 1
   operator size_t() const;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-    friend id operatorOP(const id &lhs, const id &rhs) { /* ... */ }
-    friend id operatorOP(const id &lhs, const size_t &rhs) { /* ... */ }
+  friend id operatorOP(const id& lhs, const id& rhs) { /* ... */
+  }
+  friend id operatorOP(const id& lhs, const size_t& rhs) { /* ... */
+  }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-    friend id &operatorOP(id &lhs, const id &rhs) { /* ... */ }
-    friend id &operatorOP(id &lhs, const size_t &rhs) { /* ... */ }
+  friend id& operatorOP(id& lhs, const id& rhs) { /* ... */
+  }
+  friend id& operatorOP(id& lhs, const size_t& rhs) { /* ... */
+  }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-    friend id operatorOP(const size_t &lhs, const id &rhs) { /* ... */ }
+  friend id operatorOP(const size_t& lhs, const id& rhs) { /* ... */
+  }
 
   // OP is unary +, -
-  friend id operatorOP(const id &rhs) { /* ... */ }
+  friend id operatorOP(const id& rhs) { /* ... */
+  }
 
   // OP is prefix ++, --
-  friend id & operatorOP(id &rhs) { /* ... */ }
+  friend id& operatorOP(id& rhs) { /* ... */
+  }
 
   // OP is postfix ++, --
-  friend id operatorOP(id &lhs, int) { /* ... */ }
-
+  friend id operatorOP(id& lhs, int) { /* ... */
+  }
 };
 
 // Deduction guides
-id(size_t) -> id<1>;
-id(size_t, size_t) -> id<2>;
-id(size_t, size_t, size_t) -> id<3>;
+id(size_t)->id<1>;
+id(size_t, size_t)->id<2>;
+id(size_t, size_t, size_t)->id<3>;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/identity.h
+++ b/adoc/headers/identity.h
@@ -7,7 +7,8 @@ struct known_identity {
 };
 
 template <typename BinaryOperation, typename AccumulatorT>
-inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation, AccumulatorT>::value;
+inline constexpr AccumulatorT known_identity_v =
+    known_identity<BinaryOperation, AccumulatorT>::value;
 
 template <typename BinaryOperation, typename AccumulatorT>
 struct has_known_identity {
@@ -15,4 +16,5 @@ struct has_known_identity {
 };
 
 template <typename BinaryOperation, typename AccumulatorT>
-inline constexpr bool has_known_identity_v = has_known_identity<BinaryOperation, AccumulatorT>::value;
+inline constexpr bool has_known_identity_v =
+    has_known_identity<BinaryOperation, AccumulatorT>::value;

--- a/adoc/headers/imageProperties.h
+++ b/adoc/headers/imageProperties.h
@@ -5,23 +5,23 @@ namespace sycl {
 namespace property {
 namespace image {
 class use_host_ptr {
-  public:
-    use_host_ptr() = default;
+ public:
+  use_host_ptr() = default;
 };
 
 class use_mutex {
-  public:
-    use_mutex(std::mutex &mutexRef);
+ public:
+  use_mutex(std::mutex& mutexRef);
 
-    std::mutex *get_mutex_ptr() const;
+  std::mutex* get_mutex_ptr() const;
 };
 
 class context_bound {
-  public:
-    context_bound(context boundContext);
+ public:
+  context_bound(context boundContext);
 
-    context get_context() const;
+  context get_context() const;
 };
-}  // namespace image
-}  // namespace property
-}  // namespace sycl
+} // namespace image
+} // namespace property
+} // namespace sycl

--- a/adoc/headers/imageSampler.h
+++ b/adoc/headers/imageSampler.h
@@ -11,10 +11,7 @@ enum class addressing_mode : /* unspecified */ {
   none
 };
 
-enum class filtering_mode : /* unspecified */ {
-  nearest,
-  linear
-};
+enum class filtering_mode : /* unspecified */ { nearest, linear };
 
 enum class coordinate_normalization_mode : /* unspecified */ {
   normalized,
@@ -27,4 +24,4 @@ struct image_sampler {
   filtering_mode filtering;
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/interop/templateFunctionGetNative.h
+++ b/adoc/headers/interop/templateFunctionGetNative.h
@@ -3,7 +3,7 @@
 
 namespace sycl {
 
-template<backend Backend, class T>
-backend_return_t<Backend, T> get_native(const T &syclObject);
+template <backend Backend, class T>
+backend_return_t<Backend, T> get_native(const T& syclObject);
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/interop/templateFunctionMakeX.h
+++ b/adoc/headers/interop/templateFunctionMakeX.h
@@ -3,75 +3,75 @@
 
 namespace sycl {
 
-template<backend Backend>
-platform make_platform(const backend_input_t<Backend, platform> &backendObject);
+template <backend Backend>
+platform make_platform(const backend_input_t<Backend, platform>& backendObject);
 
-template<backend Backend>
-device make_device(const backend_input_t<Backend, device> &backendObject);
+template <backend Backend>
+device make_device(const backend_input_t<Backend, device>& backendObject);
 
-template<backend Backend>
-context make_context(const backend_input_t<Backend, context> &backendObject,
+template <backend Backend>
+context make_context(const backend_input_t<Backend, context>& backendObject,
                      const async_handler asyncHandler = {});
 
-template<backend Backend>
-queue make_queue(const backend_input_t<Backend, queue> &backendObject,
-                 const context &targetContext,
+template <backend Backend>
+queue make_queue(const backend_input_t<Backend, queue>& backendObject,
+                 const context& targetContext,
                  const async_handler asyncHandler = {});
 
-template<backend Backend>
-event make_event(const backend_input_t<Backend, event> &backendObject,
-                 const context &targetContext);
+template <backend Backend>
+event make_event(const backend_input_t<Backend, event>& backendObject,
+                 const context& targetContext);
 
 template <backend Backend, typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 buffer<T, Dimensions, AllocatorT>
-make_buffer(const backend_input_t<Backend, buffer<T, Dimensions, AllocatorT>>
-                &backendObject,
-            const context &targetContext, event availableEvent);
+make_buffer(const backend_input_t<Backend, buffer<T, Dimensions, AllocatorT>>&
+                backendObject,
+            const context& targetContext, event availableEvent);
 
 template <backend Backend, typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 buffer<T, Dimensions, AllocatorT>
-make_buffer(const backend_input_t<Backend, buffer<T, Dimensions, AllocatorT>>
-                &backendObject,
-            const context &targetContext);
+make_buffer(const backend_input_t<Backend, buffer<T, Dimensions, AllocatorT>>&
+                backendObject,
+            const context& targetContext);
 
 template <backend Backend, int Dimensions = 1,
           typename AllocatorT = sycl::image_allocator>
 sampled_image<Dimensions, AllocatorT> make_sampled_image(
-    const backend_input_t<Backend, sampled_image<Dimensions, AllocatorT>>
-        &backendObject,
-    const context &targetContext, image_sampler imageSampler,
+    const backend_input_t<Backend, sampled_image<Dimensions, AllocatorT>>&
+        backendObject,
+    const context& targetContext, image_sampler imageSampler,
     event availableEvent);
 
 template <backend Backend, int Dimensions = 1,
           typename AllocatorT = sycl::image_allocator>
 sampled_image<Dimensions, AllocatorT> make_sampled_image(
-    const backend_input_t<Backend, sampled_image<Dimensions, AllocatorT>>
-        &backendObject,
-    const context &targetContext, image_sampler imageSampler);
+    const backend_input_t<Backend, sampled_image<Dimensions, AllocatorT>>&
+        backendObject,
+    const context& targetContext, image_sampler imageSampler);
 
 template <backend Backend, int Dimensions = 1,
           typename AllocatorT = sycl::image_allocator>
 unsampled_image<Dimensions, AllocatorT> make_unsampled_image(
-    const backend_input_t<Backend, unsampled_image<Dimensions, AllocatorT>>
-        &backendObject,
-    const context &targetContext, event availableEvent);
+    const backend_input_t<Backend, unsampled_image<Dimensions, AllocatorT>>&
+        backendObject,
+    const context& targetContext, event availableEvent);
 
 template <backend Backend, int Dimensions = 1,
           typename AllocatorT = sycl::image_allocator>
 unsampled_image<Dimensions, AllocatorT> make_unsampled_image(
-    const backend_input_t<Backend, unsampled_image<Dimensions, AllocatorT>>
-        &backendObject,
-    const context &targetContext);
+    const backend_input_t<Backend, unsampled_image<Dimensions, AllocatorT>>&
+        backendObject,
+    const context& targetContext);
 
-template<backend Backend, bundle_state State>
+template <backend Backend, bundle_state State>
 kernel_bundle<State> make_kernel_bundle(
-    const backend_input_t<Backend, kernel_bundle<State>> &backendObject,
-    const context &targetContext);
+    const backend_input_t<Backend, kernel_bundle<State>>& backendObject,
+    const context& targetContext);
 
-template<backend Backend>
-kernel make_kernel(const backend_input_t<Backend, kernel> &backendObject,
-                   const context &targetContext);
+template <backend Backend>
+kernel make_kernel(const backend_input_t<Backend, kernel>& backendObject,
+                   const context& targetContext);
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/interop/typeTraitsBackendTraits.h
+++ b/adoc/headers/interop/typeTraitsBackendTraits.h
@@ -3,14 +3,11 @@
 
 namespace sycl {
 
-template <backend Backend>
-class backend_traits {
+template <backend Backend> class backend_traits {
  public:
-  template <class T>
-  using input_type = /* see below */;
+  template <class T> using input_type = /* see below */;
 
-  template <class T>
-  using return_type = /* see below */;
+  template <class T> using return_type = /* see below */;
 
   using errc = /* see below */;
 };
@@ -23,4 +20,4 @@ template <backend Backend, typename SyclType>
 using backend_return_t =
     typename backend_traits<Backend>::template return_type<SyclType>;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/item.h
+++ b/adoc/headers/item.h
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1, bool WithOffset = true>
-class item {
-public:
+template <int Dimensions = 1, bool WithOffset = true> class item {
+ public:
   item() = delete;
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
   id<Dimensions> get_id() const;
 
@@ -31,4 +30,4 @@ public:
 
   size_t get_linear_id() const;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/kernelInfo.h
+++ b/adoc/headers/kernelInfo.h
@@ -8,7 +8,7 @@ namespace kernel {
 struct num_args;
 struct attributes;
 
-}  // namespace kernel
+} // namespace kernel
 
 namespace kernel_device_specific {
 
@@ -22,7 +22,7 @@ struct compile_num_sub_groups;
 struct max_sub_group_size;
 struct compile_sub_group_size;
 
-}  // namespace kernel_device_specific
+} // namespace kernel_device_specific
 
-}  // namespace info
-}  // namespace sycl
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/marray.h
+++ b/adoc/headers/marray.h
@@ -3,8 +3,7 @@
 
 namespace sycl {
 
-template <typename DataT, std::size_t NumElements>
-class marray {
+template <typename DataT, std::size_t NumElements> class marray {
  public:
   using value_type = DataT;
   using reference = DataT&;
@@ -14,13 +13,12 @@ class marray {
 
   marray();
 
-  explicit constexpr marray(const DataT &arg);
+  explicit constexpr marray(const DataT& arg);
 
-  template <typename... ArgTN>
-  constexpr marray(const ArgTN&... args);
+  template <typename... ArgTN> constexpr marray(const ArgTN&... args);
 
-  constexpr marray(const marray<DataT, NumElements> &rhs);
-  constexpr marray(marray<DataT, NumElements> &&rhs);
+  constexpr marray(const marray<DataT, NumElements>& rhs);
+  constexpr marray(marray<DataT, NumElements>&& rhs);
 
   // Available only when: NumElements == 1
   operator DataT() const;
@@ -31,8 +29,8 @@ class marray {
   reference operator[](std::size_t index);
   const_reference operator[](std::size_t index) const;
 
-  marray &operator=(const marray<DataT, NumElements> &rhs);
-  marray &operator=(const DataT &rhs);
+  marray& operator=(const marray<DataT, NumElements>& rhs);
+  marray& operator=(const DataT& rhs);
 
   // iterator functions
   iterator begin();
@@ -41,84 +39,115 @@ class marray {
   iterator end();
   const_iterator end() const;
 
-
   // OP is: +, -, *, /, %
-  /* If OP is %, available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray operatorOP(const marray &lhs, const DataT &rhs) { /* ... */ }
+  /* If OP is %, available only when: DataT != float && DataT != double && DataT
+   * != half. */
+  friend marray operatorOP(const marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray operatorOP(const marray& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: +=, -=, *=, /=, %=
-  /* If OP is %=, available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray &operatorOP(marray &lhs, const DataT &rhs) { /* ... */ }
+  /* If OP is %=, available only when: DataT != float && DataT != double &&
+   * DataT != half. */
+  friend marray& operatorOP(marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray& operatorOP(marray& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is prefix ++, --
-  friend marray &operatorOP(marray &rhs) { /* ... */ }
+  friend marray& operatorOP(marray& rhs) { /* ... */
+  }
 
   // OP is postfix ++, --
-  friend marray operatorOP(marray& lhs, int) { /* ... */ }
+  friend marray operatorOP(marray& lhs, int) { /* ... */
+  }
 
   // OP is unary +, -
-  friend marray operatorOP(marray &rhs) { /* ... */ }
+  friend marray operatorOP(marray& rhs) { /* ... */
+  }
 
   // OP is: &, |, ^
   /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray operatorOP(const marray &lhs, const DataT &rhs) { /* ... */ }
+  friend marray operatorOP(const marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray operatorOP(const marray& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: &=, |=, ^=
   /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray &operatorOP(marray &lhs, const DataT &rhs) { /* ... */ }
+  friend marray& operatorOP(marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray& operatorOP(marray& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: &&, ||
-  friend marray<bool, NumElements> operatorOP(const marray &lhs, const marray &rhs) {
+  friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                              const marray& rhs) {
     /* ... */ }
-  friend marray<bool, NumElements> operatorOP(const marray& lhs, const DataT &rhs) {
-    /* ... */ }
-
-  // OP is: <<, >>
-  /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray operatorOP(const marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray operatorOP(const marray &lhs, const DataT &rhs) { /* ... */ }
-
-  // OP is: <<=, >>=
-  /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray &operatorOP(marray &lhs, const marray &rhs) { /* ... */ }
-  friend marray &operatorOP(marray &lhs, const DataT &rhs) { /* ... */ }
-
-  // OP is: ==, !=, <, >, <=, >=
-  friend marray<bool, NumElements> operatorOP(const marray &lhs, const marray &rhs) {
-    /* ... */ }
-  friend marray<bool, NumElements> operatorOP(const marray &lhs, const DataT &rhs) {
+    friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                                const DataT& rhs) {
     /* ... */ }
 
-  /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray operator~(const marray &v) { /* ... */ }
+    // OP is: <<, >>
+    /* Available only when: DataT != float && DataT != double && DataT != half.
+     */
+    friend marray operatorOP(const marray& lhs, const marray& rhs) { /* ... */
+    }
+    friend marray operatorOP(const marray& lhs, const DataT& rhs) { /* ... */
+    }
 
-  // OP is: +, -, *, /, %
-  /* operator% is only available when: DataT != float && DataT != double && DataT != half. */
-  friend marray operatorOP(const DataT &lhs, const marray &rhs) { /* ... */ }
+    // OP is: <<=, >>=
+    /* Available only when: DataT != float && DataT != double && DataT != half.
+     */
+    friend marray& operatorOP(marray& lhs, const marray& rhs) { /* ... */
+    }
+    friend marray& operatorOP(marray& lhs, const DataT& rhs) { /* ... */
+    }
 
-  // OP is: &, |, ^
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend marray operatorOP(const DataT &lhs, const marray &rhs) { /* ... */ }
-
-  // OP is: &&, ||
-  friend marray<bool, NumElements> operatorOP(const DataT &lhs, const marray &rhs) {
+    // OP is: ==, !=, <, >, <=, >=
+    friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                                const marray& rhs) {
+    /* ... */ }
+    friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                                const DataT& rhs) {
     /* ... */ }
 
-  // OP is: <<, >>
-  /* Available only when: DataT != float && DataT != double && DataT != half. */
-  friend marray operatorOP(const DataT &lhs, const marray &rhs) { /* ... */ }
+    /* Available only when: DataT != float && DataT != double && DataT != half.
+     */
+    friend marray operator~(const marray& v) { /* ... */
+    }
 
-  // OP is: ==, !=, <, >, <=, >=
-  friend marray<bool, NumElements> operatorOP(const DataT &lhs, const marray &rhs) {
+    // OP is: +, -, *, /, %
+    /* operator% is only available when: DataT != float && DataT != double &&
+     * DataT != half. */
+    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+    }
+
+    // OP is: &, |, ^
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+    }
+
+    // OP is: &&, ||
+    friend marray<bool, NumElements> operatorOP(const DataT& lhs,
+                                                const marray& rhs) {
     /* ... */ }
 
-  friend marray<bool, NumElements> operator!(const marray &v) { /* ... */ }
+    // OP is: <<, >>
+    /* Available only when: DataT != float && DataT != double && DataT != half.
+     */
+    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+    }
 
+    // OP is: ==, !=, <, >, <=, >=
+    friend marray<bool, NumElements> operatorOP(const DataT& lhs,
+                                                const marray& rhs) {
+    /* ... */ }
+
+    friend marray<bool, NumElements> operator!(const marray& v) { /* ... */
+    }
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -12,37 +12,36 @@ enum class address_space : /* unspecified */ {
   generic_space
 };
 
-enum class decorated : /* unspecified */ {
-  no,
-  yes,
-  legacy
-};
+enum class decorated : /* unspecified */ { no, yes, legacy };
 
-}  // namespace access
+} // namespace access
 
-template<typename T> struct remove_decoration {
+template <typename T> struct remove_decoration {
   using type = /* ... */;
 };
 
-template<typename T>
-using remove_decoration_t = remove_decoration<T>::type;
+template <typename T> using remove_decoration_t = remove_decoration<T>::type;
 
-template <typename ElementType, access::address_space Space, access::decorated DecorateAddress>
+template <typename ElementType, access::address_space Space,
+          access::decorated DecorateAddress>
 class multi_ptr {
  public:
-  static constexpr bool is_decorated = DecorateAddress == access::decorated::yes;
+  static constexpr bool is_decorated =
+      DecorateAddress == access::decorated::yes;
   static constexpr access::address_space address_space = Space;
 
   using value_type = ElementType;
-  using pointer = std::conditional_t<is_decorated, __unspecified__ *,
+  using pointer = std::conditional_t<is_decorated, __unspecified__*,
                                      std::add_pointer_t<value_type>>;
-  using reference = std::conditional_t<is_decorated, __unspecified__ &,
+  using reference = std::conditional_t<is_decorated, __unspecified__&,
                                        std::add_lvalue_reference_t<value_type>>;
   using iterator_category = std::random_access_iterator_tag;
   using difference_type = std::ptrdiff_t;
 
-  static_assert(std::is_same_v<remove_decoration_t<pointer>, std::add_pointer_t<value_type>>);
-  static_assert(std::is_same_v<remove_decoration_t<reference>, std::add_lvalue_reference_t<value_type>>);
+  static_assert(std::is_same_v<remove_decoration_t<pointer>,
+                               std::add_pointer_t<value_type>>);
+  static_assert(std::is_same_v<remove_decoration_t<reference>,
+                               std::add_lvalue_reference_t<value_type>>);
   // Legacy has a different interface.
   static_assert(DecorateAddress != access::decorated::legacy);
 
@@ -50,35 +49,37 @@ class multi_ptr {
   multi_ptr();
   multi_ptr(const multi_ptr&);
   multi_ptr(multi_ptr&&);
-  explicit multi_ptr(typename multi_ptr<ElementType, Space, access::decorated::yes>::pointer);
+  explicit multi_ptr(
+      typename multi_ptr<ElementType, Space, access::decorated::yes>::pointer);
   multi_ptr(std::nullptr_t);
 
   // Only if Space == global_space or generic_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-  multi_ptr(accessor<value_type, Dimensions, Mode, target::device, IsPlaceholder>);
+  multi_ptr(
+      accessor<value_type, Dimensions, Mode, target::device, IsPlaceholder>);
 
   // Only if Space == local_space or generic_space
-  template <int Dimensions>
-  multi_ptr(local_accessor<ElementType, Dimensions>);
+  template <int Dimensions> multi_ptr(local_accessor<ElementType, Dimensions>);
 
   // Deprecated
   // Only if Space == local_space or generic_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-  multi_ptr(accessor<value_type, Dimensions, Mode, target::local, IsPlaceholder>);
+  multi_ptr(
+      accessor<value_type, Dimensions, Mode, target::local, IsPlaceholder>);
 
   // Assignment and access operators
-  multi_ptr &operator=(const multi_ptr&);
-  multi_ptr &operator=(multi_ptr&&);
-  multi_ptr &operator=(std::nullptr_t);
+  multi_ptr& operator=(const multi_ptr&);
+  multi_ptr& operator=(multi_ptr&&);
+  multi_ptr& operator=(std::nullptr_t);
 
   // Only if Space == address_space::generic_space
   // and AS != access::address_space::constant_space
-  template<access::address_space AS, access::decorated IsDecorated>
-  multi_ptr &operator=(const multi_ptr<value_type, AS, IsDecorated>&);
+  template <access::address_space AS, access::decorated IsDecorated>
+  multi_ptr& operator=(const multi_ptr<value_type, AS, IsDecorated>&);
   // Only if Space == address_space::generic_space
   // and AS != access::address_space::constant_space
-  template<access::address_space AS, access::decorated IsDecorated>
-  multi_ptr &operator=(multi_ptr<value_type, AS, IsDecorated>&&);
+  template <access::address_space AS, access::decorated IsDecorated>
+  multi_ptr& operator=(multi_ptr<value_type, AS, IsDecorated>&&);
 
   reference operator[](std::ptrdiff_t) const;
 
@@ -87,7 +88,7 @@ class multi_ptr {
 
   pointer get() const;
   std::add_pointer_t<value_type> get_raw() const;
-  __unspecified__ * get_decorated() const;
+  __unspecified__* get_decorated() const;
 
   // Conversion to the underlying pointer type
   // Deprecated, get() should be used instead.
@@ -123,16 +124,16 @@ class multi_ptr {
 
   // Implicit conversion to a multi_ptr<void>.
   // Only available when value_type is not const-qualified.
-  template<access::decorated DecorateAddress2>
+  template <access::decorated DecorateAddress2>
   operator multi_ptr<void, Space, DecorateAddress2>() const;
 
   // Implicit conversion to a multi_ptr<const void>.
   // Only available when value_type is const-qualified.
-  template<access::decorated DecorateAddress2>
+  template <access::decorated DecorateAddress2>
   operator multi_ptr<const void, Space, DecorateAddress2>() const;
 
   // Implicit conversion to multi_ptr<const value_type, Space>.
-  template<access::decorated DecorateAddress2>
+  template <access::decorated DecorateAddress2>
   operator multi_ptr<const value_type, Space, DecorateAddress2>() const;
 
   // Implicit conversion to the non-decorated version of multi_ptr.
@@ -146,37 +147,65 @@ class multi_ptr {
   void prefetch(size_t numElements) const;
 
   // Arithmetic operators
-  friend multi_ptr& operator++(multi_ptr& mp) { /* ... */ }
-  friend multi_ptr operator++(multi_ptr& mp, int) { /* ... */ }
-  friend multi_ptr& operator--(multi_ptr& mp) { /* ... */ }
-  friend multi_ptr operator--(multi_ptr& mp, int) { /* ... */ }
-  friend multi_ptr& operator+=(multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr& operator-=(multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr operator+(const multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr operator-(const multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend reference operator*(const multi_ptr& lhs) { /* ... */ }
+  friend multi_ptr& operator++(multi_ptr& mp) { /* ... */
+  }
+  friend multi_ptr operator++(multi_ptr& mp, int) { /* ... */
+  }
+  friend multi_ptr& operator--(multi_ptr& mp) { /* ... */
+  }
+  friend multi_ptr operator--(multi_ptr& mp, int) { /* ... */
+  }
+  friend multi_ptr& operator+=(multi_ptr& lhs, difference_type r) { /* ... */
+  }
+  friend multi_ptr& operator-=(multi_ptr& lhs, difference_type r) { /* ... */
+  }
+  friend multi_ptr operator+(const multi_ptr& lhs,
+                             difference_type r) { /* ... */
+  }
+  friend multi_ptr operator-(const multi_ptr& lhs,
+                             difference_type r) { /* ... */
+  }
+  friend reference operator*(const multi_ptr& lhs) { /* ... */
+  }
 
-  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
 
-  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
 
-  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
 };
 
 // Specialization of multi_ptr for void and const void
@@ -184,15 +213,17 @@ class multi_ptr {
 template <access::address_space Space, access::decorated DecorateAddress>
 class multi_ptr<VoidType, Space, DecorateAddress> {
  public:
-  static constexpr bool is_decorated = DecorateAddress == access::decorated::yes;
+  static constexpr bool is_decorated =
+      DecorateAddress == access::decorated::yes;
   static constexpr access::address_space address_space = Space;
 
   using value_type = VoidType;
-  using pointer = std::conditional_t<is_decorated, __unspecified__ *,
+  using pointer = std::conditional_t<is_decorated, __unspecified__*,
                                      std::add_pointer_t<value_type>>;
   using difference_type = std::ptrdiff_t;
 
-  static_assert(std::is_same_v<remove_decoration_t<pointer>, std::add_pointer_t<value_type>>);
+  static_assert(std::is_same_v<remove_decoration_t<pointer>,
+                               std::add_pointer_t<value_type>>);
   // Legacy has a different interface.
   static_assert(DecorateAddress != access::decorated::legacy);
 
@@ -200,14 +231,15 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   multi_ptr();
   multi_ptr(const multi_ptr&);
   multi_ptr(multi_ptr&&);
-  explicit multi_ptr(typename multi_ptr<VoidType, Space, access::decorated::yes>::pointer);
+  explicit multi_ptr(
+      typename multi_ptr<VoidType, Space, access::decorated::yes>::pointer);
   multi_ptr(std::nullptr_t);
 
   // Only if Space == global_space
   template <typename ElementType, int Dimensions, access_mode Mode,
             access::placeholder IsPlaceholder>
-  multi_ptr(accessor<ElementType, Dimensions, Mode,
-                     target::device, IsPlaceholder>);
+  multi_ptr(
+      accessor<ElementType, Dimensions, Mode, target::device, IsPlaceholder>);
 
   // Only if Space == local_space
   template <typename ElementType, int Dimensions>
@@ -217,13 +249,13 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   // Only if Space == local_space
   template <typename ElementType, int Dimensions, access_mode Mode,
             access::placeholder IsPlaceholder>
-  multi_ptr(accessor<ElementType, Dimensions, Mode, target::local,
-                     IsPlaceholder>);
+  multi_ptr(
+      accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
 
   // Assignment operators
-  multi_ptr &operator=(const multi_ptr&);
-  multi_ptr &operator=(multi_ptr&&);
-  multi_ptr &operator=(std::nullptr_t);
+  multi_ptr& operator=(const multi_ptr&);
+  multi_ptr& operator=(multi_ptr&&);
+  multi_ptr& operator=(std::nullptr_t);
 
   pointer get() const;
 
@@ -246,46 +278,63 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   // Implicit conversion to multi_ptr<const void, Space>
   operator multi_ptr<const void, Space, DecorateAddress>() const;
 
-  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
 
-  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
 
-  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
 };
 
 // Deprecated, address_space_cast should be used instead.
-template <typename ElementType, access::address_space Space, access::decorated DecorateAddress>
-multi_ptr<ElementType, Space, DecorateAddress> make_ptr(ElementType *);
+template <typename ElementType, access::address_space Space,
+          access::decorated DecorateAddress>
+multi_ptr<ElementType, Space, DecorateAddress> make_ptr(ElementType*);
 
 template <access::address_space Space, access::decorated DecorateAddress,
           typename ElementType>
-multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType *);
+multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 
 // Deduction guides
 template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
           class T>
-multi_ptr(
-    accessor<T, Dimensions, Mode, target::device, IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, Mode, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space>;
 template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
           class T>
 multi_ptr(local_accessor<T, Dimensions>)
     -> multi_ptr<T, access::address_space::local_space>;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -13,10 +13,14 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
 
   // Implementation defined pointer and reference types that correspond to
   // SYCL/OpenCL interoperability types for OpenCL C functions.
-  using pointer_t = multi_ptr<ElementType, Space, access::decorated::yes>::pointer;
-  using const_pointer_t = multi_ptr<const ElementType, Space, access::decorated::yes>::pointer;
-  using reference_t = multi_ptr<ElementType, Space, access::decorated::yes>::reference;
-  using const_reference_t = multi_ptr<const ElementType, Space, access::decorated::yes>::reference;
+  using pointer_t =
+      multi_ptr<ElementType, Space, access::decorated::yes>::pointer;
+  using const_pointer_t =
+      multi_ptr<const ElementType, Space, access::decorated::yes>::pointer;
+  using reference_t =
+      multi_ptr<ElementType, Space, access::decorated::yes>::reference;
+  using const_reference_t =
+      multi_ptr<const ElementType, Space, access::decorated::yes>::reference;
 
   static constexpr access::address_space address_space = Space;
 
@@ -30,25 +34,29 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   ~multi_ptr();
 
   // Assignment and access operators
-  multi_ptr &operator=(const multi_ptr&);
-  multi_ptr &operator=(multi_ptr&&);
-  multi_ptr &operator=(pointer_t);
-  multi_ptr &operator=(ElementType*);
-  multi_ptr &operator=(std::nullptr_t);
-  friend ElementType& operator*(const multi_ptr& mp) { /* ... */ }
+  multi_ptr& operator=(const multi_ptr&);
+  multi_ptr& operator=(multi_ptr&&);
+  multi_ptr& operator=(pointer_t);
+  multi_ptr& operator=(ElementType*);
+  multi_ptr& operator=(std::nullptr_t);
+  friend ElementType& operator*(const multi_ptr& mp) { /* ... */
+  }
   ElementType* operator->() const;
 
   // Only if Space == global_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-  multi_ptr(accessor<ElementType, Dimensions, Mode, target::device, IsPlaceholder>);
+  multi_ptr(
+      accessor<ElementType, Dimensions, Mode, target::device, IsPlaceholder>);
 
   // Only if Space == local_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-  multi_ptr(accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
+  multi_ptr(
+      accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
 
   // Only if Space == constant_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-  multi_ptr(accessor<ElementType, Dimensions, Mode, target::constant_buffer, IsPlaceholder>);
+  multi_ptr(accessor<ElementType, Dimensions, Mode, target::constant_buffer,
+                     IsPlaceholder>);
 
   // Returns the underlying OpenCL C pointer
   pointer_t get() const;
@@ -65,41 +73,69 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   operator multi_ptr<const void, Space, access::decorated::legacy>() const;
 
   // Implicit conversion to multi_ptr<const ElementType, Space>
-  operator multi_ptr<const ElementType, Space, access::decorated::legacy>() const;
+  operator multi_ptr<const ElementType, Space, access::decorated::legacy>()
+      const;
 
   // Arithmetic operators
-  friend multi_ptr& operator++(multi_ptr& mp) { /* ... */ }
-  friend multi_ptr operator++(multi_ptr& mp, int) { /* ... */ }
-  friend multi_ptr& operator--(multi_ptr& mp) { /* ... */ }
-  friend multi_ptr operator--(multi_ptr& mp, int) { /* ... */ }
-  friend multi_ptr& operator+=(multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr& operator-=(multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr operator+(const multi_ptr& lhs, difference_type r) { /* ... */ }
-  friend multi_ptr operator-(const multi_ptr& lhs, difference_type r) { /* ... */ }
+  friend multi_ptr& operator++(multi_ptr& mp) { /* ... */
+  }
+  friend multi_ptr operator++(multi_ptr& mp, int) { /* ... */
+  }
+  friend multi_ptr& operator--(multi_ptr& mp) { /* ... */
+  }
+  friend multi_ptr operator--(multi_ptr& mp, int) { /* ... */
+  }
+  friend multi_ptr& operator+=(multi_ptr& lhs, difference_type r) { /* ... */
+  }
+  friend multi_ptr& operator-=(multi_ptr& lhs, difference_type r) { /* ... */
+  }
+  friend multi_ptr operator+(const multi_ptr& lhs,
+                             difference_type r) { /* ... */
+  }
+  friend multi_ptr operator-(const multi_ptr& lhs,
+                             difference_type r) { /* ... */
+  }
 
   void prefetch(size_t numElements) const;
 
-  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
 
-  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
 
-  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
 };
 
 // Legacy interface, inherited from 1.2.1.
@@ -115,7 +151,8 @@ class [[deprecated]] multi_ptr<VoidType, Space, access::decorated::legacy> {
   // Implementation defined pointer types that correspond to
   // SYCL/OpenCL interoperability types for OpenCL C functions
   using pointer_t = multi_ptr<VoidType, Space, access::decorated::yes>::pointer;
-  using const_pointer_t = multi_ptr<const VoidType, Space, access::decorated::yes>::pointer;
+  using const_pointer_t =
+      multi_ptr<const VoidType, Space, access::decorated::yes>::pointer;
 
   static constexpr access::address_space address_space = Space;
 
@@ -129,11 +166,11 @@ class [[deprecated]] multi_ptr<VoidType, Space, access::decorated::legacy> {
   ~multi_ptr();
 
   // Assignment operators
-  multi_ptr &operator=(const multi_ptr&);
-  multi_ptr &operator=(multi_ptr&&);
-  multi_ptr &operator=(pointer_t);
-  multi_ptr &operator=(VoidType*);
-  multi_ptr &operator=(std::nullptr_t);
+  multi_ptr& operator=(const multi_ptr&);
+  multi_ptr& operator=(multi_ptr&&);
+  multi_ptr& operator=(pointer_t);
+  multi_ptr& operator=(VoidType*);
+  multi_ptr& operator=(std::nullptr_t);
 
   // Only if Space == global_space
   template <typename ElementType, int Dimensions, access_mode Mode>
@@ -156,32 +193,50 @@ class [[deprecated]] multi_ptr<VoidType, Space, access::decorated::legacy> {
   // Explicit conversion to a multi_ptr<ElementType>
   // If VoidType is const, ElementType must be as well
   template <typename ElementType>
-  explicit operator multi_ptr<ElementType, Space, access::decorated::legacy>() const;
+  explicit
+  operator multi_ptr<ElementType, Space, access::decorated::legacy>() const;
 
   // Implicit conversion to multi_ptr<const void, Space>
   operator multi_ptr<const void, Space, access::decorated::legacy>() const;
 
-  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, const multi_ptr& rhs) { /* ... */
+  }
 
-  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
-  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */ }
+  friend bool operator==(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator!=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator<=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
+  friend bool operator>=(const multi_ptr& lhs, std::nullptr_t) { /* ... */
+  }
 
-  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */ }
-
+  friend bool operator==(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator!=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator<=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
+  friend bool operator>=(std::nullptr_t, const multi_ptr& rhs) { /* ... */
+  }
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/ndRange.h
+++ b/adoc/headers/ndRange.h
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1>
-class nd_range {
-public:
-
-   /* -- common interface members -- */
+template <int Dimensions = 1> class nd_range {
+ public:
+  /* -- common interface members -- */
 
   // The offset is deprecated in SYCL 2020.
   nd_range(range<Dimensions> globalSize, range<Dimensions> localSize,
@@ -17,4 +15,4 @@ public:
   range<Dimensions> get_group_range() const;
   id<Dimensions> get_offset() const; // Deprecated in SYCL 2020.
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1>
-class nd_item {
-public:
+template <int Dimensions = 1> class nd_item {
+ public:
   nd_item() = delete;
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
   id<Dimensions> get_global_id() const;
 
@@ -48,21 +47,26 @@ public:
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-    decorated_global_ptr<DataT> src, size_t numElements) const;
+                                     decorated_global_ptr<DataT> src,
+                                     size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-    decorated_local_ptr<DataT> src, size_t numElements) const;
+                                     decorated_local_ptr<DataT> src,
+                                     size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-    decorated_global_ptr<DataT> src, size_t numElements, size_t srcStride) const;
+                                     decorated_global_ptr<DataT> src,
+                                     size_t numElements,
+                                     size_t srcStride) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-    decorated_local_ptr<DataT> src, size_t numElements, size_t destStride) const;
+                                     decorated_local_ptr<DataT> src,
+                                     size_t numElements,
+                                     size_t destStride) const;
 
-  template <typename... EventTN>
-  void wait_for(EventTN... events) const;
+  template <typename... EventTN> void wait_for(EventTN... events) const;
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/openclBackend/createBundle.h
+++ b/adoc/headers/openclBackend/createBundle.h
@@ -4,12 +4,12 @@
 namespace sycl::opencl {
 
 template <bundle_state State>
-kernel_bundle<State> create_bundle(const context &ctxt,
-                                   const std::vector<device> &devs,
-                                   const std::vector<cl_program> &clPrograms);
+kernel_bundle<State> create_bundle(const context& ctxt,
+                                   const std::vector<device>& devs,
+                                   const std::vector<cl_program>& clPrograms);
 
 kernel_bundle<bundle_state::executable>
-create_bundle(const context &ctxt, const std::vector<device> &devs,
-              const std::vector<cl_kernel> &clKernels);
+create_bundle(const context& ctxt, const std::vector<device>& devs,
+              const std::vector<cl_kernel>& clKernels);
 
 } // namespace sycl::opencl

--- a/adoc/headers/openclcInterop.h
+++ b/adoc/headers/openclcInterop.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-extern "C" typename sycl::decorated_global_ptr<std::int32_t>::pointer my_func(
-    sycl::float4::vector_t x, double y);
+extern "C" typename sycl::decorated_global_ptr<std::int32_t>::pointer
+my_func(sycl::float4::vector_t x, double y);

--- a/adoc/headers/parallelFor.h
+++ b/adoc/headers/parallelFor.h
@@ -1,23 +1,21 @@
 // Copyright (c) 2011-2022 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-void single_task(kernel *syclKernel);
+void single_task(kernel* syclKernel);
 
-void parallel_for(nd_range<Dimensions> ndRange, kernel *k);
+void parallel_for(nd_range<Dimensions> ndRange, kernel* k);
 
-void parallel_for(range range<Dimensions> kernel *syclKernel);
+void parallel_for(range range<Dimensions> kernel* syclKernel);
 
-
-template <typename KernelName, class KernelType>
-void single_task(KernelType);
+template <typename KernelName, class KernelType> void single_task(KernelType);
 
 template <typename KernelName, class KernelType>
 void parallel_for(range<Dimensions> num_work_items, KernelType);
 
 // Deprecated in SYCL 2020.
 template <typename KernelName, class KernelType>
-void parallel_for(range<Dimensions> numWorkItems,
-                  id<Dimensions> workItemOffset, KernelType);
+void parallel_for(range<Dimensions> numWorkItems, id<Dimensions> workItemOffset,
+                  KernelType);
 
 template <typename KernelName, class KernelType>
 void parallel_for(nd_range<Dimensions> ndRange, KernelType);
@@ -31,16 +29,15 @@ void parallel_for_work_group(range<Dimensions> numWorkGroups,
                              range<Dimensions> workGroupSize,
                              WorkgroupFunctionType);
 
-template <class KernelType>
-void single_task(KernelType);
+template <class KernelType> void single_task(KernelType);
 
 template <class KernelType>
 void parallel_for(range<Dimensions> numWorkItems, KernelType);
 
 // Deprecated in SYCL 2020.
 template <class KernelType>
-void parallel_for(range<Dimensions> numWorkItems,
-                  id<Dimensions> workItemOffset, KernelType);
+void parallel_for(range<Dimensions> numWorkItems, id<Dimensions> workItemOffset,
+                  KernelType);
 
 template <class KernelType>
 void parallel_for(nd_range<Dimensions> ndRange, KernelType);
@@ -49,7 +46,6 @@ void parallel_for(nd_range<Dimensions> ndRange, KernelType);
 template <class KernelType>
 void parallel_for(nd_range<Dimensions> numWorkItems,
                   id<Dimensions> workItemOffset, KernelType);
-
 
 template <class WorkgroupFunctionType>
 void parallel_for_work_group(range<Dimensions> numWorkGroups,

--- a/adoc/headers/platform.h
+++ b/adoc/headers/platform.h
@@ -7,14 +7,14 @@ class platform {
   platform();
 
   template <typename DeviceSelector>
-  explicit platform(const DeviceSelector &deviceSelector);
+  explicit platform(const DeviceSelector& deviceSelector);
 
   /* -- common interface members -- */
 
   backend get_backend() const noexcept;
 
-  std::vector<device> get_devices(
-    info::device_type = info::device_type::all) const;
+  std::vector<device>
+      get_devices(info::device_type = info::device_type::all) const;
 
   template <typename Param> typename Param::return_type get_info() const;
 
@@ -23,8 +23,8 @@ class platform {
 
   bool has(aspect asp) const;
 
-  bool has_extension(const std::string &extension) const; // Deprecated
+  bool has_extension(const std::string& extension) const; // Deprecated
 
   static std::vector<platform> get_platforms();
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/platformInfo.h
+++ b/adoc/headers/platformInfo.h
@@ -11,6 +11,6 @@ struct name;
 struct vendor;
 struct extensions; // Deprecated
 
-}  // namespace platform
-}  // namespace info
-}  // namespace sycl
+} // namespace platform
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/pointer.h
+++ b/adoc/headers/pointer.h
@@ -3,57 +3,67 @@
 
 namespace sycl {
 
-template <typename ElementType, access::address_space Space, access::decorated IsDecorated>
+template <typename ElementType, access::address_space Space,
+          access::decorated IsDecorated>
 class multi_ptr;
 
 // Template specialization aliases for different pointer address spaces
 
-template <typename ElementType, access::decorated IsDecorated = access::decorated::legacy>
-using global_ptr = multi_ptr<ElementType, access::address_space::global_space,
-                             IsDecorated>;
+template <typename ElementType,
+          access::decorated IsDecorated = access::decorated::legacy>
+using global_ptr =
+    multi_ptr<ElementType, access::address_space::global_space, IsDecorated>;
 
-template <typename ElementType, access::decorated IsDecorated = access::decorated::legacy>
-using local_ptr = multi_ptr<ElementType, access::address_space::local_space,
-                            IsDecorated>;
+template <typename ElementType,
+          access::decorated IsDecorated = access::decorated::legacy>
+using local_ptr =
+    multi_ptr<ElementType, access::address_space::local_space, IsDecorated>;
 
 // Deprecated in SYCL 2020
 template <typename ElementType>
-using constant_ptr = multi_ptr<ElementType, access::address_space::constant_space,
-                               access::decorated::legacy>;
+using constant_ptr =
+    multi_ptr<ElementType, access::address_space::constant_space,
+              access::decorated::legacy>;
 
-template <typename ElementType, access::decorated IsDecorated = access::decorated::legacy>
-using private_ptr = multi_ptr<ElementType, access::address_space::private_space,
-                              IsDecorated>;
+template <typename ElementType,
+          access::decorated IsDecorated = access::decorated::legacy>
+using private_ptr =
+    multi_ptr<ElementType, access::address_space::private_space, IsDecorated>;
 
 // Template specialization aliases for different pointer address spaces.
 // The interface exposes non-decorated pointer while keeping the
 // address space information internally.
 
 template <typename ElementType>
-using raw_global_ptr = multi_ptr<ElementType, access::address_space::global_space,
-                                 access::decorated::no>;
+using raw_global_ptr =
+    multi_ptr<ElementType, access::address_space::global_space,
+              access::decorated::no>;
 
 template <typename ElementType>
 using raw_local_ptr = multi_ptr<ElementType, access::address_space::local_space,
                                 access::decorated::no>;
 
 template <typename ElementType>
-using raw_private_ptr = multi_ptr<ElementType, access::address_space::private_space,
-                                  access::decorated::no>;
+using raw_private_ptr =
+    multi_ptr<ElementType, access::address_space::private_space,
+              access::decorated::no>;
 
 // Template specialization aliases for different pointer address spaces.
 // The interface exposes decorated pointer.
 
 template <typename ElementType>
-using decorated_global_ptr = multi_ptr<ElementType, access::address_space::global_space,
-                                       access::decorated::yes>;
+using decorated_global_ptr =
+    multi_ptr<ElementType, access::address_space::global_space,
+              access::decorated::yes>;
 
 template <typename ElementType>
-using decorated_local_ptr = multi_ptr<ElementType, access::address_space::local_space,
-                                      access::decorated::yes>;
+using decorated_local_ptr =
+    multi_ptr<ElementType, access::address_space::local_space,
+              access::decorated::yes>;
 
 template <typename ElementType>
-using decorated_private_ptr = multi_ptr<ElementType, access::address_space::private_space,
-                                        access::decorated::yes>;
+using decorated_private_ptr =
+    multi_ptr<ElementType, access::address_space::private_space,
+              access::decorated::yes>;
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/priv.h
+++ b/adoc/headers/priv.h
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <typename T, int Dimensions = 1>
-class private_memory {
+template <typename T, int Dimensions = 1> class private_memory {
  public:
   // Construct based directly off the number of work-items
-  private_memory(const group<Dimensions> &);
+  private_memory(const group<Dimensions>&);
 
   // Access the instance for the current work-item
-  T &operator()(const h_item<Dimensions> &id);
+  T& operator()(const h_item<Dimensions>& id);
 };
-}
+} // namespace sycl

--- a/adoc/headers/properties.h
+++ b/adoc/headers/properties.h
@@ -3,33 +3,30 @@
 
 namespace sycl {
 
-template <typename Property>
-struct is_property;
+template <typename Property> struct is_property;
 
 template <typename Property>
 inline constexpr bool is_property_v = is_property<Property>::value;
 
-template <typename Property, typename SyclObject>
-struct is_property_of;
+template <typename Property, typename SyclObject> struct is_property_of;
 
 template <typename Property, typename SyclObject>
-inline constexpr bool is_property_of_v = is_property_of<Property, SyclObject>::value;
+inline constexpr bool is_property_of_v =
+    is_property_of<Property, SyclObject>::value;
 
 class T {
   ...
 
-  template <typename Property>
-  bool has_property() const noexcept;
+      template <typename Property>
+      bool has_property() const noexcept;
 
-  template <typename Property>
-  Property get_property() const;
+  template <typename Property> Property get_property() const;
 
   ...
 };
 
 class property_list {
  public:
-   template <typename... Properties>
-   property_list(Properties... props);
+  template <typename... Properties> property_list(Properties... props);
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/queue.h
+++ b/adoc/headers/queue.h
@@ -4,42 +4,42 @@
 namespace sycl {
 class queue {
  public:
-  explicit queue(const property_list &propList = {});
+  explicit queue(const property_list& propList = {});
 
-  explicit queue(const async_handler &asyncHandler,
-                 const property_list &propList = {});
-
-  template <typename DeviceSelector>
-  explicit queue(const DeviceSelector &deviceSelector,
-                 const property_list &propList = {});
+  explicit queue(const async_handler& asyncHandler,
+                 const property_list& propList = {});
 
   template <typename DeviceSelector>
-  explicit queue(const DeviceSelector &deviceSelector,
-                 const async_handler &asyncHandler,
-                 const property_list &propList = {});
-
-  explicit queue(const device &syclDevice, const property_list &propList = {});
-
-  explicit queue(const device &syclDevice, const async_handler &asyncHandler,
-                 const property_list &propList = {});
+  explicit queue(const DeviceSelector& deviceSelector,
+                 const property_list& propList = {});
 
   template <typename DeviceSelector>
-  explicit queue(const context &syclContext,
-                 const DeviceSelector &deviceSelector,
-                 const property_list &propList = {});
+  explicit queue(const DeviceSelector& deviceSelector,
+                 const async_handler& asyncHandler,
+                 const property_list& propList = {});
+
+  explicit queue(const device& syclDevice, const property_list& propList = {});
+
+  explicit queue(const device& syclDevice, const async_handler& asyncHandler,
+                 const property_list& propList = {});
 
   template <typename DeviceSelector>
-  explicit queue(const context &syclContext,
-                 const DeviceSelector &deviceSelector,
-                 const async_handler &asyncHandler,
-                 const property_list &propList = {});
+  explicit queue(const context& syclContext,
+                 const DeviceSelector& deviceSelector,
+                 const property_list& propList = {});
 
-  explicit queue(const context &syclContext, const device &syclDevice,
-                 const property_list &propList = {});
+  template <typename DeviceSelector>
+  explicit queue(const context& syclContext,
+                 const DeviceSelector& deviceSelector,
+                 const async_handler& asyncHandler,
+                 const property_list& propList = {});
 
-  explicit queue(const context &syclContext, const device &syclDevice,
-                 const async_handler &asyncHandler,
-                 const property_list &propList = {});
+  explicit queue(const context& syclContext, const device& syclDevice,
+                 const property_list& propList = {});
+
+  explicit queue(const context& syclContext, const device& syclDevice,
+                 const async_handler& asyncHandler,
+                 const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -58,11 +58,9 @@ class queue {
   template <typename Param>
   typename Param::return_type get_backend_info() const;
 
-  template <typename T>
-  event submit(T cgf);
+  template <typename T> event submit(T cgf);
 
-  template <typename T>
-  event submit(T cgf, const queue &secondaryQueue);
+  template <typename T> event submit(T cgf, const queue& secondaryQueue);
 
   void wait();
 
@@ -73,91 +71,83 @@ class queue {
   /* -- convenience shortcuts -- */
 
   template <typename KernelName, typename KernelType>
-  event single_task(const KernelType &kernelFunc);
+  event single_task(const KernelType& kernelFunc);
 
   template <typename KernelName, typename KernelType>
-  event single_task(event depEvent, const KernelType &kernelFunc);
+  event single_task(event depEvent, const KernelType& kernelFunc);
 
   template <typename KernelName, typename KernelType>
-  event single_task(const std::vector<event> &depEvents,
-                    const KernelType &kernelFunc);
+  event single_task(const std::vector<event>& depEvents,
+                    const KernelType& kernelFunc);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
+  template <typename KernelName, int Dims, typename... Rest>
+  event parallel_for(range<Dims> numWorkItems, Rest&&... rest);
+
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
+  template <typename KernelName, int Dims, typename... Rest>
+  event parallel_for(range<Dims> numWorkItems, event depEvent, Rest&&... rest);
+
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dims, typename... Rest>
   event parallel_for(range<Dims> numWorkItems,
-                     Rest&&... rest);
+                     const std::vector<event>& depEvents, Rest&&... rest);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dims, typename... Rest>
-  event parallel_for(range<Dims> numWorkItems, event depEvent,
-                     Rest&&... rest);
+  event parallel_for(nd_range<Dims> executionRange, Rest&&... rest);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dims, typename... Rest>
-  event parallel_for(range<Dims> numWorkItems,
-                     const std::vector<event> &depEvents,
+  event parallel_for(nd_range<Dims> executionRange, event depEvent,
                      Rest&&... rest);
 
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
-  template <typename KernelName, int Dims, typename... Rest>
-  event parallel_for(nd_range<Dims> executionRange,
-                     Rest&&... rest);
-
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
+  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType
+  // &kernelFunc
   template <typename KernelName, int Dims, typename... Rest>
   event parallel_for(nd_range<Dims> executionRange,
-                     event depEvent,
-                     Rest&&... rest);
-
-  // Parameter pack acts as-if: Reductions&&... reductions, const KernelType &kernelFunc
-  template <typename KernelName, int Dims, typename... Rest>
-  event parallel_for(nd_range<Dims> executionRange,
-                     const std::vector<event> &depEvents,
-                     Rest&&... rest);
+                     const std::vector<event>& depEvents, Rest&&... rest);
 
   /* -- USM functions -- */
 
   event memcpy(void* dest, const void* src, size_t numBytes);
+  event memcpy(void* dest, const void* src, size_t numBytes, event depEvent);
   event memcpy(void* dest, const void* src, size_t numBytes,
-               event depEvent);
-  event memcpy(void* dest, const void* src, size_t numBytes,
-               const std::vector<event> &depEvents);
+               const std::vector<event>& depEvents);
 
+  template <typename T> event copy(const T* src, T* dest, size_t count);
   template <typename T>
-  event copy(const T* src, T *dest, size_t count);
+  event copy(const T* src, T* dest, size_t count, event depEvent);
   template <typename T>
-  event copy(const T* src, T *dest, size_t count,
-             event depEvent);
-  template <typename T>
-  event copy(const T* src, T *dest, size_t count,
-             const std::vector<event> &depEvents);
+  event copy(const T* src, T* dest, size_t count,
+             const std::vector<event>& depEvents);
 
   event memset(void* ptr, int value, size_t numBytes);
+  event memset(void* ptr, int value, size_t numBytes, event depEvent);
   event memset(void* ptr, int value, size_t numBytes,
-               event depEvent);
-  event memset(void* ptr, int value, size_t numBytes,
-               const std::vector<event> &depEvents);
+               const std::vector<event>& depEvents);
 
+  template <typename T> event fill(void* ptr, const T& pattern, size_t count);
   template <typename T>
-  event fill(void* ptr, const T& pattern, size_t count);
-  template <typename T>
-  event fill(void* ptr, const T& pattern, size_t count,
-             event depEvent);
+  event fill(void* ptr, const T& pattern, size_t count, event depEvent);
   template <typename T>
   event fill(void* ptr, const T& pattern, size_t count,
-             const std::vector<event> &depEvents);
+             const std::vector<event>& depEvents);
 
   event prefetch(void* ptr, size_t numBytes);
+  event prefetch(void* ptr, size_t numBytes, event depEvent);
   event prefetch(void* ptr, size_t numBytes,
-                 event depEvent);
-  event prefetch(void* ptr, size_t numBytes,
-                 const std::vector<event> &depEvents);
+                 const std::vector<event>& depEvents);
 
-  event mem_advise(void *ptr, size_t numBytes, int advice);
-  event mem_advise(void *ptr, size_t numBytes, int advice,
-                   event depEvent);
-  event mem_advise(void *ptr, size_t numBytes, int advice,
-                   const std::vector<event> &depEvents);
+  event mem_advise(void* ptr, size_t numBytes, int advice);
+  event mem_advise(void* ptr, size_t numBytes, int advice, event depEvent);
+  event mem_advise(void* ptr, size_t numBytes, int advice,
+                   const std::vector<event>& depEvents);
 
   /// Placeholder accessor shortcuts
 
@@ -168,32 +158,28 @@ class queue {
   event copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
              std::shared_ptr<DestT> dest);
 
-  template <typename SrcT, typename DestT, int DestDims,
-            access_mode DestMode, target DestTgt,
-            access::placeholder IsPlaceholder>
-  event
-  copy(std::shared_ptr<SrcT> src,
-       accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder> dest);
+  template <typename SrcT, typename DestT, int DestDims, access_mode DestMode,
+            target DestTgt, access::placeholder IsPlaceholder>
+  event copy(std::shared_ptr<SrcT> src,
+             accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder> dest);
 
   template <typename SrcT, int SrcDims, access_mode SrcMode, target SrcTgt,
             access::placeholder IsPlaceholder, typename DestT>
   event copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
-             DestT *dest);
+             DestT* dest);
 
-  template <typename SrcT, typename DestT, int DestDims,
-            access_mode DestMode, target DestTgt,
-            access::placeholder IsPlaceholder>
-  event
-  copy(const SrcT *src,
-       accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder> dest);
+  template <typename SrcT, typename DestT, int DestDims, access_mode DestMode,
+            target DestTgt, access::placeholder IsPlaceholder>
+  event copy(const SrcT* src,
+             accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder> dest);
 
   template <typename SrcT, int SrcDims, access_mode SrcMode, target SrcTgt,
-            access::placeholder IsSrcPlaceholder, typename DestT,
-            int DestDims, access_mode DestMode, target DestTgt,
+            access::placeholder IsSrcPlaceholder, typename DestT, int DestDims,
+            access_mode DestMode, target DestTgt,
             access::placeholder IsDestPlaceholder>
-  event copy(
-      accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsSrcPlaceholder> src,
-      accessor<DestT, DestDims, DestMode, DestTgt, IsDestPlaceholder> dest);
+  event
+  copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsSrcPlaceholder> src,
+       accessor<DestT, DestDims, DestMode, DestTgt, IsDestPlaceholder> dest);
 
   template <typename T, int Dims, access_mode Mode, target Tgt,
             access::placeholder IsPlaceholder>
@@ -201,6 +187,6 @@ class queue {
 
   template <typename T, int Dims, access_mode Mode, target Tgt,
             access::placeholder IsPlaceholder>
-  event fill(accessor<T, Dims, Mode, Tgt, IsPlaceholder> dest, const T &src);
+  event fill(accessor<T, Dims, Mode, Tgt, IsPlaceholder> dest, const T& src);
 };
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/queueInfo.h
+++ b/adoc/headers/queueInfo.h
@@ -8,6 +8,6 @@ namespace queue {
 struct context;
 struct device;
 
-}  // namespace queue
-}  // namespace info
-}  // namespace sycl
+} // namespace queue
+} // namespace info
+} // namespace sycl

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -2,49 +2,58 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-template <int Dimensions = 1>
-class range {
-public:
-  /* The following constructor is only available in the range class specialization where: Dimensions==1 */
+template <int Dimensions = 1> class range {
+ public:
+  /* The following constructor is only available in the range class
+   * specialization where: Dimensions==1 */
   range(size_t dim0);
-  /* The following constructor is only available in the range class specialization where: Dimensions==2 */
+  /* The following constructor is only available in the range class
+   * specialization where: Dimensions==2 */
   range(size_t dim0, size_t dim1);
-  /* The following constructor is only available in the range class specialization where: Dimensions==3 */
+  /* The following constructor is only available in the range class
+   * specialization where: Dimensions==3 */
   range(size_t dim0, size_t dim1, size_t dim2);
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
   size_t get(int dimension) const;
-  size_t &operator[](int dimension);
+  size_t& operator[](int dimension);
   size_t operator[](int dimension) const;
 
   size_t size() const;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const range &lhs, const range &rhs) { /* ... */ }
-  friend range operatorOP(const range &lhs, const size_t &rhs) { /* ... */ }
+  friend range operatorOP(const range& lhs, const range& rhs) { /* ... */
+  }
+  friend range operatorOP(const range& lhs, const size_t& rhs) { /* ... */
+  }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-  friend range & operatorOP(range &lhs, const range &rhs) { /* ... */ }
-  friend range & operatorOP(range &lhs, const size_t &rhs) { /* ... */ }
+  friend range& operatorOP(range& lhs, const range& rhs) { /* ... */
+  }
+  friend range& operatorOP(range& lhs, const size_t& rhs) { /* ... */
+  }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const size_t &lhs, const range &rhs) { /* ... */ }
+  friend range operatorOP(const size_t& lhs, const range& rhs) { /* ... */
+  }
 
   // OP is unary +, -
-  friend range operatorOP(const range &rhs) { /* ... */ }
+  friend range operatorOP(const range& rhs) { /* ... */
+  }
 
   // OP is prefix ++, --
-  friend range & operatorOP(range &rhs) { /* ... */ }
+  friend range& operatorOP(range& rhs) { /* ... */
+  }
 
   // OP is postfix ++, --
-  friend range operatorOP(range &lhs, int) { /* ... */ }
-
+  friend range operatorOP(range& lhs, int) { /* ... */
+  }
 };
 
 // Deduction guides
-range(size_t) -> range<1>;
-range(size_t, size_t) -> range<2>;
-range(size_t, size_t, size_t) -> range<3>;
+range(size_t)->range<1>;
+range(size_t, size_t)->range<2>;
+range(size_t, size_t, size_t)->range<3>;
 
-}  // sycl
+} // namespace sycl

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 // Exposition only
-template <typename T, typename BinaryOperation, int Dimensions, /* unspecified */>
+template <typename T, typename BinaryOperation, int Dimensions,
+          /* unspecified */>
 class reducer {
-public:
-
+ public:
   using value_type = T;
   using binary_operation = BinaryOperation;
   static constexpr int dimensions = Dimensions;
@@ -23,32 +23,36 @@ public:
   /* Only available if Dimensions > 0 */
   __unspecified__ operator[](size_t index)
 
-  /* Only available if identity value is known */
-  T identity() const;
+      /* Only available if identity value is known */
+      T identity() const;
 
   /* Only available if Dimensions == 0 and either
    * BinaryOperation == plus<> or BinaryOperation == plus<T> */
-  friend reducer& operator+=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator+=(reducer&, const T&) { /* ... */
+  }
 
   /* Only available if Dimensions == 0 and either
    * BinaryOperation == multiplies<> or BinaryOperation == multiplies<T> */
-  friend reducer& operator*=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator*=(reducer&, const T&) { /* ... */
+  }
 
   /* Only available if Dimensions == 0, T is an integral type and either
    * BinaryOperation == bit_and<> or BinaryOperation == bit_and<T> */
-  friend reducer& operator&=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator&=(reducer&, const T&) { /* ... */
+  }
 
   /* Only available if Dimensions == 0, T is an integral type and either
    * BinaryOperation == bit_or<> or BinaryOperation == bit_or<T> */
-  friend reducer& operator|=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator|=(reducer&, const T&) { /* ... */
+  }
 
   /* Only available if Dimensions == 0, T is an integral type and either
    * BinaryOperation == bit_xor<> or BinaryOperation == bit_xor<T> */
-  friend reducer& operator^=(reducer&, const T&) { /* ... */ }
+  friend reducer& operator^=(reducer&, const T&) { /* ... */
+  }
 
-  /* Only available if Dimensions == 0, T is an integral type, T is not bool and either
-   * BinaryOperation == plus<> or BinaryOperation == plus<T> */
-  friend reducer& operator++(reducer&) { /* ... */ }
-
+  /* Only available if Dimensions == 0, T is an integral type, T is not bool and
+   * either BinaryOperation == plus<> or BinaryOperation == plus<T> */
+  friend reducer& operator++(reducer&) { /* ... */
+  }
 };
-

--- a/adoc/headers/reduction.h
+++ b/adoc/headers/reduction.h
@@ -2,19 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 template <typename BufferT, typename BinaryOperation>
-__unspecified__ reduction(BufferT vars, handler& cgh, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__ reduction(BufferT vars, handler& cgh, BinaryOperation combiner,
+                          const property_list& propList = {});
 
 template <typename T, typename BinaryOperation>
-__unspecified__ reduction(T* var, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__ reduction(T* var, BinaryOperation combiner,
+                          const property_list& propList = {});
 
 template <typename T, typename Extent, typename BinaryOperation>
-__unspecified__ reduction(span<T, Extent> vars, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__ reduction(span<T, Extent> vars, BinaryOperation combiner,
+                          const property_list& propList = {});
 
 template <typename BufferT, typename BinaryOperation>
-__unspecified__ reduction(BufferT vars, handler& cgh, const BufferT::value_type& identity, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__
+reduction(BufferT vars, handler& cgh, const BufferT::value_type& identity,
+          BinaryOperation combiner, const property_list& propList = {});
 
 template <typename T, typename BinaryOperation>
-__unspecified__ reduction(T* var, const T& identity, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__ reduction(T* var, const T& identity, BinaryOperation combiner,
+                          const property_list& propList = {});
 
 template <typename T, typename Extent, typename BinaryOperation>
-__unspecified__ reduction(span<T, Extent> vars, const T& identity, BinaryOperation combiner, const property_list &propList = {});
+__unspecified__ reduction(span<T, Extent> vars, const T& identity,
+                          BinaryOperation combiner,
+                          const property_list& propList = {});

--- a/adoc/headers/sampledImage.h
+++ b/adoc/headers/sampledImage.h
@@ -20,25 +20,25 @@ enum class image_format : /* unspecified */ {
 template <int Dimensions = 1, typename AllocatorT = sycl::image_allocator>
 class sampled_image {
  public:
-  sampled_image(const void *hostPointer, image_format format,
-                  image_sampler sampler, const range<Dimensions> &rangeRef,
-                  const property_list &propList = {});
+  sampled_image(const void* hostPointer, image_format format,
+                image_sampler sampler, const range<Dimensions>& rangeRef,
+                const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  sampled_image(const void *hostPointer, image_format format,
-                  image_sampler sampler, const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch,
-                  const property_list &propList = {});
+  sampled_image(const void* hostPointer, image_format format,
+                image_sampler sampler, const range<Dimensions>& rangeRef,
+                const range<Dimensions - 1>& pitch,
+                const property_list& propList = {});
 
-  sampled_image(std::shared_ptr<const void> &hostPointer, image_format format,
-                  image_sampler sampler, const range<Dimensions> &rangeRef,
-                  const property_list &propList = {});
+  sampled_image(std::shared_ptr<const void>& hostPointer, image_format format,
+                image_sampler sampler, const range<Dimensions>& rangeRef,
+                const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  sampled_image(std::shared_ptr<const void> &hostPointer, image_format format,
-                  image_sampler sampler, const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch,
-                  const property_list &propList = {});
+  sampled_image(std::shared_ptr<const void>& hostPointer, image_format format,
+                image_sampler sampler, const range<Dimensions>& rangeRef,
+                const range<Dimensions - 1>& pitch,
+                const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -53,11 +53,9 @@ class sampled_image {
 
   size_t size() const;
 
-  template<typename... Ts>
-  auto get_access(Ts... args);
+  template <typename... Ts> auto get_access(Ts... args);
 
-  template<typename... Ts>
-  auto get_host_access(Ts... args);
+  template <typename... Ts> auto get_host_access(Ts... args);
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/stream.h
+++ b/adoc/headers/stream.h
@@ -19,7 +19,6 @@ enum class stream_manipulator : /* unspecified */ {
   defaultfloat
 };
 
-
 const stream_manipulator flush = stream_manipulator::flush;
 
 const stream_manipulator dec = stream_manipulator::dec;
@@ -52,9 +51,8 @@ __width_manipulator__ setw(int width);
 
 class stream {
  public:
-
-  stream(size_t totalBufferSize, size_t workItemBufferSize, handler& cgh
-         const property_list &propList = {});
+  stream(size_t totalBufferSize, size_t workItemBufferSize,
+         handler& cgh const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -67,13 +65,12 @@ class stream {
 
   size_t get_work_item_buffer_size() const;
 
-  /* get_max_statement_size() has the same functionality as get_work_item_buffer_size(),
-     and is provided for backward compatibility.  get_max_statement_size() is a deprecated
-     query. */
+  /* get_max_statement_size() has the same functionality as
+     get_work_item_buffer_size(), and is provided for backward compatibility.
+     get_max_statement_size() is a deprecated query. */
   size_t get_max_statement_size() const;
 };
 
-template <typename T>
-const stream& operator<<(const stream& os, const T &rhs);
+template <typename T> const stream& operator<<(const stream& os, const T& rhs);
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/subgroup.h
+++ b/adoc/headers/subgroup.h
@@ -3,15 +3,14 @@
 
 namespace sycl {
 class sub_group {
-public:
-
+ public:
   using id_type = id<1>;
   using range_type = range<1>;
   using linear_id_type = uint32_t;
   static constexpr int dimensions = 1;
   static constexpr memory_scope fence_scope = memory_scope::sub_group;
 
-   /* -- common interface members -- */
+  /* -- common interface members -- */
 
   id<1> get_group_id() const;
 
@@ -32,7 +31,5 @@ public:
   uint32_t get_local_linear_range() const;
 
   bool leader() const;
-
 };
-}  // sycl
-
+} // namespace sycl

--- a/adoc/headers/synchronization.h
+++ b/adoc/headers/synchronization.h
@@ -5,4 +5,4 @@ namespace sycl {
 
 void atomic_fence(memory_order order, memory_scope scope);
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/unsampledImage.h
+++ b/adoc/headers/unsampledImage.h
@@ -20,61 +20,61 @@ enum class image_format : /* unspecified */ {
 template <int Dimensions = 1, typename AllocatorT = sycl::image_allocator>
 class unsampled_image {
  public:
-  unsampled_image(image_format format, const range<Dimensions> &rangeRef,
-                  const property_list &propList = {});
+  unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+                  const property_list& propList = {});
 
-  unsampled_image(image_format format, const range<Dimensions> &rangeRef,
-                  AllocatorT allocator, const property_list &propList = {});
-
-  /* Available only when: Dimensions > 1 */
-  unsampled_image(image_format format, const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch,
-                  const property_list &propList = {});
+  unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+                  AllocatorT allocator, const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  unsampled_image(image_format format, const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch, AllocatorT allocator,
-                  const property_list &propList = {});
-
-  unsampled_image(void *hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const property_list &propList = {});
-
-  unsampled_image(void *hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef, AllocatorT allocator,
-                  const property_list &propList = {});
+  unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch,
+                  const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  unsampled_image(void *hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch,
-                  const property_list &propList = {});
+  unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch, AllocatorT allocator,
+                  const property_list& propList = {});
+
+  unsampled_image(void* hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const property_list& propList = {});
+
+  unsampled_image(void* hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef, AllocatorT allocator,
+                  const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  unsampled_image(void *hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch, AllocatorT allocator,
-                  const property_list &propList = {});
-
-  unsampled_image(std::shared_ptr<void> &hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const property_list &propList = {});
-
-  unsampled_image(std::shared_ptr<void> &hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef, AllocatorT allocator,
-                  const property_list &propList = {});
+  unsampled_image(void* hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch,
+                  const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  unsampled_image(std::shared_ptr<void> &hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch,
-                  const property_list &propList = {});
+  unsampled_image(void* hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch, AllocatorT allocator,
+                  const property_list& propList = {});
+
+  unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const property_list& propList = {});
+
+  unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef, AllocatorT allocator,
+                  const property_list& propList = {});
 
   /* Available only when: Dimensions > 1 */
-  unsampled_image(std::shared_ptr<void> &hostPointer, image_format format,
-                  const range<Dimensions> &rangeRef,
-                  const range<Dimensions - 1> &pitch, AllocatorT allocator,
-                  const property_list &propList = {});
+  unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch,
+                  const property_list& propList = {});
+
+  /* Available only when: Dimensions > 1 */
+  unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+                  const range<Dimensions>& rangeRef,
+                  const range<Dimensions - 1>& pitch, AllocatorT allocator,
+                  const property_list& propList = {});
 
   /* -- common interface members -- */
 
@@ -91,11 +91,9 @@ class unsampled_image {
 
   AllocatorT get_allocator() const;
 
-  template<typename... Ts>
-  auto get_access(Ts... args);
+  template <typename... Ts> auto get_access(Ts... args);
 
-  template<typename... Ts>
-  auto get_host_access(Ts... args);
+  template <typename... Ts> auto get_host_access(Ts... args);
 
   template <typename Destination = std::nullptr_t>
   void set_final_data(Destination finalData = std::nullptr);
@@ -103,4 +101,4 @@ class unsampled_image {
   void set_write_back(bool flag = true);
 };
 
-}  // namespace sycl
+} // namespace sycl

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -3,13 +3,7 @@
 
 namespace sycl {
 
-enum class rounding_mode : /* unspecified */ {
-  automatic,
-  rte,
-  rtz,
-  rtp,
-  rtn
-};
+enum class rounding_mode : /* unspecified */ { automatic, rte, rtz, rtp, rtn };
 
 struct elem {
   static constexpr int x = 0;
@@ -38,8 +32,7 @@ struct elem {
   static constexpr int sF = 15;
 };
 
-template <typename DataT, int NumElements>
-class vec {
+template <typename DataT, int NumElements> class vec {
  public:
   using element_type = DataT;
 
@@ -49,12 +42,11 @@ class vec {
 
   vec();
 
-  explicit constexpr vec(const DataT &arg);
+  explicit constexpr vec(const DataT& arg);
 
-  template <typename... ArgTN>
-  constexpr vec(const ArgTN&... args);
+  template <typename... ArgTN> constexpr vec(const ArgTN&... args);
 
-  constexpr vec(const vec<DataT, NumElements> &rhs);
+  constexpr vec(const vec<DataT, NumElements>& rhs);
 
 #ifdef __SYCL_DEVICE_ONLY__
   vec(vector_t nativeVector);
@@ -75,14 +67,13 @@ class vec {
   // Deprecated
   size_t get_count() const;
 
-  template <typename ConvertT, rounding_mode RoundingMode = rounding_mode::automatic>
+  template <typename ConvertT,
+            rounding_mode RoundingMode = rounding_mode::automatic>
   vec<ConvertT, NumElements> convert() const;
 
-  template <typename AsT>
-  AsT as() const;
+  template <typename AsT> AsT as() const;
 
-  template<int... swizzleIndexes>
-  __swizzled_vec__ swizzle() const;
+  template <int... swizzleIndexes> __swizzled_vec__ swizzle() const;
 
   // Available only when NumElements <= 4.
   // XYZW_ACCESS is: x, y, z, w, subject to NumElements.
@@ -106,7 +97,7 @@ class vec {
   // RGBA_SWIZZLE is all permutations with repetition of: r, g, b, a.
   __swizzled_vec__ RGBA_SWIZZLE() const;
 
-#endif  // #ifdef SYCL_SIMPLE_SWIZZLES
+#endif // #ifdef SYCL_SIMPLE_SWIZZLES
 
   // Available only when: NumElements > 1.
   __swizzled_vec__ lo() const;
@@ -116,107 +107,127 @@ class vec {
 
   // load and store member functions
   template <access::address_space AddressSpace, access::decorated IsDecorated>
-  void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr);
+  void load(size_t offset,
+            multi_ptr<const DataT, AddressSpace, IsDecorated> ptr);
   template <access::address_space AddressSpace, access::decorated IsDecorated>
-  void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const;
+  void store(size_t offset,
+             multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const;
 
   // subscript operator
-  DataT &operator[](int index);
-  const DataT &operator[](int index) const;
+  DataT& operator[](int index);
+  const DataT& operator[](int index) const;
 
   // OP is: +, -, *, /, %
   /* If OP is %, available only when: DataT != float && DataT != double
   && DataT != half. */
-  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec operatorOP(const vec &lhs, const DataT &rhs) { /* ... */ }
+  friend vec operatorOP(const vec& lhs, const vec& rhs) { /* ... */
+  }
+  friend vec operatorOP(const vec& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: +=, -=, *=, /=, %=
   /* If OP is %=, available only when: DataT != float && DataT != double
   && DataT != half. */
-  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec &operatorOP(vec &lhs, const DataT &rhs) { /* ... */ }
+  friend vec& operatorOP(vec& lhs, const vec& rhs) { /* ... */
+  }
+  friend vec& operatorOP(vec& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is prefix ++, --
-  friend vec &operatorOP(vec &rhs) { /* ... */ }
+  friend vec& operatorOP(vec& rhs) { /* ... */
+  }
 
   // OP is postfix ++, --
-  friend vec operatorOP(vec& lhs, int) { /* ... */ }
+  friend vec operatorOP(vec& lhs, int) { /* ... */
+  }
 
   // OP is unary +, -
-  friend vec operatorOP(const vec &rhs) { /* ... */ }
+  friend vec operatorOP(const vec& rhs) { /* ... */
+  }
 
   // OP is: &, |, ^
   /* Available only when: DataT != float && DataT != double
   && DataT != half. */
-  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec operatorOP(const vec &lhs, const DataT &rhs) { /* ... */ }
+  friend vec operatorOP(const vec& lhs, const vec& rhs) { /* ... */
+  }
+  friend vec operatorOP(const vec& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: &=, |=, ^=
   /* Available only when: DataT != float && DataT != double
   && DataT != half. */
-  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec &operatorOP(vec &lhs, const DataT &rhs) { /* ... */ }
+  friend vec& operatorOP(vec& lhs, const vec& rhs) { /* ... */
+  }
+  friend vec& operatorOP(vec& lhs, const DataT& rhs) { /* ... */
+  }
 
   // OP is: &&, ||
-  friend vec<RET, NumElements> operatorOP(const vec &lhs, const vec &rhs) {
+  friend vec<RET, NumElements> operatorOP(const vec& lhs, const vec& rhs) {
     /* ... */ }
-  friend vec<RET, NumElements> operatorOP(const vec& lhs, const DataT &rhs) {
-    /* ... */ }
-
-  // OP is: <<, >>
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend vec operatorOP(const vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec operatorOP(const vec &lhs, const DataT &rhs) { /* ... */ }
-
-  // OP is: <<=, >>=
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend vec &operatorOP(vec &lhs, const vec &rhs) { /* ... */ }
-  friend vec &operatorOP(vec &lhs, const DataT &rhs) { /* ... */ }
-
-  // OP is: ==, !=, <, >, <=, >=
-  friend vec<RET, NumElements> operatorOP(const vec &lhs, const vec &rhs) {
-    /* ... */ }
-  friend vec<RET, NumElements> operatorOP(const vec &lhs, const DataT &rhs) {
+    friend vec<RET, NumElements> operatorOP(const vec& lhs, const DataT& rhs) {
     /* ... */ }
 
-  vec &operator=(const vec<DataT, NumElements> &rhs);
-  vec &operator=(const DataT &rhs);
+    // OP is: <<, >>
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend vec operatorOP(const vec& lhs, const vec& rhs) { /* ... */
+    }
+    friend vec operatorOP(const vec& lhs, const DataT& rhs) { /* ... */
+    }
 
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend vec operator~(const vec &v) { /* ... */ }
-  friend vec<RET, NumElements> operator!(const vec &v) { /* ... */ }
+    // OP is: <<=, >>=
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend vec& operatorOP(vec& lhs, const vec& rhs) { /* ... */
+    }
+    friend vec& operatorOP(vec& lhs, const DataT& rhs) { /* ... */
+    }
 
-  // OP is: +, -, *, /, %
-  /* operator% is only available when: DataT != float && DataT != double &&
-  DataT != half. */
-  friend vec operatorOP(const DataT &lhs, const vec &rhs) { /* ... */ }
-
-  // OP is: &, |, ^
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend vec operatorOP(const DataT &lhs, const vec &rhs) { /* ... */ }
-
-  // OP is: &&, ||
-  friend vec<RET, NumElements> operatorOP(const DataT &lhs, const vec &rhs) {
+    // OP is: ==, !=, <, >, <=, >=
+    friend vec<RET, NumElements> operatorOP(const vec& lhs, const vec& rhs) {
+    /* ... */ }
+    friend vec<RET, NumElements> operatorOP(const vec& lhs, const DataT& rhs) {
     /* ... */ }
 
-  // OP is: <<, >>
-  /* Available only when: DataT != float && DataT != double
-  && DataT != half. */
-  friend vec operatorOP(const DataT &lhs, const vec &rhs) { /* ... */ }
+    vec& operator=(const vec<DataT, NumElements>& rhs);
+    vec& operator=(const DataT& rhs);
 
-  // OP is: ==, !=, <, >, <=, >=
-  friend vec<RET, NumElements> operatorOP(const DataT &lhs, const vec &rhs) {
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend vec operator~(const vec& v) { /* ... */
+    }
+    friend vec<RET, NumElements> operator!(const vec& v) { /* ... */
+    }
+
+    // OP is: +, -, *, /, %
+    /* operator% is only available when: DataT != float && DataT != double &&
+    DataT != half. */
+    friend vec operatorOP(const DataT& lhs, const vec& rhs) { /* ... */
+    }
+
+    // OP is: &, |, ^
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend vec operatorOP(const DataT& lhs, const vec& rhs) { /* ... */
+    }
+
+    // OP is: &&, ||
+    friend vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs) {
     /* ... */ }
 
+    // OP is: <<, >>
+    /* Available only when: DataT != float && DataT != double
+    && DataT != half. */
+    friend vec operatorOP(const DataT& lhs, const vec& rhs) { /* ... */
+    }
+
+    // OP is: ==, !=, <, >, <=, >=
+    friend vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs) {
+    /* ... */ }
 };
 
 // Deduction guides
 // Available only when: (std::is_same_v<T, U> && ...)
-template <class T, class... U>
-vec(T, U...) -> vec<T, sizeof...(U) + 1>;
+template <class T, class... U> vec(T, U...) -> vec<T, sizeof...(U) + 1>;
 
-}  // namespace sycl
+} // namespace sycl


### PR DESCRIPTION
Put the * and & close to the type.

The changes in the specification itself is manual work because of the intermixing of AsciiDoctor and C++ snippets but clang-format was used for changing the headers and code samples.
Since clang-format has been used, the coding style has been homogenized.

This should solve https://github.com/KhronosGroup/SYCL-Docs/issues/153