### PR TITLE
No assignment for read-only accessors

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6788,7 +6788,8 @@ a@
 const accessor& operator=(const value_type& other) const
 ----
    a@ Available only when
-      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
+      [code]#(AccessMode != access_mode::atomic &&
+      AccessMode != access_mode::read && Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 
@@ -6800,7 +6801,8 @@ a@
 const accessor& operator=(value_type&& other) const
 ----
    a@ Available only when
-      [code]#(AccessMode != access_mode::atomic && Dimensions == 0)#.
+      [code]#(AccessMode != access_mode::atomic &&
+      AccessMode != access_mode::read && Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 
@@ -7856,7 +7858,8 @@ a@
 ----
 const host_accessor& operator=(const value_type& other) const
 ----
-   a@ Available only when [code]#(Dimensions == 0)#.
+   a@ Available only when [code]#(AccessMode != access_mode::read &&
+      Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 
@@ -7865,7 +7868,8 @@ a@
 ----
 const host_accessor& operator=(value_type&& other) const
 ----
-   a@ Available only when [code]#(Dimensions == 0)#.
+   a@ Available only when [code]#(AccessMode != access_mode::read &&
+      Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 
@@ -8070,7 +8074,7 @@ a@
 ----
 const local_accessor& operator=(const value_type& other) const
 ----
-   a@ Available only when [code]#(Dimensions == 0)#.
+   a@ Available only when [code]#(!std::is_const_v<DataT> && Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 
@@ -8081,7 +8085,7 @@ a@
 ----
 const local_accessor& operator=(const value_type&& other) const
 ----
-   a@ Available only when [code]#(Dimensions == 0)#.
+   a@ Available only when [code]#(!std::is_const_v<DataT> && Dimensions == 0)#.
 
 Assignment to the single element that is accessed by this accessor.
 

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -156,10 +156,12 @@ class accessor {
   /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
   operator reference() const;
 
-  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
+  /* Available only when: (AccessMode != access_mode::atomic &&
+                           AccessMode != access_mode::read && Dimensions == 0) */
   const accessor& operator=(const value_type& other) const;
 
-  /* Available only when: (AccessMode != access_mode::atomic && Dimensions == 0) */
+  /* Available only when: (AccessMode != access_mode::atomic &&
+                           AccessMode != access_mode::read && Dimensions == 0) */
   const accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -82,10 +82,10 @@ class host_accessor {
   /* Available only when: (Dimensions == 0) */
   operator reference() const;
 
-  /* Available only when: (Dimensions == 0) */
+  /* Available only when: (AccessMode != access_mode::read && Dimensions == 0) */
   const host_accessor& operator=(const value_type& other) const;
 
-  /* Available only when: (Dimensions == 0) */
+  /* Available only when: (AccessMode != access_mode::read && Dimensions == 0) */
   const host_accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -47,10 +47,10 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   /* Available only when: (Dimensions == 0) */
   operator reference() const;
 
-  /* Available only when: (Dimensions == 0) */
+  /* Available only when: (!std::is_const_v<DataT> && Dimensions == 0) */
   const local_accessor& operator=(const value_type& other) const;
 
-  /* Available only when: (Dimensions == 0) */
+  /* Available only when: (!std::is_const_v<DataT> && Dimensions == 0) */
   const local_accessor& operator=(value_type&& other) const;
 
   /* Available only when: (Dimensions > 0) */


### PR DESCRIPTION
We added assignment operators for 0-Dimensional accessors in #278, but we mistakenly added them even for read-only accessors.  Clarify that there is no assignment operator for a read-only accessor.