### PR TITLE
Closes gh-383, corrects description of partition_type_property

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2595,7 +2595,7 @@ info::device::partition_type_property
 ----
 
     @ [.code]#info::partition_property#
-   a@ Returns the partition property of this SYCL [code]#device#. If this SYCL [code]#device# is not a sub device then the return value must be [code]#info::partition_property::no_partition#, otherwise it must be one of the following values:
+   a@ Returns the partition property of this SYCL [code]#device#. If this SYCL [code]#device# can not be partitioned any further then the return value must be [code]#info::partition_property::no_partition#, otherwise it must be one of the following values:
 --
   * [code]#info::partition_property::partition_equally#
   * [code]#info::partition_property::partition_by_counts#


### PR DESCRIPTION
Closes gh-383, corrects description of ``info::device::partition_type_property`` in correcting the condition when the value of the descriptor must be ``info::partition_property::no_partition``.