### PR TITLE
Clarifications to sub-group

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1204,14 +1204,14 @@ kernels using the features described in <<sec:reduction>>.
 
 === Work-group data parallel kernels
 
-Data parallel <<kernel>>s can also execute in a mode where the set of
-<<work-item>>s is divided into <<work-group>>s of user-defined dimensions.
-The user specifies the global <<range>> and local work-group size as
-parameters to the [code]#sycl::parallel_for# function with a
+Data parallel <<kernel,kernels>> can also execute in a mode where the set of
+<<work-item,work-items>> is divided into <<work-group,work-groups>> of
+user-defined dimensions.  The user specifies the global <<range>> and local
+work-group size as parameters to the [code]#sycl::parallel_for# function with a
 [code]#sycl::nd_range# parameter. In this mode of execution,
 kernels execute over the <<nd-range>> in work-groups of the specified
 size. It is possible to share data among work-items within the same
-work-group in <<local memory,local>> or <<global memory>> and to synchronize between
+work-group in <<local-memory,local>> or <<global-memory>> and to synchronize between
 work-items in the same work-group by calling the
 [code]#group_barrier# function. All work-groups in a given
 [code]#parallel_for# will be the same size, and the global size
@@ -1220,9 +1220,10 @@ each dimension, or the global size must be zero. When the global size
 is zero, the kernel function is not executed, the local size is ignored, and
 any dependencies are satisfied.
 
-Work-groups may be further subdivided into <<sub-group>>s.
-The size and number of sub-groups is implementation-defined and may differ for
-each kernel, and different devices may make different guarantees with respect
+Work-groups may be further subdivided into <<sub-group,sub-groups>>.  The
+work-items that compose a sub-group are selected in an implementation-defined
+way, and therefore the size and number of sub-groups may differ for each
+kernel.  Moreover, different devices may make different guarantees with respect
 to how sub-groups within a work-group are scheduled.  The maximum number of
 work-items in any sub-group in a kernel is based on a combination of the kernel
 and its dispatch dimensions.  The size of any sub-group in the dispatch is
@@ -1231,10 +1232,10 @@ sub-group is invariant for the duration of a kernel's execution.  Similarly
 to work-groups, the work-items within the same sub-group can be synchronized
 by calling the [code]#group_barrier# function.
 
-To maximize portability across devices, developers should not assume that
-work-items within a sub-group execute in any particular order, that work-groups
-are subdivided into sub-groups in a specific way, nor that the work-items
-within a sub-group provide specific forward progress guarantees.
+Portable device code must not assume that work-items within a sub-group execute
+in any particular order, that work-groups are subdivided into sub-groups in a
+specific way, nor that the work-items within a sub-group provide specific
+forward progress guarantees.
 
 Variables with <<reduction>> semantics can be added to work-group data
 parallel kernels using the features described in <<sec:reduction>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11997,8 +11997,11 @@ a@
 ----
 id<Dimensions> get_group_id() const
 ----
-   a@ Return an <<id>> representing the index of the work-group
-      within the <<nd-range>> for every dimension.
+   a@ Return an <<id>> representing the index of the work-group within the
+      global <<nd-range>> for every dimension.  Since the work-items in a
+      work-group have a defined position within the global nd-range, the
+      returned group id can be used along with the local id to uniquely
+      identify the work-item in the global nd-range.
 
 a@
 [source]
@@ -12023,7 +12026,7 @@ a@
 ----
 size_t get_local_id(int dimension) const
 ----
-   a@ Return the calling work-item's position within the <<work-group>> in the specified dimension.
+   a@ Return the same value as [code]#get_local_id()[dimension]#.
 
 It is undefined behavior for this member function to be invoked from within
 a [code]#parallel_for_work_item# context.
@@ -12041,7 +12044,7 @@ a@
 ----
 size_t get_local_range(int dimension) const
 ----
-   a@ Return the dimension of the local range specified by the [code]#dimension# parameter.
+   a@ Return the same value as [code]#get_local_range()[dimension]#.
 
 a@
 [source]
@@ -12055,7 +12058,7 @@ a@
 ----
 size_t get_group_range(int dimension) const
 ----
-   a@ Return element [code]#dimension# from the constituent group range.
+   a@ Return the same value as [code]#get_group_range()[dimension]#.
 
 a@
 [source]
@@ -12270,8 +12273,12 @@ a@
 ----
 id<1> get_group_id() const
 ----
-   a@ Return an <<id>> representing the index of the sub-group
-      within the <<work-group>>.
+   a@ Return an <<id>> representing the index of the sub-group within the
+      <<work-group>>.  Since the work-items that compose a sub-group are chosen
+      in an implementation defined way, the returned sub-group id cannot be
+      used to identify a particular work-item in the global nd-range.  Rather,
+      the returned sub-group id is merely an abstract identifier of the
+      sub-group containing this work-item.
 
 a@
 [source]
@@ -12297,8 +12304,8 @@ a@
 ----
 range<1> get_group_range() const
 ----
-   a@ Return a [code]#range# representing the number of <<sub-group>>s in the
-      <<work-group>>.
+   a@ Return a [code]#range# representing the number of
+      <<sub-group,sub-groups>> in the <<work-group>>.
 
 a@
 [source]
@@ -12315,28 +12322,28 @@ a@
 ----
 uint32_t get_group_linear_id() const
 ----
-   a@ Equivalent to [code]#get_group_id()#.
+   a@ Return the same value as [code]#get_group_id()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_group_linear_range() const
 ----
-   a@ Equivalent to [code]#get_group_range()#.
+   a@ Return the same value as [code]#get_group_range()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_local_linear_id() const
 ----
-   a@ Equivalent to [code]#get_local_id()#.
+   a@ Return the same value as [code]#get_local_id()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_local_linear_range() const
 ----
-   a@ Equivalent to [code]#get_local_range()#.
+   a@ Return the same value as [code]#get_local_range()[0]#.
 
 a@
 [source]


### PR DESCRIPTION
Clarify some of the wording about sub-groups:

* In the architecture chapter, clarify that the work-items that compose a sub-group are chosen in an implementation defined way.  Previously, we said only that the size and number of sub-groups is implementation defined.

* Also in the architecture chapter, strengthen the wording about what device code must do w.r.t. sub-groups in order to be portable.

* In the programming interface chapter, expand the specification of `group::get_group_id` and `sub_group::get_group_id` to clarify that the group id can be used to identify the work-item in the global nd-range while the sub-group id cannot.

While I was there, clean up some minor things:

* Change some glossary references for plural words so that the "s" is included in the text of the glossary link.

* Use the wording "Returns the same value as" for some `group` and `sub_group` functions to follow our existing precedent.

Partially addresses internal issue 638.