### PR TITLE
Fix `fetch_min` description in programming_interface.adoc

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18688,6 +18688,8 @@ T fetch_min(T operand, memory_order memoryOrder = memory_order::relaxed)
 ----
    a@ Deprecated in SYCL 2020.
 
+Available only when: [code]#T != float#.
+
 Atomically computes the minimum of the value [code]#operand# and the
 value at the address of the [code]#multi_ptr# associated with this
 SYCL [code]#atomic# and assigns the result to the value at the address


### PR DESCRIPTION
Missed part in `fetch_min` description restored.