### PR TITLE
Clarify that command groups enqueue commands

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1424,9 +1424,10 @@ intention is that a user will perform calls to SYCL functions, member functions,
 destructors and constructors inside that scope. These calls will be non-blocking
 on the host, but enqueue operations to the queue that the command group is submitted
 to. All user functions within the command group scope will be called on the host
-as the <<command-group-function-object>> is executed, but any device kernels it
-invokes will be added to the SYCL <<queue>>.  All kernels added to the <<queue>>
-will be executed out-of-order from each other, according to their data dependencies.
+as the <<command-group-function-object>> is executed, but any <<command,
+commands>> it invokes will be added to the SYCL <<queue>>.  All commands added
+to the <<queue>> will be executed out-of-order from each other, according to
+their data dependencies.
 
 
 [[sec:managing-object-lifetimes]]


### PR DESCRIPTION
Previous wording suggested that only device kernels were enqueued, and that other commands (e.g. data transfers, host tasks) were not scheduled according to their data dependencies.