### PR TITLE
Clarify buffer creation with nullptr

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4241,6 +4241,11 @@ merely allocate uninitialized memory, and the application is responsible for
 constructing objects by calling placement-new and for destroying them later
 by manually calling the object's destructor.
 
+For the overloads that do copy objects from host memory, the [code]#hostData#
+pointer must point to _N_ bytes of memory where _N_ is
+[code]#sizeof(T) * bufferRange.size()#.  If _N_ is zero, [code]#hostData# is
+permitted to be [code]#nullptr# or an empty [code]#std::shared_ptr#.
+
 A SYCL [code]#buffer# can construct an instance of a SYCL [code]#buffer#
 that reinterprets the original SYCL [code]#buffer# with a different
 type, dimensionality and range using the member function
@@ -6052,10 +6057,6 @@ constructor, then the buffer object and the developer's application share
 the memory region. If the shared pointer is still used on the application's
 side then the data will be copied back from the buffer or image and will be
 available to the application after the buffer or image is destroyed.
-
-If the [code]#shared_ptr# is not empty, the contents of the referenced
-memory are used to initialize the buffer.  If the [code]#shared_ptr# is
-empty, then the buffer is created with uninitialized memory.
 
 When the buffer is destroyed and the data have potentially been updated, if
 the number of copies of the shared pointer outside the runtime is 0, there

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4242,7 +4242,7 @@ constructing objects by calling placement-new and for destroying them later
 by manually calling the object's destructor.
 
 For the overloads that do copy objects from host memory, the [code]#hostData#
-pointer must point to _N_ bytes of memory where _N_ is
+pointer must point to at least _N_ bytes of memory where _N_ is
 [code]#sizeof(T) * bufferRange.size()#.  If _N_ is zero, [code]#hostData# is
 permitted to be [code]#nullptr# or an empty [code]#std::shared_ptr#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4191,7 +4191,7 @@ by manually calling the object's destructor.
 For the overloads that do copy objects from host memory, the [code]#hostData#
 pointer must point to at least _N_ bytes of memory where _N_ is
 [code]#sizeof(T) * bufferRange.size()#.  If _N_ is zero, [code]#hostData# is
-permitted to be [code]#nullptr# or an empty [code]#std::shared_ptr#.
+permitted to be a null pointer.
 
 A SYCL [code]#buffer# can construct an instance of a SYCL [code]#buffer#
 that reinterprets the original SYCL [code]#buffer# with a different
@@ -4254,7 +4254,8 @@ include::{header_dir}/buffer.h[lines=4..-1]
 a@
 [source]
 ----
