### PR TITLE
Fix for PDF build problem vs. asciidoctor-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,17 @@ Dockerfile at
 
 https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile
 
-Note that the Khronos Docker image layers on the official Ruby 2.7 Docker
+Note that the Khronos Docker image layers on the official Ruby 3.1 Docker
 image, so you must install Ruby first.
+
+If you have installed an older version of the tools and the Khronos image is
+updated, there may be corresponding changes in the specification build and
+markup required by the new versions. For example, updating from
+asciidoctor-pdf 1.6.1 to 2.2.0 required changing the `pdf-stylesdir`
+attribute in the asciidoctor build to `pdf-themesdir`. Eventually, these
+changes may make using the older tools impractical. If this happens, update
+your tools to match the latest Docker image, and rebase your working branch
+on current `main` branch.
 
 
 ### Building Using GitLab CI

--- a/README.md
+++ b/README.md
@@ -119,13 +119,12 @@ Note that the Khronos Docker image layers on the official Ruby 3.1 Docker
 image, so you must install Ruby first.
 
 If you have installed an older version of the tools and the Khronos image is
-updated, there may be corresponding changes in the specification build and
-markup required by the new versions. For example, updating from
-asciidoctor-pdf 1.6.1 to 2.2.0 required changing the `pdf-stylesdir`
-attribute in the asciidoctor build to `pdf-themesdir`. Eventually, these
-changes may make using the older tools impractical. If this happens, update
-your tools to match the latest Docker image, and rebase your working branch
-on current `main` branch.
+updated, there may be minor changes in the Makefile and markup required by
+the new versions. For example, updating from asciidoctor-pdf 1.6.1 to 2.2.0
+required changing the `pdf-stylesdir` attribute in the asciidoctor build to
+`pdf-themesdir`. Eventually, these changes may make using the older tools
+impractical. If this happens, update your tools to match the latest Docker
+image, and rebase your working branch on current `main` branch.
 
 
 ### Building Using GitLab CI

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2022 The Khronos Group, Inc.
+# Copyright 2011-2022 The Khronos Group, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,6 @@ RMRF      = rm -rf
 MKDIR     = mkdir -p
 CP        = cp
 ECHO      = echo
-GS_EXISTS = $(shell command -v gs 2> /dev/null)
 
 # Path to Python scripts used in generation
 SCRIPTS  = scripts
@@ -244,18 +243,13 @@ $(HTMLDIR)/diff.html: $(SPECSRC) $(COMMONDOCS) katexinst
 
 pdf: $(PDFDIR)/$(SPEC_BASE_NAME).pdf $(SPECSRC) $(COMMONDOCS)
 
+OPTIMIZEPDF = hexapdf optimize $(OPTIMIZEPDFOPTS)
 %.pdf: $(SPECSRC) $(COMMONDOCS)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCPDF) --trace $(ADOCOPTS) $(ADOCPDFOPTS) \
 	  --out-file $@ $(SPECSRC)
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $*-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out && mv $@.out $@
 	$(QUIET)rm -rf $(PDFMATHDIR)
 
 # Reflow text in spec sources

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -159,7 +159,7 @@ ADOCPDFEXTS  = --require asciidoctor-pdf --require asciidoctor-mathematical \
   --require $(CURDIR)/config/asciidoctor-mathematical-ext.rb
 ADOCPDFOPTS  = $(ADOCPDFEXTS) --attribute mathematical-format=svg \
   --attribute imagesoutdir=$(PDFMATHDIR) \
-  --attribute pdf-stylesdir=$(CURDIR)/config/themes \
+  --attribute pdf-themesdir=$(CURDIR)/config/themes \
   --attribute pdf-theme=pdf \
   --attribute hyphens=en_us
 

--- a/adoc/config/themes/pdf-theme.yml
+++ b/adoc/config/themes/pdf-theme.yml
@@ -1,39 +1,43 @@
 # http://gist.asciidoctor.org/?github-asciidoctor%2Fasciidoctor-pdf%2F%2Fdocs%2Ftheming-guide.adoc
 
-# Modified from asciidoctor-pdf 1.5.3 (gems/asciidoctor-pdf-1.5.3/data/themes/default-theme.yml)
-# by adding chapter names to the page footer and some custom roles
+# Modified from asciidoctor-pdf 2.2.0 (gems/asciidoctor-pdf-2.2.0/data/themes/default-theme.yml)
+# by adding chapter names to the page footer and some custom roles.
+# Khronos changes tagged with [KHR]
 
