### PR TITLE
Fix description of max_work_item_sizes

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1808,7 +1808,7 @@ a@
 info::device::max_work_item_sizes\<1>
 ----
 
-    @ [.code]#id<1>#
+    @ [.code]#range<1>#
    a@ Returns the maximum number of work-items that are permitted in a
       work-group for a kernel running in a one-dimensional index space. The
       minimum value is latexmath:[(1)] for [code]#devices# that are not of
@@ -1820,7 +1820,7 @@ a@
 info::device::max_work_item_sizes\<2>
 ----
 
-    @ [.code]#id<2>#
+    @ [.code]#range<2>#
    a@ Returns the maximum number of work-items that are permitted in each
       dimension of a work-group for a kernel running in a two-dimensional index
       space. The minimum value is latexmath:[(1,1)] for [code]#devices# that
@@ -1832,7 +1832,7 @@ a@
 info::device::max_work_item_sizes\<3>
 ----
 
-    @ [.code]#id<3>#
+    @ [.code]#range<3>#
    a@ Returns the maximum number of work-items that are permitted in each
       dimension of a work-group for a kernel running in a three-dimensional
       index space. The minimum value is latexmath:[(1,1,1)] for [code]#devices#

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1810,9 +1810,9 @@ info::device::max_work_item_sizes\<1>
 
     @ [.code]#id<1>#
    a@ Returns the maximum number of work-items that are permitted in a
-      work-group. The minimum value is latexmath:[(1)]
-      for [code]#devices# that are not of device type
-      [code]#info::device_type::custom#.
+      work-group for a kernel running in a one-dimensional index space. The
+      minimum value is latexmath:[(1)] for [code]#devices# that are not of
+      device type [code]#info::device_type::custom#.
 
 a@
 [source]
@@ -1822,9 +1822,9 @@ info::device::max_work_item_sizes\<2>
 
     @ [.code]#id<2>#
    a@ Returns the maximum number of work-items that are permitted in each
-      dimension of a work-group. The minimum value is
-      latexmath:[(1,1)] for [code]#devices# that are not of device type
-      [code]#info::device_type::custom#.
+      dimension of a work-group for a kernel running in a two-dimensional index
+      space. The minimum value is latexmath:[(1,1)] for [code]#devices# that
+      are not of device type [code]#info::device_type::custom#.
 
 a@
 [source]
@@ -1834,9 +1834,9 @@ info::device::max_work_item_sizes\<3>
 
     @ [.code]#id<3>#
    a@ Returns the maximum number of work-items that are permitted in each
-      dimension of a work-group. The minimum value
-      is latexmath:[(1,1,1)] for [code]#devices# that are not of device type
-      [code]#info::device_type::custom#.
+      dimension of a work-group for a kernel running in a three-dimensional
+      index space. The minimum value is latexmath:[(1,1,1)] for [code]#devices#
+      that are not of device type [code]#info::device_type::custom#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1809,8 +1809,8 @@ info::device::max_work_item_sizes\<1>
 ----
 
     @ [.code]#id<1>#
-   a@ Returns the maximum number of work-items that are permitted of the
-      work-group of the [code]#nd_range#. The minimum value is latexmath:[(1)]
+   a@ Returns the maximum number of work-items that are permitted in a
+      work-group. The minimum value is latexmath:[(1)]
       for [code]#devices# that are not of device type
       [code]#info::device_type::custom#.
 
@@ -1821,8 +1821,8 @@ info::device::max_work_item_sizes\<2>
 ----
 
     @ [.code]#id<2>#
-   a@ Returns the maximum number of work-items that are permitted in both
-      dimensions of the work-group of the [code]#nd_range#. The minimum value is
+   a@ Returns the maximum number of work-items that are permitted in each
+      dimension of a work-group. The minimum value is
       latexmath:[(1,1)] for [code]#devices# that are not of device type
       [code]#info::device_type::custom#.
 
@@ -1834,7 +1834,7 @@ info::device::max_work_item_sizes\<3>
 
     @ [.code]#id<3>#
    a@ Returns the maximum number of work-items that are permitted in each
-      dimension of the work-group of the [code]#nd_range#. The minimum value
+      dimension of a work-group. The minimum value
       is latexmath:[(1,1,1)] for [code]#devices# that are not of device type
       [code]#info::device_type::custom#.
 


### PR DESCRIPTION
New description is aligned with the behavior of OpenCL's CL_DEVICE_MAX_WORK_ITEM_SIZES.

Also replaced an instance of "both" with "each" to clarify that implementations are not required to return the same maximum value for both dimensions of a two-dimensional work-group.

Closes #310, closes #330.