### PR TITLE
Fix buffer reinterpret for buffer_allocator with const

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4795,7 +4795,7 @@ a@
 template <typename ReinterpretT, int ReinterpretDim>
     buffer<ReinterpretT, ReinterpretDim,
            typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-             ReinterpretT>>
+             std::remove_const_t<ReinterpretT>>>
     reinterpret(range<ReinterpretDim> reinterpretRange) const
 ----
    a@ Creates and returns a reinterpreted SYCL [code]#buffer#
@@ -4821,7 +4821,7 @@ a@
 template <typename ReinterpretT, int ReinterpretDim = Dimensions>
     buffer<ReinterpretT, ReinterpretDim,
            typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-             ReinterpretT>>
+             std::remove_const_t<ReinterpretT>>>
     reinterpret() const
 ----
    a@ Creates and returns a reinterpreted SYCL [code]#buffer#


### PR DESCRIPTION
This PR fixes a mistake in the buffer reinterpret member function. Currently if the user reinterprets the buffer from type `T` to type `const T` then the buffer_allocator is updated to type `const T` this disagrees with the `buffer_allocators` description which states, "A buffer of data type const T uses buffer_allocator<T> by default". 
I am proposing that the buffer reinterpret function removes the `const` keyword for the `buffer_allocator` to keep it consistent with the classes description and the buffers definition which also removes any `const` keyword for the `buffer_allocator`.