### PR TITLE
Add static constexpr `dimensions` member to all range/id-like types

### DIFF
--- a/adoc/headers/hitem.h
+++ b/adoc/headers/hitem.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions> class h_item {
  public:
+  static constexpr int dimensions = Dimensions;
+
   h_item() = delete;
 
   /* -- common interface members -- */

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions = 1> class id {
  public:
+  static constexpr int dimensions = Dimensions;
+
   id();
 
   /* The following constructor is only available in the id class

--- a/adoc/headers/item.h
+++ b/adoc/headers/item.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions = 1, bool WithOffset = true> class item {
  public:
+  static constexpr int dimensions = Dimensions;
+
   item() = delete;
 
   /* -- common interface members -- */

--- a/adoc/headers/ndRange.h
+++ b/adoc/headers/ndRange.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions = 1> class nd_range {
  public:
+  static constexpr int dimensions = Dimensions;
+
   /* -- common interface members -- */
 
   // The offset is deprecated in SYCL 2020.

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions = 1> class nd_item {
  public:
+  static constexpr int dimensions = Dimensions;
+
   nd_item() = delete;
 
   /* -- common interface members -- */

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -4,6 +4,8 @@
 namespace sycl {
 template <int Dimensions = 1> class range {
  public:
+  static constexpr int dimensions = Dimensions;
+
   /* The following constructor is only available in the range class
    * specialization where: Dimensions==1 */
   range(size_t dim0);


### PR DESCRIPTION
Partially addresses #270.