### PR TITLE
Add operator= for the 0-dimensional accessors

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6393,7 +6393,8 @@ class in the sections that follow.
 Accessors of type [code]#accessor#, [code]#host_accessor#, and
 [code]#local_accessor# can have zero, one, two, or three Dimensions.  A zero
 dimension accessor provides access to a single scalar element via an implicit
-conversion operator to the underlying type of that element.
+conversion operator to the underlying type of that element and via an overloaded
+assignment operator from the underlying type of the element.
 
 One, two, or three dimensional specializations of these accessors provide
 access to the elements they contain in two ways.  The first way is through a
@@ -8337,6 +8338,22 @@ For [code]#host_accessor# and [code]#local_accessor# available only when
 [code]#(Dimensions == 0)#.
 
 Returns a reference to the single element that is accessed by this accessor.
+
+For [code]#accessor# and [code]#local_accessor#, this function may only be
+called from within a <<command>>.
+
+a@
+[source]
+----
+reference operator=(const value_type &&other) const
+----
+   a@ For [code]#accessor# available only when
+      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
+
+For [code]#host_accessor# and [code]#local_accessor# available only when
+[code]#(Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6899,7 +6899,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-accessor &operator=(const value_type &other) const
+const accessor &operator=(const value_type &other) const
 ----
    a@ Available only when
       [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
@@ -6911,7 +6911,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-accessor &operator=(const value_type &&other) const
+const accessor &operator=(const value_type &&other) const
 ----
    a@ Available only when
       [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
@@ -7987,7 +7987,7 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
-host_accessor &operator=(const value_type &other) const
+const host_accessor &operator=(const value_type &other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -7996,7 +7996,7 @@ Assignment to the single element that is accessed by this accessor.
 a@
 [source]
 ----
-host_accessor &operator=(const value_type &&other) const
+const host_accessor &operator=(const value_type &&other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -8202,7 +8202,7 @@ This function may only be called from within a <<sycl-kernel-function>>.
 a@
 [source]
 ----
-local_accessor &operator=(const value_type &other) const
+const local_accessor &operator=(const value_type &other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -8213,7 +8213,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-local_accessor &operator=(const value_type &&other) const
+const local_accessor &operator=(const value_type &&other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6899,7 +6899,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-const accessor &operator=(const value_type &other) const
+const accessor& operator=(const value_type& other) const
 ----
    a@ Available only when
       [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
@@ -6911,7 +6911,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-const accessor &operator=(const value_type &&other) const
+const accessor& operator=(value_type&& other) const
 ----
    a@ Available only when
       [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
@@ -7996,7 +7996,7 @@ Assignment to the single element that is accessed by this accessor.
 a@
 [source]
 ----
-const host_accessor &operator=(const value_type &&other) const
+const host_accessor& operator=(value_type&& other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6394,7 +6394,7 @@ Accessors of type [code]#accessor#, [code]#host_accessor#, and
 [code]#local_accessor# can have zero, one, two, or three Dimensions.  A zero
 dimension accessor provides access to a single scalar element via an implicit
 conversion operator to the underlying type of that element and via an overloaded
-assignment operator from the underlying type of the element.
+copy/move assignment operators from the underlying type of the element.
 
 One, two, or three dimensional specializations of these accessors provide
 access to the elements they contain in two ways.  The first way is through a
@@ -6893,6 +6893,30 @@ accessor_ptr<IsDecorated> get_multi_ptr() const noexcept
       buffer, even if this is a <<ranged-accessor>> whose range does not start
       at the beginning of the buffer.  The return value is unspecified if the
       accessor is empty.
+
+This function may only be called from within a <<command>>.
+
+a@
+[source]
+----
+accessor &operator=(const value_type &other) const
+----
+   a@ Available only when
+      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
+
+This function may only be called from within a <<command>>.
+
+a@
+[source]
+----
+accessor &operator=(const value_type &&other) const
+----
+   a@ Available only when
+      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
 
 This function may only be called from within a <<command>>.
 
@@ -7960,6 +7984,24 @@ If this is a <<ranged-accessor>>, returns the offset that was specified when the
 accessor was constructed.  For other accessors, returns the default constructed
 [code]#id<Dimensions>{}#.
 
+a@
+[source]
+----
+host_accessor &operator=(const value_type &other) const
+----
+   a@ Available only when [code]#(Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
+
+a@
+[source]
+----
+host_accessor &operator=(const value_type &&other) const
+----
+   a@ Available only when [code]#(Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
+
 |====
 
 
@@ -8157,6 +8199,28 @@ accessor_ptr<IsDecorated> get_multi_ptr() const noexcept
 
 This function may only be called from within a <<sycl-kernel-function>>.
 
+a@
+[source]
+----
+local_accessor &operator=(const value_type &other) const
+----
+   a@ Available only when [code]#(Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
+
+This function may only be called from within a <<command>>.
+
+a@
+[source]
+----
+local_accessor &operator=(const value_type &&other) const
+----
+   a@ Available only when [code]#(Dimensions == 0)#.
+
+Assignment to the single element that is accessed by this accessor.
+
+This function may only be called from within a <<command>>.
+
 |====
 
 
@@ -8338,22 +8402,6 @@ For [code]#host_accessor# and [code]#local_accessor# available only when
 [code]#(Dimensions == 0)#.
 
 Returns a reference to the single element that is accessed by this accessor.
-
-For [code]#accessor# and [code]#local_accessor#, this function may only be
-called from within a <<command>>.
-
-a@
-[source]
-----
-reference operator=(const value_type &&other) const
-----
-   a@ For [code]#accessor# available only when
-      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
-
-For [code]#host_accessor# and [code]#local_accessor# available only when
-[code]#(Dimensions == 0)#.
-
-Assignment to the single element that is accessed by this accessor.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -7987,7 +7987,7 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
-const host_accessor &operator=(const value_type &other) const
+const host_accessor& operator=(const value_type& other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -8202,7 +8202,7 @@ This function may only be called from within a <<sycl-kernel-function>>.
 a@
 [source]
 ----
-const local_accessor &operator=(const value_type &other) const
+const local_accessor& operator=(const value_type& other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 
@@ -8213,7 +8213,7 @@ This function may only be called from within a <<command>>.
 a@
 [source]
 ----
-const local_accessor &operator=(const value_type &&other) const
+const local_accessor& operator=(const value_type&& other) const
 ----
    a@ Available only when [code]#(Dimensions == 0)#.
 

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -153,8 +153,11 @@ class accessor {
   /* Available only when: (Dimensions > 0) */
   id<Dimensions> get_offset() const;
 
-  /* Available only when: (Dimensions == 0) */
+  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
   operator reference() const;
+
+  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
+  reference operator=(const value_type &&other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -157,10 +157,10 @@ class accessor {
   operator reference() const;
 
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
-  accessor &operator=(const value_type &other) const;
+  const accessor &operator=(const value_type &other) const;
 
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
-  accessor &operator=(const value_type &&other) const;
+  const accessor &operator=(const value_type &&other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -157,10 +157,10 @@ class accessor {
   operator reference() const;
 
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
-  const accessor &operator=(const value_type &other) const;
+  const accessor& operator=(const value_type& other) const;
 
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
-  const accessor &operator=(const value_type &&other) const;
+  const accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -157,7 +157,10 @@ class accessor {
   operator reference() const;
 
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
-  reference operator=(const value_type &&other) const;
+  accessor &operator=(const value_type &other) const;
+
+  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
+  accessor &operator=(const value_type &&other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -83,7 +83,10 @@ class host_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  reference operator=(const value_type &&other) const;
+  host_accessor &operator=(const value_type &other) const;
+
+  /* Available only when: (Dimensions == 0) */
+  host_accessor &operator=(const value_type &&other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -83,10 +83,10 @@ class host_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  host_accessor &operator=(const value_type &other) const;
+  const host_accessor &operator=(const value_type &other) const;
 
   /* Available only when: (Dimensions == 0) */
-  host_accessor &operator=(const value_type &&other) const;
+  const host_accessor &operator=(const value_type &&other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -82,6 +82,9 @@ class host_accessor {
   /* Available only when: (Dimensions == 0) */
   operator reference() const;
 
+  /* Available only when: (Dimensions == 0) */
+  reference operator=(const value_type &&other) const;
+
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;
 

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -83,10 +83,10 @@ class host_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  const host_accessor &operator=(const value_type &other) const;
+  const host_accessor& operator=(const value_type& other) const;
 
   /* Available only when: (Dimensions == 0) */
-  const host_accessor &operator=(const value_type &&other) const;
+  const host_accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -48,10 +48,10 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  const local_accessor &operator=(const value_type &Other) const;
+  const local_accessor& operator=(const value_type& other) const;
 
   /* Available only when: (Dimensions == 0) */
-  const local_accessor &operator=(const value_type &&Other) const;
+  const local_accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -48,10 +48,10 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  local_accessor &operator=(const value_type &Other) const;
+  const local_accessor &operator=(const value_type &Other) const;
 
   /* Available only when: (Dimensions == 0) */
-  local_accessor &operator=(const value_type &&Other) const;
+  const local_accessor &operator=(const value_type &&Other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -47,6 +47,9 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   /* Available only when: (Dimensions == 0) */
   operator reference() const;
 
+  /* Available only when: (Dimensions == 0) */
+  reference operator=(const value_type &&Other) const;
+
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;
 

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -48,7 +48,10 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   operator reference() const;
 
   /* Available only when: (Dimensions == 0) */
-  reference operator=(const value_type &&Other) const;
+  local_accessor &operator=(const value_type &Other) const;
+
+  /* Available only when: (Dimensions == 0) */
+  local_accessor &operator=(const value_type &&Other) const;
 
   /* Available only when: (Dimensions > 0) */
   reference operator[](id<Dimensions> index) const;


### PR DESCRIPTION
That enables uses like this:

```
  q.submit([&](sycl::handler &cgh) {
    sycl::local_accessor<int, 0> A{cgh};
    cgh.single_task<class Kernel>([=] { A = 42; });
  });
```

This PR also fixes incosistency in the description of "operator
reference" for buffer accessor - it is only available for non-atomic
access-mode as mentioned in some places but not in its synopsis.