### PR TITLE
Minor fix to "item::operator size_t()"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11500,7 +11500,7 @@ operator size_t() const
 ----
    a@ Available only when: [code]#Dimensions == 1#
 
-Returns the same value as [code]#get(0)#.
+Returns the same value as [code]#get_id(0)#.
 
 a@
 [source]


### PR DESCRIPTION
I happened to notice this when reviewing the CTS test plan.