### PR TITLE
Clarify is_group and bool_constant alias relations

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19979,12 +19979,13 @@ The [code]#is_group# type trait is used to determine which types of groups are
 supported by group functions, and to control when group functions participate
 in overload resolution.
 
-[code]#is_group<T># is [code]#std::true_type# if [code]#T# is the type of a
-standard SYCL group ([code]#group# or [code]#sub_group#) and
-[code]#std::false_type# otherwise.  A SYCL implementation may introduce
-additional specializations of [code]#is_group<T># for implementation-defined
-group types, if the interface of those types supports all member functions and
-static members common to the [code]#group# and [code]#sub_group# classes.
+[code]#is_group<T># inherits from [code]#std::true_type# if [code]#T# is the
+type of a standard SYCL group ([code]#group# or [code]#sub_group#) and it
+inherits from [code]#std::false_type# otherwise.  A SYCL implementation may
+introduce additional specializations of [code]#is_group<T># for
+implementation-defined group types, if the interface of those types supports all
+member functions and static members common to the [code]#group# and
+[code]#sub_group# classes.
 
 ==== [code]#group_broadcast#
 


### PR DESCRIPTION
This commit changes the wording for `is_group` to specify that it inherits from `std::true_type` or `std::false_type`, instead of stating that they are the same. This is in line with other traits in the specification.