+# [KHR]
 # Number the pages starting at the title
 page-numbering-start-at: title
 # but only start the headers and footers on the next page, the table-of-content
 running-content-start-at: toc
+# [end KHR]
 
 font:
   catalog:
     # Noto Serif supports Latin, Latin-1 Supplement, Latin Extended-A, Greek, Cyrillic, Vietnamese & an assortment of symbols
     Noto Serif:
-      normal: notoserif-regular-subset.ttf
-      bold: notoserif-bold-subset.ttf
-      italic: notoserif-italic-subset.ttf
-      bold_italic: notoserif-bold_italic-subset.ttf
+      normal: GEM_FONTS_DIR/notoserif-regular-subset.ttf
+      bold: GEM_FONTS_DIR/notoserif-bold-subset.ttf
+      italic: GEM_FONTS_DIR/notoserif-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/notoserif-bold_italic-subset.ttf
     # M+ 1mn supports ASCII and the circled numbers used for conums
     M+ 1mn:
-      normal: mplus1mn-regular-subset.ttf
-      bold: mplus1mn-bold-subset.ttf
-      italic: mplus1mn-italic-subset.ttf
-      bold_italic: mplus1mn-bold_italic-subset.ttf
+      normal: GEM_FONTS_DIR/mplus1mn-regular-subset.ttf
+      bold: GEM_FONTS_DIR/mplus1mn-bold-subset.ttf
+      italic: GEM_FONTS_DIR/mplus1mn-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/mplus1mn-bold_italic-subset.ttf
 page:
   background_color: FFFFFF
   layout: portrait
-  # When opening the file, display all the page
+  # [KHR]
   initial_zoom: Fit
+  # [end KHR]
   margin: [0.5in, 0.67in, 0.67in, 0.67in]
   # margin_inner and margin_outer keys are used for recto/verso print margins when media=prepress
   margin_inner: 0.75in
   margin_outer: 0.59in
   size: A4
 base:
-  align: justify
+  text_align: justify
   # color as hex string (leading # is optional)
   font_color: 333333
   # color as RGB array
@@ -49,15 +53,12 @@ base:
   #line_height_length: 18
   #font_size: 11.2
   #line_height_length: 16
-  ##font_size: 10.5
-  # Do not forget to adapt accordingly line_height_length
-  font_size: 10
-  #line_height_length: 15
-  # correct line height for Noto Serif metrics
-  #line_height_length: 12
-  line_height_length: 10
   #font_size: 11.25
   #line_height_length: 18
+  # [KHR]
+  font_size: 10
+  line_height_length: 10
+  # [end KHR]
   line_height: $base_line_height_length / $base_font_size
   font_size_large: round($base_font_size * 1.25)
   font_size_small: round($base_font_size * 0.85)
@@ -67,6 +68,8 @@ base:
   border_radius: 4
   border_width: 0.5
 role:
+  lead:
+    font_size: $base_font_size_large
   line-through:
     text_decoration: line-through
   underline:
@@ -76,8 +79,10 @@ role:
   small:
     font_size: $base_font_size_small
   subtitle:
-    font_size: 0.8em
     font_color: 999999
+    font_size: 0.8em
+    font_style: normal_italic
+  # [KHR]
   # Asciidoctor custom [code] role
   code:
     font_size: 1em
@@ -96,38 +101,37 @@ role:
 #   border_color: CCCCCC
 #   border_radius: $base_border_radius
 #   border_width: 0.75
-
+  # [end KHR]
 # FIXME vertical_rhythm is weird; we should think in terms of ems
 #vertical_rhythm: $base_line_height_length * 2 / 3
 # correct line height for Noto Serif metrics (comes with built-in line height)
 vertical_rhythm: $base_line_height_length
 horizontal_rhythm: $base_line_height_length
-# QUESTION should vertical_spacing be block_spacing instead?
-vertical_spacing: $vertical_rhythm
 link:
   font_color: 428BCA
-# literal is currently used for inline monospaced in prose and table cells
-literal:
+# codespan is currently used for monospaced phrases and table cells
+codespan:
   font_color: B12146
   font_family: M+ 1mn
 button:
   content: "[\u2009%s\u2009]"
   font_style: bold
-key:
+kbd:
   background_color: F5F5F5
   border_color: CCCCCC
   border_offset: 2
   border_radius: 2
   border_width: 0.5
-  font_family: $literal_font_family
+  font_family: $codespan_font_family
   separator: "\u202f+\u202f"
 mark:
   background_color: FFFF00
   border_offset: 1
 menu:
