### PR TITLE
Clarify USM allocation of zero size

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10184,9 +10184,10 @@ leak.  If there are not enough resources to allocate the requested memory,
 these functions return [code]#nullptr#.
 
 When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
-zero) the value returned by these functions is unspecified, but the returned
-pointer may not be used to access storage.  If the pointer is not null, it
-must be passed to [code]#sycl::free# to avoid a memory leak.
+zero), these functions behave in a manor consistent with {cpp}
+[code]#std::malloc#.  The value returned is unspecified in this case, and the
+returned pointer may not be used to access storage.  If this pointer is not
+null, it must be passed to [code]#sycl::free# to avoid a memory leak.
 
 [[table.usm.device.allocs]]
 .Device USM Allocation Functions

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10183,6 +10183,11 @@ eventually be deallocated with [code]#sycl::free# in order to avoid a memory
 leak.  If there are not enough resources to allocate the requested memory,
 these functions return [code]#nullptr#.
 
+When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
+zero) the value returned by these functions is unspecified, but the returned
+pointer may not be used to access storage.  If the pointer is not null, it
+must be passed to [code]#sycl::free# to avoid a memory leak.
+
 [[table.usm.device.allocs]]
 .Device USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]


### PR DESCRIPTION
Clarify the behavior of the USM malloc-like functions when the requested size is zero bytes, making them consistent with the behavior of `std::malloc`.

Closes #355.