### PR TITLE
Add atomic_ref::fetch_xor to synopsis

### DIFF
--- a/adoc/headers/atomicref.h
+++ b/adoc/headers/atomicref.h
@@ -99,6 +99,10 @@ class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
                     memory_order order = default_read_modify_write_order,
                     memory_scope scope = default_scope) const noexcept;
 
+  Integral fetch_xor(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept;
+
   Integral fetch_min(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept;


### PR DESCRIPTION
This function is described in table 154 "Additional member functions available on an object of type `atomic_ref<T>` for integral `T`, but we forgot to add it to the synopsis.  Do that now.