-  caret_content: " <font size=\"1.15em\"><color rgb=\"b12146\">\u203a</color></font> "
+  caret_content: " <font size=\"1.15em\" color=\"#B12146\">\u203a</font> "
+  font_style: bold
 heading:
-  align: left
+  text_align: left
   font_color: $base_font_color
   font_style: bold
   # h1 is used for part titles (book doctype) or the doctitle (article doctype)
@@ -145,13 +149,13 @@ heading:
   margin_bottom: $vertical_rhythm * 0.9
   min_height_after: $base_line_height_length * 1.5
 title_page:
-  align: right
+  text_align: right
   logo:
     top: 10%
   title:
     top: 55%
     font_size: $heading_h1_font_size
-    font_color: 999999
+    font_color: $role_subtitle_font_color
     line_height: 0.9
   subtitle:
     font_size: $heading_h3_font_size
@@ -164,7 +168,6 @@ title_page:
   revision:
     margin_top: $base_font_size * 1.25
 block:
-  margin_top: 0
   margin_bottom: $vertical_rhythm
 caption:
   align: left
@@ -172,26 +175,22 @@ caption:
   font_style: italic
   # FIXME perhaps set line_height instead of / in addition to margins?
   margin_inside: $vertical_rhythm / 3
-  #margin_inside: $vertical_rhythm / 4
   margin_outside: 0
-lead:
-  font_size: $base_font_size_large
-  line_height: 1.4
 abstract:
   font_color: 5C6266
-  font_size: $lead_font_size
-  line_height: $lead_line_height
+  font_size: $role_lead_font_size
+  line_height: 1.4
   font_style: italic
   first_line_font_style: bold
   title:
-    align: center
+    text_align: center
     font_color: $heading_font_color
     font_size: $heading_h4_font_size
     font_style: $heading_font_style
 admonition:
   column_rule_color: $base_border_color
   column_rule_width: $base_border_width
-  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+  padding: [$vertical_rhythm / 3.0, $horizontal_rhythm, $vertical_rhythm / 3.0, $horizontal_rhythm]
   #icon:
   #  tip:
   #    name: far-lightbulb
@@ -200,27 +199,28 @@ admonition:
   label:
     text_transform: uppercase
     font_style: bold
-blockquote:
+quote:
   font_size: $base_font_size_large
   border_color: $base_border_color
   border_width: 0
-  border_left_width: 5
-  # FIXME disable negative padding bottom once margin collapsing is implemented
-  padding: [0, $horizontal_rhythm, $block_margin_bottom * -0.75, $horizontal_rhythm + $blockquote_border_left_width / 2]
-  cite_font_size: $base_font_size_small
-  cite_font_color: 999999
+  border_left_width: $horizontal_rhythm / 3
+  padding: [$vertical_rhythm / 4, $horizontal_rhythm, $vertical_rhythm / 4, $horizontal_rhythm + $quote_border_left_width / 2]
+  cite:
+    font_size: $base_font_size_small
+    font_color: $role_subtitle_font_color
 verse:
-  font_size: $blockquote_font_size
-  border_color: $blockquote_border_color
-  border_width: $blockquote_border_width
-  border_left_width: $blockquote_border_left_width
-  padding: $blockquote_padding
-  cite_font_size: $blockquote_cite_font_size
-  cite_font_color: $blockquote_cite_font_color
-# code is used for source blocks (perhaps change to source or listing?)
+  font_size: $quote_font_size
+  border_color: $quote_border_color
+  border_width: $quote_border_width
+  border_left_width: $quote_border_left_width
+  padding: $quote_padding
+  cite:
+    font_size: $quote_cite_font_size
+    font_color: $quote_cite_font_color
+# code is used for literal, listing, and source blocks and literal table cells
 code:
   font_color: $base_font_color
-  font_family: $literal_font_family
+  font_family: $codespan_font_family
   font_size: ceil($base_font_size)
   padding: $code_font_size
   line_height: 1.25
@@ -231,8 +231,8 @@ code:
   border_radius: $base_border_radius
   border_width: 0.75
 conum:
-  font_family: $literal_font_family
-  font_color: $literal_font_color
+  font_family: $codespan_font_family
+  font_color: $codespan_font_color
   font_size: $base_font_size
   line_height: 4 / 3
   glyphs: circled
@@ -241,22 +241,19 @@ example:
   border_radius: $base_border_radius
   border_width: 0.75
   background_color: $page_background_color
