### PR TITLE
Relax exception requirement for placeholder capture

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6554,10 +6554,16 @@ yet bound to a <<command-group>>.  Before such an accessor can be used in a
 <<command>>, it must be bound by calling [code]#handler::require()#.  If a
 placeholder accessor is passed as an argument to a <<command>> without first
 being bound to a <<command-group>> with [code]#handler::require()#, the
-implementation throws a synchronous [code]#exception# with the
-[code]#errc::kernel_argument# error code when the <<command>> is submitted.
+implementation may throw a synchronous [code]#exception# with the
+[code]#errc::kernel_argument# error code when the <<command>> is submitted. If
+the implementation does not throw an synchronous [code]#exception# upon
+<<command>> submission, an asynchronous [code]#exception# will be thrown during
+the execution of the <<command>> if it calls any of the member functions stating
+so (see <<sec:accessors.command.buffer.interface>> and
+<<sec:accessor.common.members>>.)
 
 
+[[sec:accessors.command.buffer.interface]]
 ===== Interface for buffer command accessors
 
 A synopsis of the [code]#accessor# class is provided below, showing the
@@ -6918,6 +6924,11 @@ accessor_ptr<IsDecorated> get_multi_ptr() const noexcept
 
 This function may only be called from within a <<command>>.
 
+A <<command>> calling this function will throw an asynchronous
+[code]#exception# with [code]#exception#errc::kernel_argument# if this is a
+placeholder accessor that has not been bound to a <<command>> by calling
+[code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -6931,6 +6942,11 @@ Assignment to the single element that is accessed by this accessor.
 
 This function may only be called from within a <<command>>.
 
+A <<command>> calling this function will throw an asynchronous
+[code]#exception# with [code]#exception#errc::kernel_argument# if this is a
+placeholder accessor that has not been bound to a <<command>> by calling
+[code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -6943,6 +6959,11 @@ const accessor& operator=(value_type&& other) const
 Assignment to the single element that is accessed by this accessor.
 
 This function may only be called from within a <<command>>.
+
+A <<command>> calling this function will throw an asynchronous
+[code]#exception# with [code]#exception#errc::kernel_argument# if this is a
+placeholder accessor that has not been bound to a <<command>> by calling
+[code]#handler::require()#.
 
 |====
 
@@ -7078,6 +7099,7 @@ size_t get_count() const
 |====
 
 
+[[sec:accessor.command.buffer.constant.specialization]]
 ====== Accessor specialization with [code]#target::constant_buffer#
 
 The [code]#accessor# class may be specialized with target
@@ -7099,9 +7121,14 @@ This accessor type can be constructed as a "placeholder" accessor.  As with
 other [code]#accessor# specializations that are placeholders,
 [code]#handler::require()# must be called before passing a placeholder accessor
 to a <<command>>.  If the application neglects to call
-[code]#handler::require()# on a placeholder accessor, the implementation throws
-a synchronous [code]#exception# with the [code]#errc::kernel_argument# error
-code when the <<command>> is submitted.
+[code]#handler::require()# on a placeholder accessor, the implementation may
+throw a synchronous [code]#exception# with the [code]#errc::kernel_argument#
+error code when the <<command>> is submitted. If the implementation does not
+throw an synchronous [code]#exception# upon <<command>> submission, an
+asynchronous [code]#exception# will be thrown during the execution of the
+<<command>> if it calls any of the member functions stating so (see
+<<sec:accessor.command.buffer.constant.specialization>> and
+<<sec:accessor.deprecated.common.members>>.)
 
 A synopsis for this specialization of [code]#accessor# is provided below.
 Since some of the class types and member functions have the same name and
@@ -7293,6 +7320,13 @@ constant_ptr<DataT> get_pointer() const noexcept
       buffer, even if this is a <<ranged-accessor>> whose range does not start
       at the beginning of the buffer.  The return value is unspecified if the
       accessor is empty.
+
+This function may only be called from within a <<command>>.
+
+A <<command>> calling this function will throw an asynchronous
+[code]#exception# with [code]#exception#errc::kernel_argument# if this is a
+placeholder accessor that has not been bound to a <<command>> by calling
+[code]#handler::require()#.
 
 |====
 
@@ -7523,6 +7557,8 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing.
 
+This function may only be called from within a <<command>>.
+
 a@
 [source]
 ----
@@ -7536,6 +7572,8 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing, at the index specified by [code]#index#.
 
+This function may only be called from within a <<command>>.
+
 a@
 [source]
 ----
@@ -7548,6 +7586,8 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing, at the index specified by [code]#index#.
 
+This function may only be called from within a <<command>>.
+
 a@
 [source]
 ----
@@ -7556,6 +7596,8 @@ local_ptr<DataT> get_pointer() const noexcept
    a@ Returns a [code]#multi_ptr# to the work-group's local memory allocation
       that this accessor is accessing.  The return value is unspecified if the
       accessor is empty.
+
+This function may only be called from within a <<command>>.
 
 |====
 
@@ -7669,6 +7711,15 @@ When [code]#AccessTarget# is [code]#target::local#, available only when
 
 Returns a reference to the single element that is accessed by this accessor.
 
+When [code]#AccessTarget# is [code]#target::local# or [code]#target::constant#,
+this function may only be called from within a <<command>>.
+
+When [code]#AccessTarget# is [code]#target::constant# or
+[code]#target::constant#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -7684,6 +7735,15 @@ When [code]#AccessTarget# is [code]#target::local#, available only when
 Returns a reference to the element at the location specified by [code]#index#.
 If this is a <<ranged-accessor>>, the element is determined by adding
 [code]#index# to the accessor's offset.
+
+When [code]#AccessTarget# is [code]#target::local# or [code]#target::constant#,
+this function may only be called from within a <<command>>.
+
+When [code]#AccessTarget# is [code]#target::constant# or
+[code]#target::constant#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -7702,6 +7762,15 @@ appropriate for the type it represents (including this subscript operator).
 If this is a <<ranged-accessor>>, the implicit [code]#id# in the returned
 instance also includes the accessor's offset.
 
+When [code]#AccessTarget# is [code]#target::local# or [code]#target::constant#,
+this function may only be called from within a <<command>>.
+
+When [code]#AccessTarget# is [code]#target::constant# or
+[code]#target::constant#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -7717,6 +7786,15 @@ When [code]#AccessTarget# is [code]#target::local#, available only when
 Returns a reference to the element at the location specified by [code]#index#.
 If this is a <<ranged-accessor>>, the element is determined by adding
 [code]#index# to the accessor's offset.
+
+When [code]#AccessTarget# is [code]#target::local# or [code]#target::constant#,
+this function may only be called from within a <<command>>.
+
+When [code]#AccessTarget# is [code]#target::constant# or
+[code]#target::constant#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 |====
 
@@ -8412,6 +8490,11 @@ Returns a reference to the single element that is accessed by this accessor.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8429,6 +8512,11 @@ If this is a <<ranged-accessor>>, the element is determined by adding
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -8450,6 +8538,11 @@ instance also includes the accessor's offset.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8468,6 +8561,11 @@ If this is a <<ranged-accessor>>, the element is determined by adding
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8484,6 +8582,11 @@ The return value is unspecified if the accessor is empty.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8498,6 +8601,11 @@ iterator to first element within the accessor's range.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -8515,6 +8623,11 @@ range.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8529,6 +8642,11 @@ const iterator to first element within the accessor's range.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -8546,6 +8664,11 @@ accessor's range.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8560,6 +8683,11 @@ iterator adaptor to the last element within the accessor's range.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -8577,6 +8705,11 @@ within the accessor's range.
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
 
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
+
 a@
 [source]
 ----
@@ -8591,6 +8724,11 @@ an const iterator adaptor to last element within the accessor's range.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 a@
 [source]
@@ -8607,6 +8745,11 @@ within the accessor's range.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
+
+For [code]#accessor#, a <<command>> calling this function will throw an
+asynchronous [code]#exception# with [code]#exception#errc::kernel_argument# if
+this is a placeholder accessor that has not been bound to a <<command>> by
+calling [code]#handler::require()#.
 
 |====
 


### PR DESCRIPTION
Currently the specification mandates that an implementation throws a synchronous exception when a command is submitted that has captured an accessor that has not previously been through `handler::require`. However, it may be difficult for `host_task` and general commands in library-only implementations to guarantee. To alleviate these problems, this commit aims to relax these exception requirements make the synchronous exception optional and require select accessor member functions to trigger asynchronous exceptions if the corresponding command is executed.

Additionally, this commit adds notes to select member functions in the deprecated accessors specializations for `target::local` and `target::constant` specifying that they can only be used in commands. This corresponds to the same interfaces for the non-deprecated accessor classes.