### PR TITLE
Clarify queries for memory scope / order caps

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1033,10 +1033,9 @@ The meanings of these values are identical to those defined in the {cpp} core
 language.
 
 The complete set of memory orders is not guaranteed to be supported by every
-device, nor across all combinations of devices within a context.  The memory
-orders supported by a specific device and context can be queried using
-functionalities of the [code]#sycl::device# and [code]#sycl::context# classes,
-respectively.
+device, nor across all combinations of devices within a context.  The set of
+supported memory orders can be queried via the information descriptors for the
+[code]#sycl::device# and [code]#sycl::context# classes.
 
 [NOTE]
 ====
@@ -1071,6 +1070,10 @@ values:
     work-item or host thread in the system that is currently permitted to
     access the memory allocation containing the referenced object, as
     defined by the capabilities of <<buffer,buffers>> and <<usm>>.
+
+The complete set of memory scopes is not guaranteed to be supported by every
+device.  The set of supported memory scopes can be queried via the information
+descriptors for the [code]#sycl::device# and [code]#sycl::context# classes.
 
 The broadest scope that can be applied to an atomic operation corresponds to
 the set of work-items which can access the associated memory location.  For

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1012,6 +1012,7 @@ supporting concurrent atomic accesses to USM allocations and acquire-release or 
 consistent memory orderings, cross-device memory consistency can be
 enforced through the use of <<mem-fence>> and atomic operations.
 
+[[sec:memory-ordering]]
 ==== Memory ordering
 
 [source,,linenums]
@@ -1032,6 +1033,9 @@ values:
 The meanings of these values are identical to those defined in the {cpp} core
 language.
 