-  # FIXME reenable padding bottom once margin collapsing is implemented
-  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
+  padding: [$vertical_rhythm, $horizontal_rhythm, $vertical_rhythm, $horizontal_rhythm]
 image:
   align: left
 prose:
-  margin_top: $block_margin_top
   margin_bottom: $block_margin_bottom
 sidebar:
   background_color: EEEEEE
   border_color: E1E1E1
   border_radius: $base_border_radius
   border_width: $base_border_width
-  # FIXME reenable padding bottom once margin collapsing is implemented
-  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
+  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, $vertical_rhythm, $vertical_rhythm * 1.25]
   title:
-    align: center
+    text_align: center
     font_color: $heading_font_color
     font_size: $heading_h4_font_size
     font_style: $heading_font_style
@@ -264,21 +261,23 @@ thematic_break:
   border_color: $base_border_color
   border_style: solid
   border_width: $base_border_width
-  margin_top: $vertical_rhythm * 0.5
-  margin_bottom: $vertical_rhythm * 1.5
+  padding: [$vertical_rhythm * 0.5, 0]
+list:
+  indent: $horizontal_rhythm * 1.5
+  #marker_font_color: 404040
+  # NOTE list_item_spacing only applies to list items that do not have complex content
+  item_spacing: $vertical_rhythm / 2
 description_list:
   term_font_style: bold
   term_spacing: $vertical_rhythm / 4
   description_indent: $horizontal_rhythm * 1.25
-outline_list:
-  indent: $horizontal_rhythm * 1.5
-  #marker_font_color: 404040
-  # NOTE outline_list_item_spacing applies to list items that do not have complex content
-  item_spacing: $vertical_rhythm / 2
+callout_list:
+  margin_top_after_code: -$block_margin_bottom / 2
 table:
   background_color: $page_background_color
   border_color: DDDDDD
   border_width: $base_border_width
+  grid_width: $base_border_width
   cell_padding: 3
   head:
     font_style: bold
@@ -296,15 +295,17 @@ toc:
     #levels: 2 3
 footnotes:
   font_size: round($base_font_size * 0.75)
-  item_spacing: $outline_list_item_spacing / 2
-
+  item_spacing: $list_item_spacing / 2
+index:
+  column_gap: $vertical_rhythm
 header:
   font_size: $base_font_size_small
+  line_height: 1
+  vertical_align: middle
+  # [KHR]
   border_color: DDDDDD
   border_width: 0.25
   height: $base_line_height_length * 2.5
-  line_height: 1
-  vertical_align: middle
   # Put the spec name and the deep section title in the header
   sectlevels: 10
   recto:
@@ -317,7 +318,7 @@ header:
       content: '{section-title}'
     right:
       content: '{SYCL_NAME} {SYCL_VERSION} rev {SYCL_REVISION}'
-
+  # [end KHR]
 footer:
   font_size: $base_font_size_small
   # NOTE if background_color is set, background and border will span width of page
@@ -327,14 +328,14 @@ footer:
   line_height: 1
   padding: [$base_line_height_length / 2, 1, 0, 1]
   vertical_align: top
-  # Put the page number and the chapter title
   recto:
-    #columns: "<50% =0% >50%"
     right:
-      # content: '{page-number}'
+      # [KHR]
       content: '{chapter-title} | {page-number}'
+      # [end KHR]
   verso:
-    #columns: $footer_recto_columns
     left:
-      # content: $footer_recto_right_content
+      content: $footer_recto_right_content
+      # [KHR]
       content: '{page-number} | {chapter-title}'
+      # [end KHR]


### PR DESCRIPTION
Per
https://github.com/KhronosGroup/SYCL-Docs/pull/268#issuecomment-1198790889

A recent update to the asciidoctor-spec Docker image moved it from
asciidoctor-pdf 1.6.1 to 2.2.0, and deprecated the `pdf-stylesdir`
attribute, causing the PDF build to fail. This branch updates the
deprecated attribute and adds a note to the repository README. It also updates the custom PDF theme to match changes in the current asciidoctor-pdf default theme, and switches from 'optimize-pdf' to 'hexapdf' to reduce PDF output size. 'hexapdf' is found in the latest asciidoctor-spec Docker image.

I believe this fixes all the issues noted on !268. There is a small visual difference making the PDF spec about 5 pages shorter. I think this may be due to an updated table layout configuration that operates more compactly - hopefully it's not an issue as finding the root cause could take a while.