### PR TITLE
Mention kernel_handler in kernel function definition

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -489,8 +489,9 @@ object. For the full description please refer to <<subsec:buffers>>.
     A SYCL {cpp} source file that contains SYCL API calls.
 
 [[sycl-kernel-function]]SYCL kernel function::
-    A type which is callable with [code]#operator()# that takes a
-    <<id>>, <<item>>, <<nd-item>> or <<work-group>> which can be passed to
+    A type which is callable with [code]#operator()# that takes an
+    <<id>>, <<item>>, <<nd-item>> or <<work-group>>, and an optional
+    [code]#kernel_handler# as its last parameter. This type can be passed to
     kernel enqueue member functions of the <<handler>>. A
     <<sycl-kernel-function>> defines an entry point to a <<kernel>>. The
     function object can be a named <<device-copyable>> type or lambda


### PR DESCRIPTION
The `operator()` may also take a `kernel_handler`.