### PR TITLE
Fix blocking accessor in example

### DIFF
--- a/adoc/code/algorithms.cpp
+++ b/adoc/code/algorithms.cpp
@@ -31,5 +31,5 @@ myQueue.submit([&](handler& cgh) {
   });
 });
 
-host_accessor a { inputBuf };
+host_accessor a { outputBuf };
 assert(a[0] == 523776 && a[1] == 120);

--- a/adoc/code/algorithms.cpp
+++ b/adoc/code/algorithms.cpp
@@ -31,5 +31,6 @@ myQueue.submit([&](handler& cgh) {
   });
 });
 
-assert(outputBuf.get_host_access()[0] == 523776 &&
-       outputBuf.get_host_access()[1] == 120);
+auto a = outputBuf.get_host_access();
+assert(a[0] == 523776 &&
+       a[1] == 120);

--- a/adoc/code/algorithms.cpp
+++ b/adoc/code/algorithms.cpp
@@ -31,6 +31,5 @@ myQueue.submit([&](handler& cgh) {
   });
 });
 
-auto a = outputBuf.get_host_access();
-assert(a[0] == 523776 &&
-       a[1] == 120);
+host_accessor a { inputBuf };
+assert(a[0] == 523776 && a[1] == 120);


### PR DESCRIPTION
Since `outputBuf`'s element type is `int`, the `host_accessor` created from `get_host_access()` will have `read_write` access mode. The assertion contains an expression creating two accessors such that

1. the first accessor will not be destructed until the end of the expression
2. since the second accessor is accessing the same buffer as the first, it will need to wait until the first accessor is destructed

and so no forward progress can be made.