### PR TITLE
Clarify "is_compatible"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14999,7 +14999,12 @@ application is compatible with a device unless:
   in <<sec:optional-kernel-features>>; or
 * It is decorated with a [code]#[[sycl::device_has()]]# {cpp} attribute that
   lists an aspect that is not supported by the device, as described in
-  <<sec:kernel.attributes>>.
+  <<sec:kernel.attributes>>; or
+* The translation unit containing the kernel was compiled in a compilation
+  environment that does not support the device.  Each implementation defines
+  the specific criteria for which devices are supported in its compilation
+  environment.  For example, this might be dependent on options passed to the
+  compiler.
 
 A device built-in kernel is only compatible with the device for which it is
 built-in.


### PR DESCRIPTION
This PR addresses an issue that was raised during the review of KhronosGroup/SYCL-CTS#553.  It is also related to the clarification made in #370.

When we clarified the semantics of `any_device_has` and `all_devices_have`, we decided that these tell information about the "compilation environment" used to compile the SYCL translation unit. This implies that kernels in a TU might not be compatible with some devices depending on the "compilation environment".  For example, a vendor's compiler might support some compiler flag that allows kernels to run on GPU devices but not on other devices.

While writing the CTS, we realized that applications need some way to tell if a kernel was compiled in a way that restricts the devices on which it can run.  It seems like the existing API `is_compatible` is a good fit, so this PR extends the semantics to say that this API also considers the "compilation environment" when determining compatibility.
