### PR TITLE
[SYCL] Modify signature of `async_work_group_copy` in `nd_item` and `group` 

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11881,7 +11881,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<DataT> src,
+                                   decorated_global_ptr<const DataT> src,
                                    size_t numElements) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -11894,7 +11894,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<DataT> src,
+                                   decorated_local_ptr<const DataT> src,
                                    size_t numElements) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -11907,7 +11907,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<DataT> src,
+                                   decorated_global_ptr<const DataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -11921,7 +11921,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<DataT> src,
+                                   decorated_local_ptr<const DataT> src,
                                    size_t numElements, size_t destStride) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -12357,7 +12357,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<DataT> src,
+                                   decorated_global_ptr<const DataT> src,
                                    size_t numElements) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -12370,7 +12370,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<DataT> src,
+                                   decorated_local_ptr<const DataT> src,
                                    size_t numElements) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -12383,7 +12383,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<DataT> src,
+                                   decorated_global_ptr<const DataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.
@@ -12397,7 +12397,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<DataT> src,
+                                   decorated_local_ptr<const DataT> src,
                                    size_t numElements, size_t destStride) const
 ----
    a@ Permitted types for [code]#DataT# are all scalar and vector types.

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -51,23 +51,23 @@ template <int Dimensions = 1> class group {
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<DataT> src,
+                                     decorated_global_ptr<const DataT> src,
                                      size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<DataT> src,
+                                     decorated_local_ptr<const DataT> src,
                                      size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<DataT> src,
+                                     decorated_global_ptr<const DataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<DataT> src,
+                                     decorated_local_ptr<const DataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -49,23 +49,23 @@ template <int Dimensions = 1> class nd_item {
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<DataT> src,
+                                     decorated_global_ptr<const DataT> src,
                                      size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<DataT> src,
+                                     decorated_local_ptr<const DataT> src,
                                      size_t numElements) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<DataT> src,
+                                     decorated_global_ptr<const DataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
   template <typename DataT>
   device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<DataT> src,
+                                     decorated_local_ptr<const DataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 


### PR DESCRIPTION
Currently the source argument in `async_work_group_copy` of `nd_item` and `group` shares the same type with destination for their corresponding `multi_ptr` types.  Ideally The source should be declared as a `multi_ptr<const>` type.
Apart from above reasoning, I faced an issue on an attempt to update `accessor::get_pointer/accessor::get_multi_ptr`  to conform to the specifications in [PR-8874](https://github.com/intel/llvm/pull/8874).
An `access::mode::read` specialised accessor should return a  `multi_ptr<const DataT>` on call to `get_multi_ptr`. If the created `multi_ptr` is needed for a call to `async_work_group_copy` it requires an undesired conversion of `multi_ptr<const DataT>` to `multi_ptr<DataT>`.

This PR defines source of `async_work_group_copy` as a `multi_ptr<const DataT>` to address both conceptual and technical issues mentioned.

