### PR TITLE
Clarify sycl::atomic_ref

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17945,43 +17945,77 @@ device_event(___unspecified___)
 [[sec:atomic-references]]
 === Atomic references
 
-The SYCL specification provides atomic operations based on the library
-syntax from the next {cpp} specification. The set of supported orderings is
+The [code]#sycl::atomic_ref# class provides the ability to perform atomic
+operations in device code with a syntax similar to the {cpp} standard
+[code]#std::atomic_ref#.  The [code]#sycl::atomic_ref# class must not be used
+in host code.
+
+Unlike [code]#std::atomic_ref#, [code]#sycl::atomic_ref# does not provide a
+default memory ordering for its operations.  Instead, the application must
+specify a default ordering via the [code]#DefaultOrder# template parameter.
+This ordering is used as a default for most of the atomic operations, but
+each member function also provides an optional parameter that allows the
+application to override this default.  The set of supported orderings is
 specific to a device, but every device is guaranteed to support at least
-[code]#memory_order::relaxed#. Since different devices have different
-capabilities, there is no default ordering in SYCL and the default order
-used by each instance of [code]#sycl::atomic_ref# is set by a template
-argument. If the default order is set to [code]#memory_order::relaxed#,
-all memory order arguments default to [code]#memory_order::relaxed#. If
-the default order is set to [code]#memory_order::acq_rel#, memory order
-arguments default to [code]#memory_order::acquire# for load operations,
+[code]#memory_order::relaxed#.  If the default order is set to
+[code]#memory_order::relaxed#, all memory order arguments default to
+[code]#memory_order::relaxed#.  If the default order is set to
+[code]#memory_order::acq_rel#, memory order arguments default to
+[code]#memory_order::acquire# for load operations,
 [code]#memory_order::release# for store operations and
-[code]#memory_order::acq_rel# for read-modify-write operations. If the
+[code]#memory_order::acq_rel# for read-modify-write operations.  If the
 default order is set to [code]#memory_order::seq_cst#, all memory order
 arguments default to [code]#memory_order::seq_cst#.
 
-The SYCL atomic library may map directly to the underlying {cpp} library in
-<<sycl-application>> code, and must interact safely with the host {cpp}
-atomic library when used in host code. The SYCL library must be used in
-device code to ensure that only the limited subset of functionality is
-available. SYCL device compilers should give a compilation error on use of
-the [code]#std::atomic# and [code]#std::atomic_ref# classes and
-functions in device code.
+The [code]#sycl::atomic_ref# class has a template parameter
+[code]#DefaultScope#, which allows the application to define a default memory
+scope for the atomic operations.  Each member function also provides an
+optional parameter that allows the application to override this default.
 
-The template parameter [code]#Space# is permitted to be
-[code]#access::address_space::generic_space#,
-[code]#access::address_space::global_space# or [code]#access::address_space::local_space#.
+The [code]#sycl::atomic_ref# class also has a template parameter
+[code]#AddressSpace#, which allows the application to make an assertion about
+the address space of the object of type [code]#T# that it references.  The
+default value for this parameter is
+[code]#access::address_space::generic_space#, which indicates that the object
+could be in either the global or local address spaces.  If the application
+knows the address space, it can set this template parameter to either
+[code]#access::address_space::global_space# or
+[code]#access::address_space::local_space# as an assertion to the
+implementation.  Specifying the address space via this template parameter may
+allow the implementation to perform certain optimizations.  Specifying an
+address space that does not match the object's actual address space results in
+undefined behavior.
 
