### PR TITLE
Fix typo "kernel::get_info"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -15474,6 +15474,7 @@ There is no public default constructor for this class.
 include::{header_dir}/bundle/kernelClass.h[lines=4..-1]
 ----
 
+[[sec:kernel.query]]
 ==== Queries
 
 The following member functions provide various queries for a <<kernel>>.
@@ -19940,7 +19941,7 @@ Using a group function inside of a kernel may introduce additional
 limits on the resources available to user code inside the same kernel.  The
 behavior of these limits is implementation-defined, but must be reflected by
 calls to kernel querying functions (such as
-[code]#kernel_bundle::get_kernel_info)# as described in <<sec:bundles.query>>.
+[code]#kernel::get_info#) as described in <<sec:kernel.query>>.
 
 It is undefined behavior for any group function to be invoked within a
 [code]#parallel_for_work_group# or [code]#parallel_for_work_item#


### PR DESCRIPTION
Fix a typo in the introduction to the group functions.  There is no function named `kernel_bundle::get_kernel_info`.  We meant `kernel::get_info`.

Partially addresses #376