### PR TITLE
Fix description of the half precision math functions

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -21218,7 +21218,7 @@ In SYCL the half precision math functions are defined in
 [code]#sycl::half_precision#. The functions that are
 available within this namespace are specified in
 <<table.half.math.functions>>. These functions are
-implemented with a minimum of 10-bits of accuracy i.e. an ULP value is
+implemented with a minimum of 10-bits of accuracy i.e. the maximum error is
 less than or equal to 8192 ulp.
 
 


### PR DESCRIPTION
AFAIK "ULP value" has a different meaning. :)