### PR TITLE
Add missing accessor deduction tags to syntax highlighting

### DIFF
--- a/adoc/config/rouge/lib/rouge/lexers/sycl.rb
+++ b/adoc/config/rouge/lib/rouge/lexers/sycl.rb
@@ -500,7 +500,11 @@ module Rouge
         memory_scope_work_item
         no_init
         read_only
+        read_only_host_task
+        read_write
+        read_write_host_task
         write_only
+        write_only_host_task
       )
 
       # Here are some interesting tokens


### PR DESCRIPTION
Add missing tags from "4.7.6.3. Deduction tags" section. https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_deduction_tags