### PR TITLE
Simplify opencl::cl_ type and sizeof(T)

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -219,24 +219,6 @@ The standard {cpp} fixed width types, e.g. [code]#int8_t#,
 should have the same size as defined by the {cpp} standard for host and
 device.
 
-ifdef::showtodos[]
-[NOTE]
-.Note
-====
-To ensure that pointer types and [code]#size_t# use the same amount of
-storage on host and device when inside structures, SYCL also requires that
-device compilers use the host sizes for pointers or [code]#size_t#. Devices
-may be using a smaller size internally for pointers and [code]#size_t#,
-but this should not impact the programming model for users. In the case where
-devices use larger pointer size internally than the host, then
-[code]#size_t# will match the <<host-pointer>> size. For structures shared
-between host and device it is recommended to use fixed width types for pointers.
-Scalar data types for a SYCL device compiler are described in
-<<table.types.fundamental>>.
-====
-endif::showtodos[]
-
-
 
 [[table.types.fundamental]]
 .Fundamental data types supported by SYCL

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -443,13 +443,6 @@ whether the object has actively been used on these devices yet or not.
 
 // From 3.10 Language restrictions in kernels
 
-Some types in SYCL vary according to pointer size or vary on the host
-according to the host ABI, such as [code]#size_t# or [code]#long#. In order
-for the SYCL device compiler to ensure that the sizes of
-these types match the sizes on the host and to enable data of these types
-to be shared between host and device, the OpenCL interoperability types
-are defined, [code]#sycl::cl_int# and [code]#sycl::cl_size_t#.
-
 The OpenCL C function qualifier [code]#+__kernel+# and the access
 qualifiers: [code]#+__read_only+#, [code]#+__write_only+# and [code]#+__read_write+#
 are not exposed in SYCL via keywords, but are instead encapsulated in
@@ -951,7 +944,7 @@ scalar data types, and these have additional requirements in terms of size and
 signedness on top of what is guaranteed by ISO {cpp}. For the purpose of
 interoperability and portability, SYCL defines a set of aliases to {cpp} types
 within the [code]#sycl::opencl# namespace using the [code]#cl_#
-prefix. These aliases are described in <<table.types.aliases>>
+prefix. These aliases are described in <<table.types.aliases>>.
 
 
 [[table.types.aliases]]


### PR DESCRIPTION
This addresses concerns raised in #312.

1. It removes a sentence in [C.6. Interoperability with the OpenCL API](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:opencl:interfacing-with-opencl). 

   - This sentence contained a typo (it should have been `sycl::opencl::cl_int`)
   - It's the only place on the spec where `sycl::cl_size_t` is defined. The OpenCL spec doesn't even define an  `OpenCL size_t`. We reached the conclusion that such a type was not needed.
   - This sentence is paraphrasing [C.7.8. Data types](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_data_types_2) 

> The OpenCL C language standard [Section 6.11](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#opencl12) defines its own built-in scalar data types, and these have additional requirements in terms of size and signedness on top of what is guaranteed by ISO C++. For the purpose of interoperability and portability, SYCL defines a set of aliases to C++ types within the sycl::opencl namespace using the cl_ prefix. These aliases are described in [Table 192](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.types.aliases)

2. It removes a paragraph in [5.5. Built-in scalar data types](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:scalartypes).  Indeed this paragraph is more confusing than helpful.  The type size should be identical between the host and the device. 