### PR TITLE
Add single source single compiler pass (SSCP) to the glossary

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1681,6 +1681,7 @@ implementations need not follow the guidelines listed here.  However, this
 section is intended to help readers understand the possible strategies that can
 be used to implement SYCL.
 
+[[subsec:smcp]]
 === Single source multiple compiler passes
 
 With this technique, known as <<smcp>>, there are separate host and device
@@ -1722,13 +1723,15 @@ do not require a <<kernel-name>> at the invocation site, so they must implement
 some other way to make the association.
 
 
+[[subsec:sscp]]
 === Single source single compiler pass
 
-With this technique, the vendor implements a custom compiler that reads each
-SYCL source file only once, and that compiler generates the host code as well
-as the <<device-image, device images>> for the <<sycl-kernel-function,
-SYCL kernel functions>>.  As in the <<smcp>> case, each <<device-image>> could
-either contain native device ISA or an intermediate language.
+With this technique, known as <<sscp>>, the vendor implements a custom
+compiler that reads each SYCL source file only once, and that compiler
+generates the host code as well as the <<device-image, device images>>
+for the <<sycl-kernel-function, SYCL kernel functions>>.  As in the
+<<smcp>> case, each <<device-image>> could either contain native
+device ISA or an intermediate language.
 
 === Library-only implementation
 

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -432,14 +432,16 @@ object. For the full description please refer to <<subsec:buffers>>.
     be inlined, public and defaulted, none of them should be explicitly
     declared.
 
-[[smcp]]SMCP::
-    The single-source multiple compiler-passes (SMCP) technique allows a
-    single source file to be parsed by multiple compilers for building
-    native programs per compilation target. For example, a standard {cpp} CPU
-    compiler for targeting <<host>> will parse the <<sycl-file>> to
-    create the {cpp} <<sycl-application>> which offloads parts of the
-    computation to other <<device,devices>>. A SYCL device compiler will parse
-    the same source file and target only SYCL kernels.
+[[smcp]]SMCP:: The single-source multiple compiler-passes (SMCP)
+    technique allows a single-source file to be parsed by multiple
+    compilers for building native programs per compilation target. For
+    example, a standard {cpp} CPU compiler for targeting <<host>> will
+    parse the <<sycl-file>> to create the {cpp} <<sycl-application>>
+    which offloads parts of the computation to other
+    <<device,devices>>. A SYCL device compiler will parse the same
+    source file and target only SYCL kernels. For the full description
+    please refer to <<subsec:smcp>>.  See <<sscp>> for the dual
+    approach.
 
 [[specialization-constant]]specialization constant::
     A constant variable where the value is not known until compilation of
@@ -450,6 +452,16 @@ object. For the full description please refer to <<subsec:buffers>>.
     <<specialization-constant>> both in the <<sycl-application>> for setting
     the value prior to the compilation of a <<kernel-bundle>> and in a
     <<sycl-kernel-function>> for retrieving the value during invocation.
+
+[[sscp]]SSCP:: The single-source single compiler-pass (SSCP) technique
+    allows a single-source file to be parsed only once by a single
+    compiler. For example, the SYCL compiler will parse the
+    <<sycl-file>> once. Then, from this single intermediate
+    representation, for each kind of device architecture a compilation
+    flow will be generate the binary for each kernel and another
+    compilation flow will generate the <<host>> code of the {cpp}
+    <<sycl-application>>. For the full description please refer to
+    <<subsec:sscp>>. See <<smcp>> for the dual approach.
 
 [[string-kernel-name]]string kernel name::
     The name of a <<sycl-kernel-function>> in string form, this can be the

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -432,7 +432,8 @@ object. For the full description please refer to <<subsec:buffers>>.
     be inlined, public and defaulted, none of them should be explicitly
     declared.
 
-[[smcp]]SMCP:: The single-source multiple compiler-passes (SMCP)
+[[smcp]]SMCP::
+     The single-source multiple compiler-passes (SMCP)
     technique allows a single-source file to be parsed by multiple
     compilers for building native programs per compilation target. For
     example, a standard {cpp} CPU compiler for targeting <<host>> will
@@ -440,7 +441,7 @@ object. For the full description please refer to <<subsec:buffers>>.
     which offloads parts of the computation to other
     <<device,devices>>. A SYCL device compiler will parse the same
     source file and target only SYCL kernels. For the full description
-    please refer to <<subsec:smcp>>.  See <<sscp>> for the dual
+    please refer to <<subsec:smcp>>.  See <<sscp>> for another
     approach.
 
 [[specialization-constant]]specialization constant::
@@ -453,15 +454,16 @@ object. For the full description please refer to <<subsec:buffers>>.
     the value prior to the compilation of a <<kernel-bundle>> and in a
     <<sycl-kernel-function>> for retrieving the value during invocation.
 
-[[sscp]]SSCP:: The single-source single compiler-pass (SSCP) technique
+[[sscp]]SSCP::
+    The single-source single compiler-pass (SSCP) technique
     allows a single-source file to be parsed only once by a single
     compiler. For example, the SYCL compiler will parse the
     <<sycl-file>> once. Then, from this single intermediate
     representation, for each kind of device architecture a compilation
-    flow will be generate the binary for each kernel and another
+    flow will generate the binary for each kernel and another
     compilation flow will generate the <<host>> code of the {cpp}
     <<sycl-application>>. For the full description please refer to
-    <<subsec:sscp>>. See <<smcp>> for the dual approach.
+    <<subsec:sscp>>. See <<smcp>> for another approach.
 
 [[string-kernel-name]]string kernel name::
     The name of a <<sycl-kernel-function>> in string form, this can be the


### PR DESCRIPTION
Also add some links back to the subsections of SMCP and SSCP.