### PR TITLE
Clarify blocking behavior of `queue::submit`

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -411,6 +411,7 @@ The SYCL implementation guarantees the correct initialization and
 destruction of any resource handled by the underlying <<backend-api>>, except
 for those the user has obtained manually via the SYCL interoperability API.
 
+[[sec:command-groups-exec-order]]
 ==== SYCL command groups and execution order
 
 By default, SYCL queues execute kernel functions in an out-of-order fashion

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2906,9 +2906,12 @@ function.
 
 All member functions of the [code]#queue# class are synchronous and errors
 are handled by throwing synchronous SYCL exceptions. The [code]#submit#
-member function schedules <<command-group,command groups>> asynchronously, so any errors
-in the submission of a <<command-group>> are handled by throwing synchronous
-SYCL exceptions. Any exceptions from the <<command-group>> after it has
+member function synchronously invokes the provided
+<<command-group-function-object>> (as described in
+<<sec:command-groups-exec-order>>) in the calling thread, thereby scheduling a
+<<command-group>> for asynchronous execution. Any error in the submission of a
+<<command-group>> is handled by throwing a synchronous SYCL exception.
+Any exceptions from the <<command-group>> after it has
 been submitted are handled by passing <<async-error,asynchronous errors>> at specific times to an
 <<async-handler>>, as described in <<error-handling>>.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2911,8 +2911,8 @@ member function synchronously invokes the provided
 <<sec:command-groups-exec-order>>) in the calling thread, thereby scheduling a
 <<command-group>> for asynchronous execution. Any error in the submission of a
 <<command-group>> is handled by throwing a synchronous SYCL exception.
-Any exceptions from the <<command-group>> after it has
-been submitted are handled by passing <<async-error,asynchronous errors>> at specific times to an
+Any errors from the <<command-group>> after it has been submitted are handled by
+passing <<async-error,asynchronous errors>> at specific times to an
 <<async-handler>>, as described in <<error-handling>>.
 
 A SYCL [code]#queue# can wait for all <<command-group,command groups>> that it has


### PR DESCRIPTION
Clarify that the CGF provided to `queue::submit` is invoked in the calling thread.

Resolves #307.