### PR TITLE
Buffer from container always blocks in destructor

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5052,11 +5052,10 @@ lifetime, and the contents of this memory are unspecified for the
 lifetime of the buffer. If the container memory is modified by the host
 during the lifetime of this buffer, then the results are undefined.
 
-When the buffer is destroyed, if the return type of
-[code]#std::data(container)# is not [code]#const# then the destructor
-will block until all work in queues on the buffer have completed, and will
-then copy the contents of the buffer to the container (if required)
-and then return.
+When the buffer is destroyed, the destructor will block until all work in
+queues on the buffer have completed.  If the return type of
+[code]#std::data(container)# is not [code]#const# then the destructor will also
+copy the contents of the buffer to the container (if required).
 --
 
 


### PR DESCRIPTION
Clarify the behavior of the buffer destructor for a buffer that is created from a container.  The previous wording said that the destructor blocks if the container is non-const, but it didn't say what happens for a const container.  The new wording clarifies that it blocks in this case also.

This is consistent with the behavior of buffers that are constructed from a host pointer.  In that case, the destructor always blocks, even when host pointer is const.