### PR TITLE
Clarifications to device copyable

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1783,8 +1783,8 @@ implicitly device copyable.
 Although implementations are not required to support device code that calls
 library functions from the {cpp} core language, some implementations may
 provide device support for some of these functions.  If the implementation
-provides device support for one of the following classes in the {cpp} core
-language, that type is also implicitly device copyable:
+provides device support for one of the following classes, that type is also
+implicitly device copyable:
 
   * [code]#std::array<T, 0>#;
   * [code]#std::array<T, N># if [code]#T# is device copyable;
@@ -1798,7 +1798,8 @@ language, that type is also implicitly device copyable:
     [code]#Types# are device copyable;
   * [code]#std::basic_string_view<CharT, Traits>#;
   * [code]#std::span<ElementType, Extent># (the [code]#std::span# type has
-    been introduced in {cpp}20).
+    been introduced in {cpp}20);
+  * [code]#sycl::span<ElementType, Extent>#.
 
 If the implementation provides device support for one of the classes listed
 above, arrays of that class and cv-qualified versions of that class are also

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1778,8 +1778,13 @@ certain arguments to a <<sycl-kernel-function>> (as described in
 <<device-copyable>> as defined below.
 
 Any type that is trivially copyable (as defined by the {cpp} core language) is
-implicitly device copyable.  In addition, the following types from the {cpp}
-core language are implicitly device copyable:
+implicitly device copyable.
+
+Although implementations are not required to support device code that calls
+library functions from the {cpp} core language, some implementations may
+provide device support for some of these functions.  If the implementation
+provides device support for one of the following classes in the {cpp} core
+language, that type is also implicitly device copyable:
 
   * [code]#std::array<T, 0>#;
   * [code]#std::array<T, N># if [code]#T# is device copyable;
@@ -1794,6 +1799,10 @@ core language are implicitly device copyable:
   * [code]#std::basic_string_view<CharT, Traits>#;
   * [code]#std::span<ElementType, Extent># (the [code]#std::span# type has
     been introduced in {cpp}20).
+
+If the implementation provides device support for one of the classes listed
+above, arrays of that class and cv-qualified versions of that class are also
+device copyable.
 
 [NOTE]
 ====
@@ -1829,7 +1838,8 @@ have this support.  When the implementation has this support, a class type
 
 When the application explicitly declares a class type to be device copyable,
 arrays of that type and cv-qualified versions of that type are also device
-copyable.
+copyable, and the implementation sets the [code]#is_device_copyable_v# trait to
+[code]#true# for these array and cv-qualified types.
 
 [NOTE]
 ====


### PR DESCRIPTION
* Section 3.13.1 "Device copyable" lists several types from the C++ standard library as device copyable.  Clarify that this does not create a requirement for an implementation to support these types in device code.  Rather, it is saying that *if* an implementation chooses to support these types in device code (as an extension), then those types should be device copyable.  Note that section 5.4 "Language restrictions for device functions" already says that an implementation is not required to support the use of C++ standard library functions in device code.  This clarification is consistent with the wording proposed in internal issue 533.

* Clarify that when an implementation supports these standard library classes in device code, then arrays of those classes and cv-qualified versions of those classes are also device copyable.  This is consistent with the standard C++ definition of "trivially copyable".

* We already stated that when an application explicitly declares a custom type to be device copyable via the `is_device_copyable` trait, then arrays of that type and cv-qualified versions of that type are also device copyable.  Make it extra clear that the implementation is responsible for setting the `is_device_copyable` trait to `true` for these array and cv-qualified types.

Closes internal issue 533.