### PR TITLE
Fix table link in the description of platform::get_info()

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1118,7 +1118,7 @@ template <typename Param> typename Param::return_type get_info() const
    a@ Queries this SYCL [code]#platform# for information requested by
       the template parameter [code]#Param#.
       The type alias [code]#Param::return_type# must be defined in
-      accordance with the info parameters in <<table.device.info>> to
+      accordance with the info parameters in <<table.platform.info>> to
       facilitate returning the type associated with the [code]#Param#
       parameter.
 


### PR DESCRIPTION
Hi @keryell,

I continued reading... :-P

Regarding the implementation of information descriptors, by reading different parts of the standard, you can put together that the general layout should read something like:
`struct Param { using return_type = ...; };`.

The different parts that let you deduce so, are:

1) the interfaces in appendix A;

2) the changelog in appendix D.1:
"`param_traits` has been removed and the return type of an information query is now contained in the descriptor.";

3) and the descriptions for `get_info()`:
"The type alias `Param::return_type` must be defined in accordance with the info parameters in...".

What do you think of making this slightly more obvious/explicit?

Cheers
-Nuno