-buffer(const range<Dimensions>& bufferRange, const property_list& propList = {})
+buffer(const range<Dimensions>& bufferRange,
+       const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
       The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
@@ -4265,7 +4266,8 @@ buffer(const range<Dimensions>& bufferRange, const property_list& propList = {})
 a@
 [source]
 ----
-buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
+buffer(const range<Dimensions>& bufferRange,
+       AllocatorT allocator,
        const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
@@ -4280,36 +4282,43 @@ a@
 buffer(T* hostData, const range<Dimensions>& bufferRange,
        const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided.
-      The buffer is initialized with the memory specified by [code]#hostData#.
-      The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
+      parameter provided.  The buffer is initialized with the memory specified
+      by [code]#hostData#, and the buffer assumes exclusive access to this
+      memory for the duration of its lifetime.  The constructed SYCL
+      [code]#buffer# will use a default constructed [code]#AllocatorT# when
+      allocating memory on the host.  The range of the constructed SYCL
+      [code]#buffer# is specified by the [code]#bufferRange# parameter
+      provided.  Zero or more properties can be provided to the constructed
+      SYCL [code]#buffer# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-buffer(T* hostData, const range<Dimensions>& bufferRange, AllocatorT allocator,
+buffer(T* hostData, const range<Dimensions>& bufferRange,
+       AllocatorT allocator,
        const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided.
-      The buffer is initialized with the memory specified by [code]#hostData#.
-      The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
+      parameter provided.  The buffer is initialized with the memory specified
+      by [code]#hostData#, and the buffer assumes exclusive access to this
+      memory for the duration of its lifetime.  The constructed SYCL
+      [code]#buffer# will use the [code]#allocator# parameter provided when
+      allocating memory on the host.  The range of the constructed SYCL
+      [code]#buffer# is specified by the [code]#bufferRange# parameter
+      provided.  Zero or more properties can be provided to the constructed
+      SYCL [code]#buffer# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-buffer(const T* hostData, const range<Dimensions>& bufferRange,
+buffer(const T* hostData,
+       const range<Dimensions>& bufferRange,
        const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the
-      [code]#hostData# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#buffer# for
-      the duration of its lifetime.
+   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
+      parameter provided.  The buffer assumes exclusive access to this memory
+      for the duration of its lifetime.
 
 The constructed SYCL [code]#buffer# will use a default
 constructed [code]#AllocatorT# when allocating memory on
@@ -4335,13 +4344,14 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-buffer(const T* hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator, const property_list& propList = {})
+buffer(const T* hostData,
+       const range<Dimensions>& bufferRange,
+       AllocatorT allocator,
+       const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the
-      [code]#hostData# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#buffer# for
-      the duration of its lifetime.
+   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
+      parameter provided.  The buffer assumes exclusive access to this
+      memory for the duration of its lifetime.
 
 The constructed SYCL [code]#buffer# will use the
 [code]#allocator# parameter provided when allocating
@@ -4369,14 +4379,14 @@ a@
 [source]
 ----
 template <typename Container>
-buffer(Container& container, const property_list& propList = {})
+buffer(Container& container,
+       const property_list& propList = {})
 ----
    a@ Construct a one dimensional SYCL [code]#buffer# instance
       from the elements starting at [code]#std::data(container)#
       and containing [code]#std::size(container)# number of elements.
       The buffer is initialized with the contents of [code]#container#,
-      and the ownership of this [code]#Container# is given to the
-      constructed SYCL [code]#buffer# for
+      and the buffer assumes exclusive access to [code]#container# for
       the duration of its lifetime.
 
 Data is written back to [code]#container# before the completion of
@@ -4405,8 +4415,7 @@ buffer(Container& container, AllocatorT allocator,
       from the elements starting at [code]#std::data(container)#
       and containing [code]#std::size(container)# number of elements.
       The buffer is initialized with the contents of [code]#container#,
-      and the ownership of this [code]#Container# is given to the
-      constructed SYCL [code]#buffer# for
+      and the buffer assumes exclusive access to [code]#container# for
       the duration of its lifetime.
 
 Data is written back to [code]#container# before the completion of
@@ -4427,49 +4436,100 @@ is convertible to [code]#T*#.
 a@
 [source]
 ----
-buffer(const std::shared_ptr<T>& hostData, const range<Dimensions>& bufferRange,
+buffer(const std::shared_ptr<T>& hostData,
+       const range<Dimensions>& bufferRange,
        const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
+      contents of its stored pointer.  The buffer assumes exclusive access to
+      this memory for the duration of its lifetime.  The buffer also creates
+      its own internal copy of the [code]#shared_ptr# that shares ownership of
+      the [code]#hostData# memory, which means the application can safely
+      release ownership of this [code]#shared_ptr# when the constructor
+      returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use a default constructed
+[code]#AllocatorT# when allocating memory on the host.  The range of the
+constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
+parameter provided.  Zero or more properties can be provided to the
+constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-buffer(const std::shared_ptr<T>& hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator, const property_list& propList = {})
+buffer(const std::shared_ptr<T>& hostData,
+       const range<Dimensions>& bufferRange,
+       AllocatorT allocator,
+       const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
+      contents of its stored pointer.  The buffer assumes exclusive access to
+      this memory for the duration of its lifetime.  The buffer also creates
+      its own internal copy of the [code]#shared_ptr# that shares ownership of
+      the [code]#hostData# memory, which means the application can safely
+      release ownership of this [code]#shared_ptr# when the constructor
+      returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.  The range of the constructed SYCL
+[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 
 a@
 [source,c++]
 ----
 buffer(const std::shared_ptr<T[]>& hostData,
-const range<Dimensions>&  bufferRange,
-    const property_list& propList = {})
+       const range<Dimensions>&  bufferRange,
+       const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
+      contents of its stored pointer.  The buffer assumes exclusive access to
+      this memory for the duration of its lifetime.  The buffer also creates
+      its own internal copy of the [code]#shared_ptr# that shares ownership of
+      the [code]#hostData# memory, which means the application can safely
+      release ownership of this [code]#shared_ptr# when the constructor
+      returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use a default constructed
+[code]#AllocatorT# when allocating memory on the host.  The range of the
+constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
+parameter provided.  Zero or more properties can be provided to the
+constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
 
 a@
 [source,c++]
 ----
 buffer(const std::shared_ptr<T[]>& hostData,
-const range<Dimensions>& bufferRange,
-    AllocatorT allocator,
-    const property_list& propList = {})
+       const range<Dimensions>& bufferRange,
+       AllocatorT allocator,
+       const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData# parameter provided. The ownership of this memory is given to the constructed SYCL [code]#buffer# for the duration of its lifetime.
-      The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
+      contents of its stored pointer.  The buffer assumes exclusive access to
+      this memory for the duration of its lifetime.  The buffer also creates
+      its own internal copy of the [code]#shared_ptr# that shares ownership of
+      the [code]#hostData# memory, which means the application can safely
+      release ownership of this [code]#shared_ptr# when the constructor
+      returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.  The range of the constructed SYCL
+[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 
 a@
 [source]
@@ -4489,7 +4549,8 @@ a@
 [source]
 ----
 template <typename InputIterator>
-buffer(InputIterator first, InputIterator last, AllocatorT allocator = {},
+buffer(InputIterator first, InputIterator last,
+       AllocatorT allocator = {},
        const property_list& propList = {})
 ----
    a@ Create a new allocated 1D buffer initialized from the given elements
@@ -5090,7 +5151,8 @@ include::{header_dir}/unsampledImage.h[lines=4..-1]
 a@
 [source]
 ----
-unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+unsampled_image(image_format format,
+                const range<Dimensions>& rangeRef,
                 const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with
@@ -5114,8 +5176,10 @@ unsampled_image(image_format format, const range<Dimensions>& rangeRef,
 a@
 [source]
 ----
-unsampled_image(image_format format, const range<Dimensions>& rangeRef,
-                AllocatorT allocator, const property_list& propList = {})
+unsampled_image(image_format format,
+                const range<Dimensions>& rangeRef,
+                AllocatorT allocator,
+                const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with
       uninitialized memory.
@@ -5138,7 +5202,8 @@ unsampled_image(image_format format, const range<Dimensions>& rangeRef,
 a@
 [source]
 ----
-unsampled_image(image_format format, const range<Dimensions>& rangeRef,
+unsampled_image(image_format format,
+                const range<Dimensions>& rangeRef,
                 const range<Dimensions - 1>& pitch,
                 const property_list& propList = {})
 ----
@@ -5165,8 +5230,10 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-unsampled_image(image_format format, const range<Dimensions>& rangeRef,
-                const range<Dimensions - 1>& pitch, AllocatorT allocator,
+unsampled_image(image_format format,
+                const range<Dimensions>& rangeRef,
+                const range<Dimensions - 1>& pitch,
+                AllocatorT allocator,
                 const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
@@ -5197,9 +5264,8 @@ unsampled_image(void* hostPointer, image_format format,
                 const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
+      [code]#hostPointer# parameter provided.  The [code]#unsampled_image#
+      assumes exclusive access to this memory for the duration of its lifetime.
       The constructed SYCL [code]#unsampled_image# will use a default
       constructed [code]#AllocatorT# when allocating memory on the
       host.
@@ -5220,13 +5286,13 @@ a@
 [source]
 ----
 unsampled_image(void* hostPointer, image_format format,
-                const range<Dimensions>& rangeRef, AllocatorT allocator,
+                const range<Dimensions>& rangeRef,
+                AllocatorT allocator,
                 const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
+      [code]#hostPointer# parameter provided.  The [code]#unsampled_image#
+      assumes exclusive access to this memory for the duration of its lifetime.
       The constructed SYCL [code]#unsampled_image# will use the
       [code]#allocator# parameter provided when allocating memory on
       the host.
@@ -5253,9 +5319,8 @@ unsampled_image(void* hostPointer, image_format format,
    a@ Available only when: [code]#Dimensions > 1#
 
 Construct a SYCL [code]#unsampled_image# instance with the
-[code]#hostPointer# parameter provided. The ownership of this
-memory is given to the constructed SYCL [code]#unsampled_image#
-for the duration of its lifetime.
+[code]#hostPointer# parameter provided.  The [code]#unsampled_image# assumes
+exclusive access to this memory for the duration of its lifetime.
 The constructed SYCL [code]#unsampled_image# will use a default
 constructed [code]#AllocatorT# when allocating memory on the
 host.
@@ -5277,15 +5342,15 @@ a@
 ----
 unsampled_image(void* hostPointer, image_format format,
                 const range<Dimensions>& rangeRef,
-                const range<Dimensions - 1>& pitch, AllocatorT allocator,
+                const range<Dimensions - 1>& pitch,
+                AllocatorT allocator,
                 const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
 Construct a SYCL [code]#unsampled_image# instance with the
-[code]#hostPointer# parameter provided. The ownership of this
-memory is given to the constructed SYCL [code]#unsampled_image#
-for the duration of its lifetime.
+[code]#hostPointer# parameter provided. The [code]#unsampled_image# assumes
+exclusive access to this memory for the duration of its lifetime.
 The constructed SYCL [code]#unsampled_image# will use the
 [code]#allocator# parameter provided when allocating memory on
 the host.
@@ -5304,108 +5369,142 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+unsampled_image(std::shared_ptr<void>& hostPointer,
+                image_format format,
                 const range<Dimensions>& rangeRef,
                 const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
-      The constructed SYCL [code]#unsampled_image# will use a default
-      constructed [code]#AllocatorT# when allocating memory on the
-      host.
-      The element size of the constructed SYCL [code]#unsampled_image#
-      will be derived from the [code]#format# parameter.
-      The range of the constructed SYCL [code]#unsampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#unsampled_image# will be
-      the default size determined by the <<sycl-runtime>>.
-      Unless the member function [code]#set_final_data()# is called
-      with a valid non-null pointer, any memory allocated by the
-      <<sycl-runtime>> is written back to [code]#hostPointer#.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#unsampled_image# via an instance of [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#unsampled_image# with the contents of its stored pointer.  The
+      [code]#unsampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#unsampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#unsampled_image#
+with uninitialized memory.
+
+The constructed SYCL [code]#unsampled_image# will use a default
+constructed [code]#AllocatorT# when allocating memory on the
+host.
+The element size of the constructed SYCL [code]#unsampled_image#
+will be derived from the [code]#format# parameter.
+The range of the constructed SYCL [code]#unsampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#unsampled_image# will be
+the default size determined by the <<sycl-runtime>>.
+Unless the member function [code]#set_final_data()# is called
+with a valid non-null pointer, any memory allocated by the
+<<sycl-runtime>> is written back to [code]#hostPointer#.
+Zero or more properties can be provided to the constructed SYCL
+[code]#unsampled_image# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
-                const range<Dimensions>& rangeRef, AllocatorT allocator,
+unsampled_image(std::shared_ptr<void>& hostPointer,
+                image_format format,
+                const range<Dimensions>& rangeRef,
+                AllocatorT allocator,
                 const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
-      The constructed SYCL [code]#unsampled_image# will use the
-      [code]#allocator# parameter provided when allocating memory on
-      the host.
-      The element size of the constructed SYCL [code]#unsampled_image#
-      will be derived from the [code]#format# parameter.
-      The range of the constructed SYCL [code]#unsampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#unsampled_image# will be
-      the default size determined by the <<sycl-runtime>>.
-      Unless the member function [code]#set_final_data()# is called
-      with a valid non-null pointer, any memory allocated by the
-      <<sycl-runtime>> is written back to [code]#hostPointer#.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#unsampled_image# via an instance of [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#unsampled_image# with the contents of its stored pointer.  The
+      [code]#unsampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#unsampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#unsampled_image#
+with uninitialized memory.
+
+The constructed SYCL [code]#unsampled_image# will use the
+[code]#allocator# parameter provided when allocating memory on
+the host.
+The element size of the constructed SYCL [code]#unsampled_image#
+will be derived from the [code]#format# parameter.
+The range of the constructed SYCL [code]#unsampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#unsampled_image# will be
+the default size determined by the <<sycl-runtime>>.
+Unless the member function [code]#set_final_data()# is called
+with a valid non-null pointer, any memory allocated by the
+<<sycl-runtime>> is written back to [code]#hostPointer#.
+Zero or more properties can be provided to the constructed SYCL
+[code]#unsampled_image# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+unsampled_image(std::shared_ptr<void>& hostPointer,
+                image_format format,
                 const range<Dimensions>& rangeRef,
                 const range<Dimensions - 1>& pitch,
                 const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
-      The constructed SYCL [code]#unsampled_image# will use a default
-      constructed [code]#AllocatorT# when allocating memory on the
-      host.
-      The element size of the constructed SYCL [code]#unsampled_image#
-      will be derived from the [code]#format# parameter.
-      The range of the constructed SYCL [code]#unsampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#unsampled_image# will be
-      the [code]#pitch# parameter provided.
-      Unless the member function [code]#set_final_data()# is called
-      with a valid non-null pointer, any memory allocated by the
-      <<sycl-runtime>> is written back to [code]#hostPointer#.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#unsampled_image# via an instance of [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#unsampled_image# with the contents of its stored pointer.  The
+      [code]#unsampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#unsampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#unsampled_image#
+with uninitialized memory.
+
+The constructed SYCL [code]#unsampled_image# will use a default
+constructed [code]#AllocatorT# when allocating memory on the
+host.
+The element size of the constructed SYCL [code]#unsampled_image#
+will be derived from the [code]#format# parameter.
+The range of the constructed SYCL [code]#unsampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#unsampled_image# will be
+the [code]#pitch# parameter provided.
+Unless the member function [code]#set_final_data()# is called
+with a valid non-null pointer, any memory allocated by the
+<<sycl-runtime>> is written back to [code]#hostPointer#.
+Zero or more properties can be provided to the constructed SYCL
+[code]#unsampled_image# via an instance of [code]#property_list#.
 
 a@
 [source]
 ----
-unsampled_image(std::shared_ptr<void>& hostPointer, image_format format,
+unsampled_image(std::shared_ptr<void>& hostPointer,
+                image_format format,
                 const range<Dimensions>& rangeRef,
-                const range<Dimensions - 1>& pitch, AllocatorT allocator,
+                const range<Dimensions - 1>& pitch,
+                AllocatorT allocator,
                 const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#unsampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#unsampled_image#
-      for the duration of its lifetime.
-      The constructed SYCL [code]#unsampled_image# will use the
-      [code]#allocator# parameter provided when allocating memory on
-      the host.
-      The element size of the constructed SYCL [code]#unsampled_image#
-      will be derived from the [code]#format# parameter.
-      The range of the constructed SYCL [code]#unsampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#unsampled_image# will be
-      the [code]#pitch# parameter provided.
-      Unless the member function [code]#set_final_data()# is called
-      with a valid non-null pointer, any memory allocated by the
-      <<sycl-runtime>> is written back to [code]#hostPointer#.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#unsampled_image# via an instance of [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#unsampled_image# with the contents of its stored pointer.  The
+      [code]#unsampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#unsampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#unsampled_image#
+with uninitialized memory.
+
+The constructed SYCL [code]#unsampled_image# will use the
+[code]#allocator# parameter provided when allocating memory on
+the host.
+The element size of the constructed SYCL [code]#unsampled_image#
+will be derived from the [code]#format# parameter.
+The range of the constructed SYCL [code]#unsampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#unsampled_image# will be
+the [code]#pitch# parameter provided.
+Unless the member function [code]#set_final_data()# is called
+with a valid non-null pointer, any memory allocated by the
+<<sycl-runtime>> is written back to [code]#hostPointer#.
+Zero or more properties can be provided to the constructed SYCL
+[code]#unsampled_image# via an instance of [code]#property_list#.
 
 |====
 
@@ -5558,13 +5657,13 @@ a@
 [source]
 ----
 sampled_image(const void* hostPointer, image_format format,
-              image_sampler sampler, const range<Dimensions>& rangeRef,
+              image_sampler sampler,
+              const range<Dimensions>& rangeRef,
               const property_list& propList = {})
 ----
    a@ Construct a SYCL [code]#sampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#sampled_image# for
-      the duration of its lifetime.
+      [code]#hostPointer# parameter provided.  The [code]#sampled_image#
+      assumes exclusive access to this memory for the duration of its lifetime.
       The host address is [code]#const#, so the host accesses must be
       read-only. Since, the [code]#hostPointer# is [code]#const#, this image is only
       initialized with this memory and there is no write after its
@@ -5585,16 +5684,16 @@ a@
 [source]
 ----
 sampled_image(const void* hostPointer, image_format format,
-              image_sampler sampler, const range<Dimensions>& rangeRef,
+              image_sampler sampler,
+              const range<Dimensions>& rangeRef,
               const range<Dimensions - 1>& pitch,
               const property_list& propList = {})
 ----
    a@ Available only when: [code]#Dimensions > 1#.
 
-Construct a SYCL [code]#sampled_image# instance with the
-[code]#hostPointer# parameter provided. The ownership of this
-memory is given to the constructed SYCL [code]#sampled_image# for
-the duration of its lifetime.
+Construct a SYCL [code]#sampled_image# instance with the [code]#hostPointer#
+parameter provided.  The [code]#sampled_image# assumes exclusive access to this
+memory for the duration of its lifetime.
 The host address is [code]#const#, so the host accesses must be
 read-only. Since, the [code]#hostPointer# is [code]#const#, this
 image is only initialized with this memory and there is no write after
@@ -5614,57 +5713,75 @@ Zero or more properties can be provided to the constructed SYCL
 a@
 [source]
 ----
-sampled_image(std::shared_ptr<const void>& hostPointer, image_format format,
-              image_sampler sampler, const range<Dimensions>& rangeRef,
+sampled_image(std::shared_ptr<const void>& hostPointer,
+              image_format format,
+              image_sampler sampler,
+              const range<Dimensions>& rangeRef,
               const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#sampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#sampled_image# for
-      the duration of its lifetime.
-      The host address is [code]#const#, so the host accesses must be
-      read-only. Since, the [code]#hostPointer# is [code]#const#, this image is only
-      initialized with this memory and there is no write after its
-      destruction.
-      The element size of the constructed SYCL [code]#sampled_image#
-      will be derived from the [code]#format# parameter.
-      Accessors that read the constructed SYCL [code]#sampled_image# will
-      use the [code]#sampler# parameter to sample the image.
-      The range of the constructed SYCL [code]#sampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#sampled_image# will be
-      the default size determined by the <<sycl-runtime>>.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#sampled_image# via an instance of
-      [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#sampled_image# with the contents of its stored pointer.  The
+      [code]#sampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#sampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#sampled_image#
+with uninitialized memory.
+
+The host address is [code]#const#, so the host accesses must be
+read-only. Since, the [code]#hostPointer# is [code]#const#, this image is only
+initialized with this memory and there is no write after its
+destruction.
+The element size of the constructed SYCL [code]#sampled_image#
+will be derived from the [code]#format# parameter.
+Accessors that read the constructed SYCL [code]#sampled_image# will
+use the [code]#sampler# parameter to sample the image.
+The range of the constructed SYCL [code]#sampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#sampled_image# will be
+the default size determined by the <<sycl-runtime>>.
+Zero or more properties can be provided to the constructed SYCL
+[code]#sampled_image# via an instance of
+[code]#property_list#.
 
 a@
 [source]
 ----
-sampled_image(std::shared_ptr<const void>& hostPointer, image_format format,
-              image_sampler sampler, const range<Dimensions>& rangeRef,
+sampled_image(std::shared_ptr<const void>& hostPointer,
+              image_format format,
+              image_sampler sampler,
+              const range<Dimensions>& rangeRef,
               const range<Dimensions - 1>& pitch,
               const property_list& propList = {})
 ----
-   a@ Construct a SYCL [code]#sampled_image# instance with the
-      [code]#hostPointer# parameter provided. The ownership of this
-      memory is given to the constructed SYCL [code]#sampled_image# for
-      the duration of its lifetime.
-      The host address is [code]#const#, so the host accesses can be
-      read-only. Since, the [code]#hostPointer# is [code]#const#, this image is only
-      initialized with this memory and there is no write after its
-      destruction.
-      The element size of the constructed SYCL [code]#sampled_image#
-      will be derived from the [code]#format# parameter.
-      Accessors that read the constructed SYCL [code]#sampled_image# will
-      use the [code]#sampler# parameter to sample the image.
-      The range of the constructed SYCL [code]#sampled_image# is
-      specified by the [code]#rangeRef# parameter provided.
-      The pitch of the constructed SYCL [code]#sampled_image# will be
-      the [code]#pitch# parameter provided.
-      Zero or more properties can be provided to the constructed SYCL
-      [code]#sampled_image# via an instance of
-      [code]#property_list#.
+   a@ When [code]#hostPointer# is not empty, construct a SYCL
+      [code]#sampled_image# with the contents of its stored pointer.  The
+      [code]#sampled_image# assumes exclusive access to this memory for the
+      duration of its lifetime.  The [code]#sampled_image# also creates its
+      own internal copy of the [code]#shared_ptr# that shares ownership of the
+      [code]#hostData# memory, which means the application can safely release
+      ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostPointer# is empty, construct a SYCL [code]#sampled_image#
+with uninitialized memory.
+
+The host address is [code]#const#, so the host accesses can be
+read-only. Since, the [code]#hostPointer# is [code]#const#, this image is only
+initialized with this memory and there is no write after its
+destruction.
+The element size of the constructed SYCL [code]#sampled_image#
+will be derived from the [code]#format# parameter.
+Accessors that read the constructed SYCL [code]#sampled_image# will
+use the [code]#sampler# parameter to sample the image.
+The range of the constructed SYCL [code]#sampled_image# is
+specified by the [code]#rangeRef# parameter provided.
+The pitch of the constructed SYCL [code]#sampled_image# will be
+the [code]#pitch# parameter provided.
+Zero or more properties can be provided to the constructed SYCL
+[code]#sampled_image# via an instance of
+[code]#property_list#.
 
 |====
 
@@ -5954,6 +6071,10 @@ constructor, then the buffer object and the developer's application share
 the memory region. If the shared pointer is still used on the application's
 side then the data will be copied back from the buffer or image and will be
 available to the application after the buffer or image is destroyed.
+
+If the [code]#shared_ptr# is not empty, the contents of the referenced
+memory are used to initialize the buffer.  If the [code]#shared_ptr# is
+empty, then the buffer is created with uninitialized memory.
 
 When the buffer is destroyed and the data have potentially been updated, if
 the number of copies of the shared pointer outside the runtime is 0, there


### PR DESCRIPTION
Clarify that buffer and image constructors that take `shared_ptr`
support an empty `shared_ptr`, which causes the buffer or image to have
uninitialized contents.  There was previously a statement to this
effect in section 4.7.4.3 "Shared SYCL ownership of the host memory",
but the sections describing the constructors themselves didn't say
anything about this.

Null raw pointers are still not allowed, consistent with the previous
wording.  However, I clarified that null raw pointers are allowed when
the buffer size is also zero.

I also clarified the constructors taking `shared_ptr` to note that the
application can safely release ownership of the pointer after the
constructor returns.  This is consistent with the existing wording and
example in section 4.7.4.3 "Shared SYCL ownership of the host memory".

In order to avoid confusion, I changed wording like:

> The ownership of this memory is given to the constructed SYCL buffer

To:

> The buffer assumes exclusive access to this memory

This seems better because the word "ownership" has a different meaning
for `shared_ptr`.