-The data type [code]#T# is permitted to be [code]#int#, [code]#unsigned int#, [code]#long#,
-[code]#unsigned long#,
-[code]#long long#,
-[code]#unsigned long long#, [code]#float# or
-[code]#double#.  For floating-point types, the member functions of the
-[code]#atomic_ref# class may be emulated, and may use a different
-floating-point environment to those defined by
-[code]#info::device::single_fp_config# and
-[code]#info::device::double_fp_config# (i.e. floating-point atomics may
-use different rounding modes and may have different exception behavior).
+The template parameter [code]#T# must be one of the following types:
+
+* [code]#int#,
+* [code]#unsigned int#,
+* [code]#long#,
+* [code]#unsigned long#,
+* [code]#long long#,
+* [code]#unsigned long long#,
+* [code]#float#, or
+* [code]#double#.
+
+In addition, the type [code]#T# must satisfy one of the following conditions:
+
+* [code]#sizeof(T) == 4#, or
+* [code]#sizeof(T) == 8# and the code containing this [code]#atomic_ref# was
+  submitted to a device that has [code]#aspect::atomic64#.
+
+For floating-point types, the member functions of the [code]#atomic_ref# class
+may be emulated, and they may use a different floating-point environment from
+those defined by [code]#info::device::single_fp_config# and
+[code]#info::device::double_fp_config# (i.e. floating-point atomics may use
+different rounding modes and may have different exception behavior).
+
+If the code using [code]#sycl::atomic_ref# is submitted to a device that has
+[code]#aspect::usm_atomic_host_allocations# or
+[code]#aspect::usm_atomic_shared_allocations#, then atomic operations in device
+code (using [code]#sycl::atomic_ref#) are guaranteed to be atomic with respect
+to atomic operations performed in host code (using [code]#std::atomic_ref#),
+when they operate on the same object and when the memory scope is
+[code]#memory_scope::system#.
 
 The atomic types are defined as follows.
 

--- a/adoc/headers/atomicref.h
+++ b/adoc/headers/atomicref.h
@@ -22,7 +22,7 @@ template <> struct memory_order_traits<memory_order::seq_cst> {
 };
 
 template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space Space = access::address_space::generic_space>
+          access::address_space AddressSpace = access::address_space::generic_space>
 class atomic_ref {
  public:
   using value_type = T;
@@ -76,8 +76,8 @@ class atomic_ref {
 
 // Partial specialization for integral types
 template <memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space Space = access::address_space::generic_space>
-class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
+          access::address_space AddressSpace = access::address_space::generic_space>
+class atomic_ref<Integral, DefaultOrder, DefaultScope, AddressSpace> {
 
   /* All other members from atomic_ref<T> are available */
 
@@ -120,8 +120,8 @@ class atomic_ref<Integral, DefaultOrder, DefaultScope, Space> {
 
 // Partial specialization for floating-point types
 template <memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space Space = access::address_space::generic_space>
-class atomic_ref<Floating, DefaultOrder, DefaultScope, Space> {
+          access::address_space AddressSpace = access::address_space::generic_space>
+class atomic_ref<Floating, DefaultOrder, DefaultScope, AddressSpace> {
 
   /* All other members from atomic_ref<T> are available */
 
@@ -149,8 +149,8 @@ class atomic_ref<Floating, DefaultOrder, DefaultScope, Space> {
 
 // Partial specialization for pointers
 template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space Space = access::address_space::generic_space>
-class atomic_ref<T*, DefaultOrder, DefaultScope, Space> {
+          access::address_space AddressSpace = access::address_space::generic_space>
+class atomic_ref<T*, DefaultOrder, DefaultScope, AddressSpace> {
 
   using value_type = T*;
   using difference_type = ptrdiff_t;


### PR DESCRIPTION
The main change in this commit is to limit `sycl::atomic_ref` to be used only in device code and to provide a guarantee that `std::atomic_ref` will be atomic w.r.t. `sycl::atomic_ref` when the device supports host-to-device atomics.  This follows our decision in internal issue 637.

It also provides some other clarifications:

* Describes the effect of the `AddressSpace` template parameter.
* Clarifies that the type `T` must either be 32-bits or 64-bits.  If it is 64-bits, the device must have `aspect::atomic64`.

It also removes a suggestion that the compiler should issue a diagnostic if device code calls `std::atomic` or `std::atomic_ref`.  It seems odd to provide this suggestion only for these two functions since the SYCL spec does not allow device code to call any standard C++ function.  If we want to provide a suggestion (or requirement) like this, I think it should be a more comprehensive statement about calling standard C++ functions in general from device code.

Closes internal issue 637.