### PR TITLE
Align discussion of forward progress with C++

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1114,15 +1114,6 @@ arrives at a group barrier acting on group _G_, implementations must eventually
 select and potentially strengthen another work-item in group _G_ that has not
 yet arrived at the barrier.
 
-Synchronizing work-items via memory operations is unsafe in general, but is
-supported if and only if the following conditions are true:
-
-  * acquire-release or sequentially consistent memory ordering is supported
-    at the scope containing the set of work-items being synchronized;
-
-  * the work-items being synchronized both provide concurrent forward progress
-    guarantees.
-
 When a host thread blocks on the completion of a command previously submitted
 to a SYCL queue (for example, via the [code]#sycl::queue::wait# function), it
 blocks with forward progress guarantee delegation.

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1099,7 +1099,7 @@ to the buffer or USM allocation from device code.
 ==== Forward progress
 
 This section, and any subsequent section referring to progress guarantees, uses
-the following terms as defined in the {cpp}17 specification: thread of
+the following terms as defined in the {cpp} core language: thread of
 execution; weakly parallel forward progress guarantees; parallel forward
 progress guarantees; concurrent forward progress guarantees; and block with
 forward progress guarantee delegation.

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1098,6 +1098,12 @@ to the buffer or USM allocation from device code.
 
 ==== Forward progress
 
+This section, and any subsequent section referring to progress guarantees, uses
+the following terms as defined in the {cpp}17 specification: thread of
+execution; weakly parallel forward progress guarantees; parallel forward
+progress guarantees; concurrent forward progress guarantees; and block with
+forward progress guarantee delegation.
+
 Each work-item in SYCL is a separate thread of execution, providing at least
 weakly parallel forward progress guarantees.  Whether work-items provide
 stronger forward progress guarantees is implementation-defined.  All

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1123,6 +1123,14 @@ When a host thread blocks on the completion of a command previously submitted
 to a SYCL queue (for example, via the [code]#sycl::queue::wait# function), it
 blocks with forward progress guarantee delegation.
 
+[NOTE]
+====
+SYCL commands submitted to a queue are not guaranteed to begin executing until
+a host thread blocks on their completion.  In the absence of multiple host
+threads, there is no guarantee that host and device code will execute
+concurrently.
+====
+
 // Later, this label will move onto a new subsection - see below
 [[sec:progmodel.cpp]]
 == The SYCL programming model

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1098,11 +1098,11 @@ to the buffer or USM allocation from device code.
 
 ==== Forward progress
 
-Memory consistency guarantees are independent of any forward progress
-guarantees.  A SYCL implementation must ensure that the work-items in a group
-obey the semantics of <<group-barrier,group barriers>>, but is not required to
-provide any additional forward progress guarantees; each work-item is required
-only to provide weakly parallel forward progress guarantees.
+Each work-item in SYCL is a separate thread of execution, providing at least
+weakly parallel forward progress guarantees.  Whether work-items provide
+stronger forward progress guarantees is implementation-defined.  All
+implementations must ensure that the work-items in a group obey the semantics
+of <<group-barrier,group barriers>>, regardless of other progress guarantees.
 
 Synchronizing work-items via memory operations is unsafe in general, but is
 supported if and only if the following conditions are true:
@@ -1112,9 +1112,6 @@ supported if and only if the following conditions are true:
 
   * the work-items being synchronized both provide concurrent forward progress
     guarantees.
-
-The forward progress guarantee provided by each work-item is
-implementation-defined.
 
 // Later, this label will move onto a new subsection - see below
 [[sec:progmodel.cpp]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1106,9 +1106,13 @@ forward progress guarantee delegation.
 
 Each work-item in SYCL is a separate thread of execution, providing at least
 weakly parallel forward progress guarantees.  Whether work-items provide
-stronger forward progress guarantees is implementation-defined.  All
-implementations must ensure that the work-items in a group obey the semantics
-of <<group-barrier,group barriers>>, regardless of other progress guarantees.
+stronger forward progress guarantees is implementation-defined.
+
+All implementations must additionally ensure that the work-items in a group
+obey the semantics of <<group-barrier,group barriers>>: when a work-item
+arrives at a group barrier acting on group _G_, implementations must eventually
+select and potentially strengthen another work-item in group _G_ that has not
+yet arrived at the barrier.
 
 Synchronizing work-items via memory operations is unsafe in general, but is
 supported if and only if the following conditions are true:

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1108,11 +1108,11 @@ Each work-item in SYCL is a separate thread of execution, providing at least
 weakly parallel forward progress guarantees.  Whether work-items provide
 stronger forward progress guarantees is implementation-defined.
 
-All implementations must additionally ensure that the work-items in a group
-obey the semantics of <<group-barrier,group barriers>>: when a work-item
-arrives at a group barrier acting on group _G_, implementations must eventually
-select and potentially strengthen another work-item in group _G_ that has not
-yet arrived at the barrier.
+All implementations must additionally ensure that a work-item arriving at a
+<<group-barrier, group barrier>> does not prevent other work-items in the same
+group from making progress. When a work-item arrives at a group barrier acting
+on group _G_, implementations must eventually select and potentially strengthen
+another work-item in group _G_ that has not yet arrived at the barrier.
 
 When a host thread blocks on the completion of a command previously submitted
 to a SYCL queue (for example, via the [code]#sycl::queue::wait# function), it

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -604,8 +604,7 @@ unique <<work-group-id>> with the same dimensionality as the index space used fo
 the work-items. Work-items are each assigned a <<local-id>>, unique within the
 work-group, so that a single work-item can be uniquely identified by its global
 id or by a combination of its local id and work-group id.  The work-items in a
-given work-group execute concurrently on the processing elements of a single
-compute unit.
+given work-group execute on the processing elements of a single compute unit.
 
 When work-groups are used in SYCL, the index space is called an <<nd-range>>.
 An ND-range is an
@@ -1100,10 +1099,9 @@ to the buffer or USM allocation from device code.
 ==== Forward progress
 
 Memory consistency guarantees are independent of any forward progress
-guarantees.  A SYCL implementation must execute work-items concurrently
-and must ensure that the work-items in a group obey the semantics of
-<<group-barrier,group barriers>>, but are not required to provide any
-additional forward progress guarantees.
+guarantees.  A SYCL implementation must ensure that the work-items in a group
+obey the semantics of <<group-barrier,group barriers>>, but is not required to
+provide any additional forward progress guarantees.
 
 Synchronizing work-items via memory operations is unsafe in general, but is
 supported if and only if the following conditions are true:

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1101,7 +1101,8 @@ to the buffer or USM allocation from device code.
 Memory consistency guarantees are independent of any forward progress
 guarantees.  A SYCL implementation must ensure that the work-items in a group
 obey the semantics of <<group-barrier,group barriers>>, but is not required to
-provide any additional forward progress guarantees.
+provide any additional forward progress guarantees; each work-item is required
+only to provide weakly parallel forward progress guarantees.
 
 Synchronizing work-items via memory operations is unsafe in general, but is
 supported if and only if the following conditions are true:

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1119,6 +1119,10 @@ supported if and only if the following conditions are true:
   * the work-items being synchronized both provide concurrent forward progress
     guarantees.
 
+When a host thread blocks on the completion of a command previously submitted
+to a SYCL queue (for example, via the [code]#sycl::queue::wait# function), it
+blocks with forward progress guarantee delegation.
+
 // Later, this label will move onto a new subsection - see below
 [[sec:progmodel.cpp]]
 == The SYCL programming model

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1110,11 +1110,11 @@ supported if and only if the following conditions are true:
   * acquire-release or sequentially consistent memory ordering is supported
     at the scope containing the set of work-items being synchronized;
 
-  * the work-items being synchronized are guaranteed to make forward progress
-    with respect to one another.
+  * the work-items being synchronized both provide concurrent forward progress
+    guarantees.
 
-The ability of work-items to make forward progress with respect to other
-work-items is implementation-defined.
+The forward progress guarantee provided by each work-item is
+implementation-defined.
 
 // Later, this label will move onto a new subsection - see below
 [[sec:progmodel.cpp]]
@@ -1223,9 +1223,8 @@ by calling the [code]#group_barrier# function.
 
 To maximize portability across devices, developers should not assume that
 work-items within a sub-group execute in any particular order, that work-groups
-are subdivided into sub-groups in a specific way, nor that two sub-groups
-within a work-group will make forward progress with respect to one
-another.
+are subdivided into sub-groups in a specific way, nor that the work-items
+within a sub-group provide specific forward progress guarantees.
 
 Variables with <<reduction>> semantics can be added to work-group data
 parallel kernels using the features described in <<sec:reduction>>.

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -459,8 +459,8 @@ object. For the full description please refer to <<subsec:buffers>>.
 [[sub-group]]sub-group::
     The SYCL sub-group ([code]#sycl::sub_group# class) is a
     representation of a collection of related work-items within a
-    <<work-group>> that execute concurrently. For further details for the
-    [code]#sycl::sub_group# class see <<sub-group-class>>.
+    <<work-group>>. For further details for the [code]#sycl::sub_group# class
+    see <<sub-group-class>>.
 
 [[sub-group-barrier]]sub-group barrier::
     A <<group-barrier>> for all <<work-item,work items>> in a <<sub-group>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18255,10 +18255,10 @@ each type of atomic operation, consistent with the [code]#DefaultOrder# template
 
 The atomic operations and member functions behave as described in the {cpp}
 specification, barring the restrictions discussed above. Note that care
-must be taken when using atomics to implement synchronization routines due
-to the lack of forward progress guarantees between work-items in SYCL.  No
-work-item may be dependent on another work-item to make progress if the code
-is to be portable.
+must be taken when using atomics to implement synchronization routines, because
+work-items are only required to provide weakly parallel forward progress
+guarantees.  No work-item may be dependent on another work-item to make
+progress if the code is to be portable.
 
 
 [[table.atomic-refs.constructors]]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12172,9 +12172,8 @@ The local range stored in the group class is provided either by
 the programmer, when it is passed as an optional parameter to
 [code]#parallel_for_work_group#, or by the runtime system when it
 selects the optimal work-group size. This allows the developer to
-always know how many concurrent work-items are active in each
-executing work-group, even through the abstracted iteration range of the
-[code]#parallel_for_work_item# loops.
+always know how many work-items are in each executing work-group, even through
+the abstracted iteration range of the [code]#parallel_for_work_item# loops.
 
 The SYCL [code]#group# class template provides the common by-value
 semantics (see <<sec:byval-semantics>>).
@@ -12992,11 +12991,11 @@ reference to a variable of any [code]#reducer# type.  Kernels written as
 lambdas should employ [code]#auto&# or [code]#+auto&...+#, and kernels written as
 function objects should employ template parameters or template parameter packs.
 
-An implementation must guarantee that it is safe for each concurrently
-executing work-item in a kernel to call the combine function of a
-[code]#reducer# in parallel. An implementation is free to re-use reducer
-variables (e.g. across work-groups scheduled to the same compute unit) if it
-can guarantee that it is safe to do so.
+An implementation must guarantee that it is safe for multiple work-items in a
+kernel to call the combine function of a [code]#reducer# concurrently. An
+implementation is free to re-use reducer variables (e.g. across work-groups
+scheduled to the same compute unit) if it can guarantee that it is safe to do
+so.
 
 The member functions of the [code]#reducer# class are listed in
 <<table.members.reducer>>.  Additional shorthand operators may be made

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18254,12 +18254,16 @@ The static members [code]#default_read_order#, [code]#default_write_order# and
 each type of atomic operation, consistent with the [code]#DefaultOrder# template.
 
 The atomic operations and member functions behave as described in the {cpp}
-specification, barring the restrictions discussed above. Note that care
-must be taken when using atomics to implement synchronization routines, because
-work-items are only required to provide weakly parallel forward progress
-guarantees.  No work-item may be dependent on another work-item to make
-progress if the code is to be portable.
+specification, barring the restrictions discussed above.
 
+[NOTE]
+====
+Care must be taken when using atomics for work-item coordination, because
+work-items are not required to provide stronger than weakly parallel forward
+progress guarantees. Operations that block a work-item, such as continuously
+checking the value of an atomic variable until some condition holds, or using
+atomic operations that are not lock-free, may prevent overall progress.
+====
 
 [[table.atomic-refs.constructors]]
 .Constructors of the SYCL [code]#atomic_ref# class template


### PR DESCRIPTION
The commits here implement the clarifications and bug fixes that were discussed during the F2F.

A quick summary of the changes below:

- Align with terminology like "concurrent forward progress guarantees"
- Clarify the minimum requirements for SYCL implementations regarding work-item forward progress
- Clarify when commands are guaranteed to start and make progress

Addresses internal issues 311 and 627.