### PR TITLE
Clarify wording where people were misinterpreting requirement

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -177,7 +177,7 @@ these restrictions:
     <<device-function>>.
   * Variables with static storage duration that are odr-used inside a
     <<device-function>>, must be either [code]#const#
-    or [code]#constexpr#, and must simultaneously be either
+    or [code]#constexpr#, and must also be either
     zero-initialized or constant-initialized.
 
 [NOTE]

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -176,8 +176,9 @@ these restrictions:
     storage class specifier) are not allowed to be odr-used in a
     <<device-function>>.
   * Variables with static storage duration that are odr-used inside a
-    <<device-function>>, must be [code]#const#
-    or [code]#constexpr# and zero-initialized or constant-initialized.
+    <<device-function>>, must be either [code]#const#
+    or [code]#constexpr#, and must simultaneously be either
+    zero-initialized or constant-initialized.
 
 [NOTE]
 ====


### PR DESCRIPTION
Clarify wording where people were misinterpreting order of grouping in the expression.  Make clear that two conditions exist, with two options for each condition