### PR TITLE
Add missing noexcept to sampled_image member functions

### DIFF
--- a/adoc/headers/sampledImage.h
+++ b/adoc/headers/sampledImage.h
@@ -49,9 +49,9 @@ class sampled_image {
   /* Available only when: Dimensions > 1 */
   range<Dimensions - 1> get_pitch() const;
 
-  size_t byte_size() const;
+  size_t byte_size() const noexcept;
 
-  size_t size() const;
+  size_t size() const noexcept;
 
   template <typename DataT, image_target Targ = image_target::device>
   sampled_image_accessor<DataT, Dimensions, Targ>


### PR DESCRIPTION
The `byte_size` and `size` member functions in `sampled_image` are `noexcept` in the description but are not in the class declaration. This commit adds the missing `noexcept` to the class declaration, which seems to be the intention given other classes with these member functions have the same.