### PR TITLE
Add access::decorated::no to multi_ptr deduction guides

### DIFF
--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -331,10 +331,10 @@ multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
           class T>
 multi_ptr(accessor<T, Dimensions, Mode, target::device, IsPlaceholder>)
-    -> multi_ptr<T, access::address_space::global_space>;
+    -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
 template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
           class T>
 multi_ptr(local_accessor<T, Dimensions>)
-    -> multi_ptr<T, access::address_space::local_space>;
+    -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
 
 } // namespace sycl


### PR DESCRIPTION
In the current version of the SYCL 2020 specification the deduction guides for `multi_ptr` are missing the `access::decorated` template argument in the deduced type. This commit adds `access::decorated::no` to the deduced types.