+These memory orders are listed above from weakest
+([code]#memory_order::relaxed#) to strongest ([code]#memory_order::seq_cst#).
+
 The complete set of memory orders is not guaranteed to be supported by every
 device, nor across all combinations of devices within a context.  The set of
 supported memory orders can be queried via the information descriptors for the
@@ -1045,6 +1049,7 @@ device kernel results in undefined behavior. Developers are encouraged to use
 [code]#sycl::memory_order::acquire# instead.
 ====
 
+[[sec:memory-scope]]
 ==== Memory scope
 
 [source,,linenums]
@@ -1071,15 +1076,18 @@ values:
     access the memory allocation containing the referenced object, as
     defined by the capabilities of <<buffer,buffers>> and <<usm>>.
 
+The memory scopes are listed above from narrowest
+([code]#memory_scope::work_item#) to widest ([code]#memory_scope::system#).
+
 The complete set of memory scopes is not guaranteed to be supported by every
 device.  The set of supported memory scopes can be queried via the information
 descriptors for the [code]#sycl::device# and [code]#sycl::context# classes.
 
-The broadest scope that can be applied to an atomic operation corresponds to
+The widest scope that can be applied to an atomic operation corresponds to
 the set of work-items which can access the associated memory location.  For
-example, the broadest scope that can be applied to atomic operations in
+example, the widest scope that can be applied to atomic operations in
 work-group local memory is [code]#sycl::memory_scope::work_group#.  If a
-broader scope is supplied, the behavior is as-if the narrowest scope containing
+wider scope is supplied, the behavior is as-if the narrowest scope containing
 all work-items which can access the associated memory location was supplied.
 
 [NOTE]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1037,7 +1037,7 @@ These memory orders are listed above from weakest
 ([code]#memory_order::relaxed#) to strongest ([code]#memory_order::seq_cst#).
 
 The complete set of memory orders is not guaranteed to be supported by every
-device, nor across all combinations of devices within a context.  The set of
+device, nor across all combinations of devices within a platform.  The set of
 supported memory orders can be queried via the information descriptors for the
 [code]#sycl::device# and [code]#sycl::context# classes.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1428,9 +1428,11 @@ info::context::atomic_memory_order_capabilities
 
 Returns the set of memory orders supported by these atomic operations.  When a
 context returns a "stronger" memory order in this set, it must also return all
-"weaker" memory orders.  The memory orders [code]#memory_order::acquire#,
-[code]#memory_order::release#, and [code]#memory_order::acq_rel# are all the
-same strength.  If a context returns one of these, it must return them all.
+"weaker" memory orders.  (See <<sec:memory-ordering>> for a definition of
+"stronger" and "weaker" memory orders.) The memory orders
+[code]#memory_order::acquire#, [code]#memory_order::release#, and
+[code]#memory_order::acq_rel# are all the same strength.  If a context returns
+one of these, it must return them all.
 
 At a minimum, each context must support [code]#memory_order::relaxed#.
 
@@ -1449,7 +1451,8 @@ info::context::atomic_fence_order_capabilities
 
 Returns the set of memory orders supported by these [code]#atomic_fence#
 operations.  When a context returns a "stronger" memory order in this set, it
-must also return all "weaker" memory orders.
+must also return all "weaker" memory orders.  (See <<sec:memory-ordering>> for
+a definition of "stronger" and "weaker" memory orders.)
 
 At a minimum, each context must support [code]#memory_order::relaxed#,
 [code]#memory_order::acquire#, [code]#memory_order::release#, and
@@ -1464,8 +1467,9 @@ info::context::atomic_memory_scope_capabilities
     @ [.code]#std::vector<memory_scope>#
    a@ Returns the set of memory scopes supported by atomic operations on all
       devices in the context.  When a context returns a "wider" memory scope
-      in this set, it must also return all "narrower" memory scopes.  At a
-      minimum, each context must support [code]#memory_scope::work_item#,
+      in this set, it must also return all "narrower" memory scopes.  (See
+      <<sec:memory-scope>> for a definition of "wider" and "narrower" scopes.)
+      At a minimum, each context must support [code]#memory_scope::work_item#,
       [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
@@ -1477,9 +1481,11 @@ info::context::atomic_fence_scope_capabilities
     @ [.code]#std::vector<memory_scope>#
    a@ Returns the set of memory orderings supported by [code]#atomic_fence# on
       all devices in the context.  When a context returns a "wider" memory
-      scope in this set, it must also return all "narrower" memory scopes.  At
-      a minimum, each context must support [code]#memory_scope::work_item#,
-      [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
+      scope in this set, it must also return all "narrower" memory scopes.
+      (See <<sec:memory-scope>> for a definition of "wider" and "narrower"
+      scopes.) At a minimum, each context must support
+      [code]#memory_scope::work_item#, [code]#memory_scope::sub_group#, and
+      [code]#memory_scope::work_group#.
 
 |====
 
@@ -2273,10 +2279,12 @@ info::device::atomic_memory_order_capabilities
     @ [.code]#std::vector<memory_order>#
    a@ Returns the set of memory orders supported by atomic operations on the
       device.  When a device returns a "stronger" memory order in this set, it
-      must also return all "weaker" memory orders.  The memory orders
-      [code]#memory_order::acquire#, [code]#memory_order::release#, and
-      [code]#memory_order::acq_rel# are all the same strength.  If a device
-      returns one of these, it must return them all.
+      must also return all "weaker" memory orders.  (See
+      <<sec:memory-ordering>> for a definition of "stronger" and "weaker"
+      memory orders.) The memory orders [code]#memory_order::acquire#,
+      [code]#memory_order::release#, and [code]#memory_order::acq_rel# are all
+      the same strength.  If a device returns one of these, it must return them
+      all.
 
 At a minimum, each device must support [code]#memory_order::relaxed#.
 
@@ -2289,10 +2297,11 @@ info::device::atomic_fence_order_capabilities
     @ [.code]#std::vector<memory_order>#
    a@ Returns the set of memory orders supported by [code]#atomic_fence# on
       the device.  When a device returns a "stronger" memory order in this set,
-      it must also return all "weaker" memory orders.  At a minimum, each
-      device must support [code]#memory_order::relaxed#,
-      [code]#memory_order::acquire#, [code]#memory_order::release#, and
-      [code]#memory_order::acq_rel#.
+      it must also return all "weaker" memory orders.  (See
+      <<sec:memory-ordering>> for a definition of "stronger" and "weaker"
+      memory orders.) At a minimum, each device must support
+      [code]#memory_order::relaxed#, [code]#memory_order::acquire#,
+      [code]#memory_order::release#, and [code]#memory_order::acq_rel#.
 
 a@
 [source]
@@ -2303,8 +2312,9 @@ info::device::atomic_memory_scope_capabilities
     @ [.code]#std::vector<memory_scope>#
    a@ Returns the set of memory scopes supported by atomic operations on the
       device.  When a device returns a "wider" memory scope in this set, it
-      must also return all "narrower" memory scopes.  At a minimum, each device
-      must support [code]#memory_scope::work_item#,
+      must also return all "narrower" memory scopes.  (See <<sec:memory-scope>>
+      for a definition of "wider" and "narrower" scopes.) At a minimum, each
+      device must support [code]#memory_scope::work_item#,
       [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
@@ -2316,8 +2326,9 @@ info::device::atomic_fence_scope_capabilities
     @ [.code]#std::vector<memory_scope>#
    a@ Returns the set of memory scopes supported by [code]#atomic_fence# on the
       device.  When a device returns a "wider" memory scope in this set, it
-      must also return all "narrower" memory scopes.  At a minimum, each device
-      must support [code]#memory_scope::work_item#,
+      must also return all "narrower" memory scopes.  (See <<sec:memory-scope>>
+      for a definition of "wider" and "narrower" scopes.)  At a minimum, each
+      device must support [code]#memory_scope::work_item#,
       [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
@@ -20072,7 +20083,7 @@ object.
 By default, the scope of these fences is set to the narrowest
 scope including all work-items in group [code]#g# (as reported by
 [code]#Group::fence_scope#).  This scope may be optionally overridden
-with a broader scope, specified by the [code]#fence_scope# argument.
+with a wider scope, specified by the [code]#fence_scope# argument.
 --
 
 [[sec:algorithms]]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1420,11 +1420,19 @@ info::context::atomic_memory_order_capabilities
 ----
 
     @ [.code]#std::vector<memory_order>#
-   a@ Returns the set of memory orderings supported by atomic operations on all
-      devices in the context, which is guaranteed to include [code]#relaxed#.
+   a@ This query applies only to the capabilities of atomic operations that are
+      applied to memory that can be concurrently accessed by multiple devices
+      in the context.  If these capabilities are not uniform across all devices
+      in the context, the query reports only the capabilities that are common
+      for all devices.
 
-The memory ordering of the context determines the behavior of atomic operations applied
-to any memory that can be concurrently accessed by multiple devices in the context.
+Returns the set of memory orders supported by these atomic operations.  When a
+context returns a "stronger" memory order in this set, it must also return all
+"weaker" memory orders.  The memory orders [code]#memory_order::acquire#,
+[code]#memory_order::release#, and [code]#memory_order::acq_rel# are all the
+same strength.  If a context returns one of these, it must return them all.
+
+At a minimum, each context must support [code]#memory_order::relaxed#.
 
 a@
 [source]
@@ -1433,12 +1441,19 @@ info::context::atomic_fence_order_capabilities
 ----
 
     @ [.code]#std::vector<memory_order>#
-   a@ Returns the set of memory orderings supported by [code]#atomic_fence#
-      on all devices in the context, which is guaranteed to include
-      [code]#relaxed#, [code]#acquire#, [code]#release# and [code]#acq_rel#.
+   a@ This query applies only to the capabilities of [code]#atomic_fence# when
+      applied to memory that can be concurrently accessed by multiple devices
+      in the context.  If these capabilities are not uniform across all devices
+      in the context, the query reports only the capabilities that are common
+      for all devices.
 
-The memory ordering of the context determines the behavior of fence operations applied
-to any memory that can be concurrently accessed by multiple devices in the context.
+Returns the set of memory orders supported by these [code]#atomic_fence#
+operations.  When a context returns a "stronger" memory order in this set, it
+must also return all "weaker" memory orders.
+
+At a minimum, each context must support [code]#memory_order::relaxed#,
+[code]#memory_order::acquire#, [code]#memory_order::release#, and
+[code]#memory_order::acq_rel#.
 
 a@
 [source]
@@ -1447,7 +1462,11 @@ info::context::atomic_memory_scope_capabilities
 ----
 
     @ [.code]#std::vector<memory_scope>#
-   a@ Returns the set of memory scopes supported by atomic operations on all devices in the context, which is guaranteed to include [code]#work_group#.
+   a@ Returns the set of memory scopes supported by atomic operations on all
+      devices in the context.  When a context returns a "wider" memory scope
+      in this set, it must also return all "narrower" memory scopes.  At a
+      minimum, each context must support [code]#memory_scope::work_item#,
+      [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
 [source]
@@ -1456,7 +1475,11 @@ info::context::atomic_fence_scope_capabilities
 ----
 
     @ [.code]#std::vector<memory_scope>#
-   a@ Returns the set of memory orderings supported by [code]#atomic_fence# on all devices in the context, which is guaranteed to include [code]#work_group#.
+   a@ Returns the set of memory orderings supported by [code]#atomic_fence# on
+      all devices in the context.  When a context returns a "wider" memory
+      scope in this set, it must also return all "narrower" memory scopes.  At
+      a minimum, each context must support [code]#memory_scope::work_item#,
+      [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 |====
 
@@ -2248,8 +2271,14 @@ info::device::atomic_memory_order_capabilities
 ----
 
     @ [.code]#std::vector<memory_order>#
-   a@ Returns the set of memory orderings supported by atomic operations on the device,
-      which is guaranteed to include [code]#relaxed#.
+   a@ Returns the set of memory orders supported by atomic operations on the
+      device.  When a device returns a "stronger" memory order in this set, it
+      must also return all "weaker" memory orders.  The memory orders
+      [code]#memory_order::acquire#, [code]#memory_order::release#, and
+      [code]#memory_order::acq_rel# are all the same strength.  If a device
+      returns one of these, it must return them all.
+
+At a minimum, each device must support [code]#memory_order::relaxed#.
 
 a@
 [source]
@@ -2258,9 +2287,12 @@ info::device::atomic_fence_order_capabilities
 ----
 
     @ [.code]#std::vector<memory_order>#
-   a@ Returns the set of memory orderings supported by [code]#atomic_fence# on the device,
-      which is guaranteed to include [code]#relaxed#, [code]#acquire#,
-      [code]#release# and [code]#acq_rel#.
+   a@ Returns the set of memory orders supported by [code]#atomic_fence# on
+      the device.  When a device returns a "stronger" memory order in this set,
+      it must also return all "weaker" memory orders.  At a minimum, each
+      device must support [code]#memory_order::relaxed#,
+      [code]#memory_order::acquire#, [code]#memory_order::release#, and
+      [code]#memory_order::acq_rel#.
 
 a@
 [source]
@@ -2269,8 +2301,11 @@ info::device::atomic_memory_scope_capabilities
 ----
 
     @ [.code]#std::vector<memory_scope>#
-   a@ Returns the set of memory scopes supported by atomic operations on the device,
-      which is guaranteed to include [code]#work_group#.
+   a@ Returns the set of memory scopes supported by atomic operations on the
+      device.  When a device returns a "wider" memory scope in this set, it
+      must also return all "narrower" memory scopes.  At a minimum, each device
+      must support [code]#memory_scope::work_item#,
+      [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
 [source]
@@ -2279,8 +2314,11 @@ info::device::atomic_fence_scope_capabilities
 ----
 
     @ [.code]#std::vector<memory_scope>#
-   a@ Returns the set of memory scopes supported by [code]#atomic_fence# on the device,
-      which is guaranteed to include [code]#work_group#.
+   a@ Returns the set of memory scopes supported by [code]#atomic_fence# on the
+      device.  When a device returns a "wider" memory scope in this set, it
+      must also return all "narrower" memory scopes.  At a minimum, each device
+      must support [code]#memory_scope::work_item#,
+      [code]#memory_scope::sub_group#, and [code]#memory_scope::work_group#.
 
 a@
 [source]


### PR DESCRIPTION
This change clarifies some questions that arose during implementation in DPC++.

* Clarify that the query operations for supported memory scopes must return all "narrower" scopes when a "wider" scope is supported.  For example, if the device supports `memory_scope::sub_group` it must also support `memory_scope::work_item`.  This matches the OpeCL queries, which also returns all "narrower" scopes.

* Clarify that the query operations for supported memory orders must return all "weaker" orders when a "stronger" order is supported. Again, this matches OpenCL.

* Clarify in the architecture chapter that a device does not need to support every memory scope.  We said this for memory orders, but not for memory scopes.

* Clarify the wording for `context::atomic_memory_order_capabilities` and `context::atomic_fence_order_capabilities`.  These provide information about memory orders for *inter-device* operations, which could be a subset of the memory orders supported for operations within the device.  We said this before, but more tersely.