### PR TITLE
Fixed likely copy-paste error in native_vector_width section

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1894,7 +1894,7 @@ info::device::native_vector_width_half
 ----
 
     @ [.code]#uint32_t#
-   a@ Returns the native ISA vector width. The vector width is defined as the number of scalar elements that can be stored in the vector. Must return 0 for [code]#info::device::preferred_vector_width_double# if the [code]#device# does not have [code]#aspect::fp64# and must return 0 for  [code]#info::device::preferred_vector_width_half# if the [code]#device# does not have [code]#aspect::fp16#.
+   a@ Returns the native ISA vector width. The vector width is defined as the number of scalar elements that can be stored in the vector. Must return 0 for [code]#info::device::native_vector_width_double# if the [code]#device# does not have [code]#aspect::fp64# and must return 0 for  [code]#info::device::native_vector_width_half# if the [code]#device# does not have [code]#aspect::fp16#.
 
 a@
 [source]


### PR DESCRIPTION
The note accompanying `native_vector_width*` section of device descriptor table makes requirements about `preferred_vector_width*` rather than `native_vector_width*` descriptors.

This PR fixes that.