### PR TITLE
Fix misprints in marray and reduction

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12491,7 +12491,7 @@ sycl::logical_and
 a@
 [source]
 ----
-std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
 ----
 a@
 ----
@@ -12506,7 +12506,7 @@ sycl::logical_or
 a@
 [source]
 ----
-std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
 ----
 a@
 ----
@@ -17542,7 +17542,7 @@ a@
 ----
 marray& operatorOP(marray& v)
 ----
-   a@ Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#lhs# [code]#marray#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#marray# and return [code]#lhs# [code]#marray#.
+   a@ Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#v# [code]#marray#, assigning the result of each element to the corresponding element of [code]#v# [code]#marray# and return [code]#v# [code]#marray#.
 
 Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 
@@ -17551,7 +17551,7 @@ a@
 ----
 marray operatorOP(marray& v, int)
 ----
-   a@ Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#lhs# [code]#marray#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#marray# and returns a copy of [code]#lhs# [code]#marray# before the operation is performed.
+   a@ Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#v# [code]#marray#, assigning the result of each element to the corresponding element of [code]#v# [code]#marray# and returns a copy of [code]#v# [code]#marray# before the operation is performed.
 
 Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 
@@ -17736,11 +17736,9 @@ Where [code]#OP# is: [code]#&#, [code]#|#, [code]#^#.
 a@
 [source]
 ----
-marray<RET, NumElements> operatorOP(const DataT& lhs, const marray& rhs)
+marray<bool, NumElements> operatorOP(const DataT& lhs, const marray& rhs)
 ----
-   a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
-
-Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and
+   a@ Construct a new instance of the [code]#marray# class template with [code]#DataT = bool# and
 same NumElements as [code]#lhs# [code]#marray# with each element of the new [code]#marray# instance
 the result of an element-wise [code]#OP# logical operation between the [code]#lhs#
 scalar and each element of the [code]#rhs# [code]#marray#.

--- a/adoc/headers/marray.h
+++ b/adoc/headers/marray.h
@@ -56,15 +56,15 @@ template <typename DataT, std::size_t NumElements> class marray {
   }
 
   // OP is prefix ++, --
-  friend marray& operatorOP(marray& rhs) { /* ... */
+  friend marray& operatorOP(marray& v) { /* ... */
   }
 
   // OP is postfix ++, --
-  friend marray operatorOP(marray& lhs, int) { /* ... */
+  friend marray operatorOP(marray& v, int) { /* ... */
   }
 
   // OP is unary +, -
-  friend marray operatorOP(marray& rhs) { /* ... */
+  friend marray operatorOP(marray& v) { /* ... */
   }
 
   // OP is: &, |, ^
@@ -84,70 +84,70 @@ template <typename DataT, std::size_t NumElements> class marray {
   // OP is: &&, ||
   friend marray<bool, NumElements> operatorOP(const marray& lhs,
                                               const marray& rhs) {
-    /* ... */ }
-    friend marray<bool, NumElements> operatorOP(const marray& lhs,
-                                                const DataT& rhs) {
-    /* ... */ }
+  /* ... */ }
+  friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                              const DataT& rhs) {
+  /* ... */ }
 
-    // OP is: <<, >>
-    /* Available only when: DataT != float && DataT != double && DataT != half.
-     */
-    friend marray operatorOP(const marray& lhs, const marray& rhs) { /* ... */
-    }
-    friend marray operatorOP(const marray& lhs, const DataT& rhs) { /* ... */
-    }
+  // OP is: <<, >>
+  /* Available only when: DataT != float && DataT != double && DataT != half.
+   */
+  friend marray operatorOP(const marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray operatorOP(const marray& lhs, const DataT& rhs) { /* ... */
+  }
 
-    // OP is: <<=, >>=
-    /* Available only when: DataT != float && DataT != double && DataT != half.
-     */
-    friend marray& operatorOP(marray& lhs, const marray& rhs) { /* ... */
-    }
-    friend marray& operatorOP(marray& lhs, const DataT& rhs) { /* ... */
-    }
+  // OP is: <<=, >>=
+  /* Available only when: DataT != float && DataT != double && DataT != half.
+   */
+  friend marray& operatorOP(marray& lhs, const marray& rhs) { /* ... */
+  }
+  friend marray& operatorOP(marray& lhs, const DataT& rhs) { /* ... */
+  }
 
-    // OP is: ==, !=, <, >, <=, >=
-    friend marray<bool, NumElements> operatorOP(const marray& lhs,
-                                                const marray& rhs) {
-    /* ... */ }
-    friend marray<bool, NumElements> operatorOP(const marray& lhs,
-                                                const DataT& rhs) {
-    /* ... */ }
+  // OP is: ==, !=, <, >, <=, >=
+  friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                              const marray& rhs) {
+  /* ... */ }
+  friend marray<bool, NumElements> operatorOP(const marray& lhs,
+                                              const DataT& rhs) {
+  /* ... */ }
 
-    /* Available only when: DataT != float && DataT != double && DataT != half.
-     */
-    friend marray operator~(const marray& v) { /* ... */
-    }
+  /* Available only when: DataT != float && DataT != double && DataT != half.
+   */
+  friend marray operator~(const marray& v) { /* ... */
+  }
 
-    // OP is: +, -, *, /, %
-    /* operator% is only available when: DataT != float && DataT != double &&
-     * DataT != half. */
-    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
-    }
+  // OP is: +, -, *, /, %
+  /* operator% is only available when: DataT != float && DataT != double &&
+   * DataT != half. */
+  friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+  }
 
-    // OP is: &, |, ^
-    /* Available only when: DataT != float && DataT != double
-    && DataT != half. */
-    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
-    }
+  // OP is: &, |, ^
+  /* Available only when: DataT != float && DataT != double
+  && DataT != half. */
+  friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+  }
 
-    // OP is: &&, ||
-    friend marray<bool, NumElements> operatorOP(const DataT& lhs,
-                                                const marray& rhs) {
-    /* ... */ }
+  // OP is: &&, ||
+  friend marray<bool, NumElements> operatorOP(const DataT& lhs,
+                                              const marray& rhs) {
+  /* ... */ }
 
-    // OP is: <<, >>
-    /* Available only when: DataT != float && DataT != double && DataT != half.
-     */
-    friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
-    }
+  // OP is: <<, >>
+  /* Available only when: DataT != float && DataT != double && DataT != half.
+   */
+  friend marray operatorOP(const DataT& lhs, const marray& rhs) { /* ... */
+  }
 
-    // OP is: ==, !=, <, >, <=, >=
-    friend marray<bool, NumElements> operatorOP(const DataT& lhs,
-                                                const marray& rhs) {
-    /* ... */ }
+  // OP is: ==, !=, <, >, <=, >=
+  friend marray<bool, NumElements> operatorOP(const DataT& lhs,
+                                              const marray& rhs) {
+  /* ... */ }
 
-    friend marray<bool, NumElements> operator!(const marray& v) { /* ... */
-    }
+  friend marray<bool, NumElements> operator!(const marray& v) { /* ... */
+  }
 };
 
 } // namespace sycl


### PR DESCRIPTION
Reduction:
- Changed `remove_v_t` to `remove_cv_t` in identity conditions.

Math array:
- Consistently named argument `v` instead of `lhs`/`rhs` for unary operators, in the table for hidden friend functions and in the code snippet.
- Removed non-floating-point requirement for one logical operator overload (the other overloads already are correct).
- Changed return type `RET` to actual type `bool` in one instance.
- Fixed indentation in code snippet.