### PR TITLE
Disallow "++" and "--" for "vec<bool>"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16886,7 +16886,9 @@ a@
 ----
 vec& operatorOP(vec& v)
 ----
-   a@ Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and return [code]#lhs# [code]#vec#.
+   a@ Available only when: [code]#DataT != bool#.
+
+Perform an in-place element-wise [code]#OP# prefix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and return [code]#lhs# [code]#vec#.
 
 Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 
@@ -16895,7 +16897,9 @@ a@
 ----
 vec operatorOP(vec& v, int)
 ----
-   a@ Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and returns a copy of [code]#lhs# [code]#vec# before the operation is performed.
+   a@ Available only when: [code]#DataT != bool#.
+
+Perform an in-place element-wise [code]#OP# postfix arithmetic operation on each element of [code]#lhs# [code]#vec#, assigning the result of each element to the corresponding element of [code]#lhs# [code]#vec# and returns a copy of [code]#lhs# [code]#vec# before the operation is performed.
 
 Where [code]#OP# is: [code]#pass:[++]#, [code]#--#.
 

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -134,10 +134,12 @@ template <typename DataT, int NumElements> class vec {
   }
 
   // OP is prefix ++, --
+  // Available only when: DataT != bool
   friend vec& operatorOP(vec& rhs) { /* ... */
   }
 
   // OP is postfix ++, --
+  // Available only when: DataT != bool
   friend vec operatorOP(vec& lhs, int) { /* ... */
   }
 


### PR DESCRIPTION
This issue was raised by the Intel contractors who are writing CTS tests.

C++17 does not allow `++` or `--` (either prefix or postfix) for the `bool` type, so presumably we do not want to allow these operators in SYCL for the `vec<bool>` type either.  This change marks these operators as disallowed.

C++ *does* allow other arithmetic and bitwise operators on `bool`, so we do *not* disallow any of these operators on `vec<bool>`.  By following normal C++ rules, `bool` is promoted to `int` for these operators.  Therefore, an operation like
`vec &operator+=(vec&, const vec&)` would first promote each element of the operands to `int`, perform the operation, and then use "boolean conversion" to convert the result back to `bool`.

I did not make any equivalent change to `marray` because the change required there is larger in scope.  See internal issue 559 for more details.