### PR TITLE
Fix specialization id example

### DIFF
--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -44,7 +44,7 @@ inline namespace other {
 int same_name; // ILLEGAL: shadows "specialization_id" variable with same name in
                // enclosing namespace scope
 }
-inline namespace {
+inline namespace other2 {
 namespace foo { // ILLEGAL: namespace name shadows "::foo" namespace which contains
                 // "specialization_id" variable.
 } // namespace foo

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -41,12 +41,11 @@ namespace {
 constexpr specialization_id<int> same_name { 12 }; // OK
 }
 inline namespace other {
-int same_name; // ILLEGAL: shadows "specialization_id"
-               // variable with same name in enclosing
-               // namespace scope
+int same_name; // ILLEGAL: shadows "specialization_id" variable with same name in
+               // enclosing namespace scope
 }
 inline namespace {
-namespace foo { // ILLEGAL: namespace name shadows "::foo"
+namespace foo { // ILLEGAL: namespace name shadows "::foo" namespace which contains
+                // "specialization_id" variable.
 } // namespace foo
-  // "specialization_id" variable.
 } // namespace


### PR DESCRIPTION
Some of the comments in this example got accidentally deleted when clang-format was run.  Add those comments back.

Also make a small tweak to the example to avoid a C++ syntax error, from this:

```
namespace { /*...*/ }

inline namespace {
}
```

to:

```
namespace { /*...*/ }

inline namespace other2 {
}
```