### PR TITLE
Fix definitions of sycl::minimum and sycl::maximum

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19832,8 +19832,7 @@ a@
 ----
 T operator()(const T& x, const T& y) const
 ----
-   a@ Applies [code]#std::less# to its arguments, in the same order, then
-      returns the lesser argument unchanged.
+   a@ Returns [code]#y# if [code]#y < x# and #x# otherwise.
 
 |====
 
@@ -19847,8 +19846,7 @@ a@
 ----
 T operator()(const T& x, const T& y) const
 ----
-   a@ Applies [code]#std::greater# to its arguments, in the same order, then
-      returns the greater argument unchanged.
+   a@ Returns [code]#y# if [code]#x < y# and #x# otherwise.
 
 |====
 


### PR DESCRIPTION
The original definitions of sycl::minimum and sycl::maximum used std::lesser and std::greater, respectively.

These definitions unintentionally introduce differences from ISO C++:
- std::max() is defined in terms of operator <
- std::max_element() is defined in terms of operator <
- sycl::maximum requires users to define an additional operator (>)

This commit redefines both sycl::minimum and sycl::maximum in terms of operator <, to align with ISO C++ as intended.

Partially addresses internal issue 538.