### PR TITLE
Small clarification to generic address space

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -924,7 +924,9 @@ Work-items executing in a kernel have access to three distinct address spaces
     Attempting to access private memory in one work-item from another work-item
     results in undefined behavior.
   * <<generic-memory,Generic-memory>> is a virtual address space which overlaps the
-    global, local and private address spaces.
+    global, local and private address spaces. Therefore, an object that resides
+    in the global, local, or private address space can also be accessed through
+    the generic address space.
 
 ==== Access to memory
 


### PR DESCRIPTION
Clarify that objects in global, local, or private address space can also be accessed via the generic address space.