### PR TITLE
Add half to sycl::plus and sycl::multiplies

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12426,7 +12426,8 @@ sycl::plus
 a@
 [source]
 ----
-std::is_arithmetic_v<AccumulatorT>
+std::is_arithmetic_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>
 ----
 a@
 ----
@@ -12441,7 +12442,8 @@ sycl::multiplies
 a@
 [source]
 ----
-std::is_arithmetic_v<AccumulatorT>
+std::is_arithmetic_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>
 ----
 a@
 ----
@@ -12501,7 +12503,7 @@ sycl::logical_and
 a@
 [source]
 ----
-std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
 ----
 a@
 ----
@@ -12516,7 +12518,7 @@ sycl::logical_or
 a@
 [source]
 ----
-std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
 ----
 a@
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12503,7 +12503,7 @@ sycl::logical_and
 a@
 [source]
 ----
-std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
 ----
 a@
 ----
@@ -12518,7 +12518,7 @@ sycl::logical_or
 a@
 [source]
 ----
-std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>
+std::is_same_v<std::remove_v_t<AccumulatorT>, bool>
 ----
 a@
 ----


### PR DESCRIPTION
This commit add sycl::half to types with known identity for sycl::plus and sycl::multiplies.