### PR TITLE
Small clarification to SYCL_EXTERNAL

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -853,6 +853,9 @@ When a function is declared with [code]#SYCL_EXTERNAL#, that function must also
 be defined in some translation unit, where the function is declared with
 [code]#SYCL_EXTERNAL#.
 
+A function may only be declared with [code]#SYCL_EXTERNAL# if it has external
+linkage by normal C++ rules.
+
 A function declared with [code]#SYCL_EXTERNAL# may be called from both host and
 device code.  The macro has no effect when the function is called from host
 code.


### PR DESCRIPTION
State that `SYCL_EXTERNAL` can only be applied to functions with
external linkage, which clarifies that it does not "override" the C++
linkage.