### PR TITLE
Clarify native_specialization_constant when empty

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -15370,9 +15370,10 @@ image which uses a specialization constant.
 bool native_specialization_constant() const noexcept;
 ----
 
-_Returns:_ [code]#true# only if all specialization constants used in the kernel
-bundle are <<native-specialization-constant,native specialization constants>>
-in all of the bundle's device images.
+_Returns:_ [code]#true# only if the kernel bundle contains at least one device
+image which uses a specialization constant and all specialization constants
+used in all of the bundle's device images are
+<<native-specialization-constant,native specialization constants>>.
 
 [source]
 ----


### PR DESCRIPTION
Clarify the behavior of `native_specialization_constant` when the kernel bundle contains no specialization constants.  I think we intended this to return `false` in this case, not `true`.