### PR TITLE
Default multi_ptr to legacy to avoid code break with SYCL 1.2.1

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11863,7 +11863,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
-                                   global_ptr<const DataT> src,
+                                   global_ptr<DataT> src,
                                    size_t numElements) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -11876,7 +11876,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
-                                   local_ptr<const DataT> src,
+                                   local_ptr<DataT> src,
                                    size_t numElements) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -11889,7 +11889,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
-                                   global_ptr<const DataT> src,
+                                   global_ptr<DataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -11902,7 +11902,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
-                                   local_ptr<const DataT> src,
+                                   local_ptr<DataT> src,
                                    size_t numElements, size_t destStride) const
 ----
     a@ Deprecated in SYCL 2020.
@@ -12391,7 +12391,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
-                                   global_ptr<const DataT> src,
+                                   global_ptr<DataT> src,
                                    size_t numElements) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -12404,7 +12404,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
-                                   local_ptr<const DataT> src,
+                                   local_ptr<DataT> src,
                                    size_t numElements) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -12417,7 +12417,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
-                                   global_ptr<const DataT> src,
+                                   global_ptr<DataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
    a@ Deprecated in SYCL 2020.
@@ -12430,7 +12430,7 @@ a@
 ----
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
-                                   local_ptr<const DataT> src,
+                                   local_ptr<DataT> src,
                                    size_t numElements, size_t destStride) const
 ----
     a@ Deprecated in SYCL 2020.
@@ -19707,8 +19707,11 @@ template<access::address_space Space, access::decorated IsDecorated>
 template<size_t N, access::address_space Space, access::decorated IsDecorated>
 ----
 
-* Unless specified otherwise, the template parameters [code]#Space# and
-  [code]#IsDecorated# are unconstrained.
+* Unless specified otherwise, the template parameter [code]#Space# is
+  constrained to the values [code]#access::address_space::global_space#,
+  [code]#access::address_space::local_space#,
+  [code]#access::address_space::private_space# or 
+  [code]#access::address_space::generic_space.
 
 * Other template parameters are not constrained to particular values unless a
   constraint is specifically mentioned in <<table.gentypes>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19707,14 +19707,8 @@ template<access::address_space Space, access::decorated IsDecorated>
 template<size_t N, access::address_space Space, access::decorated IsDecorated>
 ----
 
-* Unless specified otherwise, the template parameter [code]#Space# is
-  constrained to the values [code]#access::address_space::global_space#,
-  [code]#access::address_space::local_space#, or
-  [code]#access::address_space::private_space#.
-
-* Unless specified otherwise, the template parameter [code]#IsDecorated# is
-  constrained to the values [code]#access::decorated::yes# or
-  [code]#access::decorated::no#.
+* Unless specified otherwise, the template parameters [code]#Space# and
+  [code]#IsDecorated# are unconstrained.
 
 * Other template parameters are not constrained to particular values unless a
   constraint is specifically mentioned in <<table.gentypes>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6962,16 +6962,31 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
-accessor_ptr<access::decorated::legacy> get_pointer() const noexcept
+global_ptr<access::decorated::legacy> get_pointer() const noexcept
 ----
-   a@ Returns a [code]#multi_ptr# to the start of this accessor's underlying
-      buffer, even if this is a <<ranged-accessor>> whose range does not start
-      at the beginning of the buffer.  The return value is unspecified if the
-      accessor is empty.
+   a@ Available only when [code]#(AccessTarget == target::device)#.
+
+Returns a [code]#multi_ptr# to the start of this accessor's underlying buffer,
+even if this is a <<ranged-accessor>> whose range does not start at the
+beginning of the buffer.  The return value is unspecified if the accessor is
+empty.
 
 This function may only be called from within a <<command>>.
 
 Deprecated in SYCL 2020.  Use [code]#get_multi_ptr# instead.
+
+a@
+[source]
+----
+std::add_pointer_t<value_type> get_pointer() const noexcept
+----
+   a@ Available only when [code]#(AccessTarget == target::host_task)#.
+
+Returns a pointer to the start of this accessor's underlying buffer, even if
+this is a <<ranged-accessor>> whose range does not start at the beginning of
+the buffer.  The return value is unspecified if the accessor is empty.
+
+This function may only be called from within a <<command>>.
 
 a@
 [source]
@@ -8087,7 +8102,7 @@ a@
 ----
 std::add_pointer_t<value_type> get_pointer() const noexcept
 ----
-   a@ Returns a [code]#multi_ptr# to the start of this accessor's underlying
+   a@ Returns a pointer to the start of this accessor's underlying
       buffer, even if this is a <<ranged-accessor>> whose range does not start
       at the beginning of the buffer.  The return value is unspecified if the
       accessor is empty.
@@ -8299,7 +8314,7 @@ void swap(local_accessor& other);
 @
 [source]
 ----
-accessor_ptr<access::decorated::legacy> get_pointer() const noexcept
+local_ptr<DataT> get_pointer() const noexcept
 ----
    a@ Returns a [code]#multi_ptr# to the start of this accessor's local memory
       region which corresponds to the calling work-group. The return value is
@@ -11913,56 +11928,70 @@ device_event async_work_group_copy(global_ptr<DataT> dest,
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<const DataT> src,
+template <typename DestDataT, typename SrcDataT>
+device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                   decorated_global_ptr<SrcDataT> src,
                                    size_t numElements) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+   a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# and
+returns a SYCL [code]#device_event# which can be used to wait on the completion
+of the copy.
 
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<const DataT> src,
+template <typename DestDataT, typename SrcDataT>
+device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                   decorated_local_ptr<SrcDataT> src,
                                    size_t numElements) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+   a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# and
+returns a SYCL [code]#device_event# which can be used to wait on the
+completion of the copy.
 
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<const DataT> src,
+template <typename DestDataT, typename SrcDataT>
+device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                   decorated_global_ptr<SrcDataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# with a source stride specified by
-      [code]#srcStride# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+   a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# with a
+source stride specified by [code]#srcStride# and returns a SYCL
+[code]#device_event# which can be used to wait on the completion of the copy.
 
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<const DataT> src,
+template <typename DestDataT, SrcDataT>
+device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                   decorated_local_ptr<SrcDataT> src,
                                    size_t numElements, size_t destStride) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# with a destination stride specified by
-      [code]#destStride# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+    a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# with a
+destination stride specified by [code]#destStride# and returns a SYCL
+[code]#device_event# which can be used to wait on the completion of the copy.
 
 a@
 [source]
@@ -12441,56 +12470,53 @@ device_event async_work_group_copy(global_ptr<DataT> dest,
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<const DataT> src,
+template <typename DestDataT, typename SrcDataT>
+device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                   decorated_local_ptr<SrcDataT> src,
                                    size_t numElements) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+   a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# and
+returns a SYCL [code]#device_event# which can be used to wait on the
+completion of the copy.
 
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<const DataT> src,
-                                   size_t numElements) const
-----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
-
-a@
-[source]
-----
-template <typename DataT>
-device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                   decorated_global_ptr<const DataT> src,
+template <typename DestDataT, typename SrcDataT>
+device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                   decorated_global_ptr<SrcDataT> src,
                                    size_t numElements, size_t srcStride) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# with a source stride specified by
-      [code]#srcStride# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+   a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# with a
+source stride specified by [code]#srcStride# and returns a SYCL
+[code]#device_event# which can be used to wait on the completion of the copy.
 
 a@
 [source]
 ----
-template <typename DataT>
-device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                   decorated_local_ptr<const DataT> src,
+template <typename DestDataT, SrcDataT>
+device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                   decorated_local_ptr<SrcDataT> src,
                                    size_t numElements, size_t destStride) const
 ----
-   a@ Permitted types for [code]#DataT# are all scalar and vector types.
-      Asynchronously copies a number of elements specified by [code]#numElements# from the source pointer [code]#src# to destination
-      pointer [code]#dest# with a destination stride specified by
-      [code]#destStride# and returns a SYCL [code]#device_event#
-      which can be used to wait on the completion of the copy.
+    a@ Available only when: (std::is_same_v<DestDataT,
+        std::remove_const_t<SrcDataT>> == true)
+
+Permitted types for [code]#DataT# are all scalar and vector types.
+Asynchronously copies a number of elements specified by [code]#numElements#
+from the source pointer [code]#src# to destination pointer [code]#dest# with a
+destination stride specified by [code]#destStride# and returns a SYCL
+[code]#device_event# which can be used to wait on the completion of the copy.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8085,6 +8085,16 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
+std::add_pointer_t<value_type> get_pointer() const noexcept
+----
+   a@ Returns a [code]#multi_ptr# to the start of this accessor's underlying
+      buffer, even if this is a <<ranged-accessor>> whose range does not start
+      at the beginning of the buffer.  The return value is unspecified if the
+      accessor is empty.
+
+a@
+[source]
+----
 const host_accessor& operator=(const value_type& other) const
 ----
    a@ Available only when [code]#(AccessMode != access_mode::read &&
@@ -8285,6 +8295,20 @@ void swap(local_accessor& other);
 ----
    a@ Swaps the contents of the current accessor with the contents of
       [code]#other#.
+
+@
+[source]
+----
+accessor_ptr<access::decorated::legacy> get_pointer() const noexcept
+----
+   a@ Returns a [code]#multi_ptr# to the start of this accessor's local memory
+      region which corresponds to the calling work-group. The return value is
+      unspecified if the accessor is empty.
+
+This function may only be called from within a <<command>>.
+
+Deprecated in SYCL 2020.  Use [code]#get_multi_ptr# instead.
+
 
 a@
 [source]
@@ -8557,22 +8581,6 @@ For [code]#host_accessor# and [code]#local_accessor# available only when
 Returns a reference to the element at the location specified by [code]#index#.
 If this is a <<ranged-accessor>>, the element is determined by adding
 [code]#index# to the accessor's offset.
-
-For [code]#accessor# and [code]#local_accessor#, this function may only be
-called from within a <<command>>.
-
-a@
-[source]
-----
-std::add_pointer_t<value_type> get_pointer() const noexcept
-----
-   a@ Returns a pointer to the start of this accessor's memory.
-
-For a buffer accessor this is a pointer to the start of the underlying buffer,
-even if this is a <<ranged-accessor>> whose range does not start at the
-beginning of the buffer.
-
-The return value is unspecified if the accessor is empty.
 
 For [code]#accessor# and [code]#local_accessor#, this function may only be
 called from within a <<command>>.
@@ -11854,6 +11862,58 @@ a@
 [source]
 ----
 template <typename DataT>
+device_event async_work_group_copy(local_ptr<DataT> dest,
+                                   global_ptr<const DataT> src,
+                                   size_t numElements) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(global_ptr<DataT> dest,
+                                   local_ptr<const DataT> src,
+                                   size_t numElements) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(local_ptr<DataT> dest,
+                                   global_ptr<const DataT> src,
+                                   size_t numElements, size_t srcStride) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(global_ptr<DataT> dest,
+                                   local_ptr<const DataT> src,
+                                   size_t numElements, size_t destStride) const
+----
+    a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
 device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
                                    decorated_global_ptr<const DataT> src,
                                    size_t numElements) const
@@ -12325,6 +12385,58 @@ different logical range sizes.
 
 This member function can only be invoked within a
 [code]#parallel_for_work_group# context.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(local_ptr<DataT> dest,
+                                   global_ptr<const DataT> src,
+                                   size_t numElements) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(global_ptr<DataT> dest,
+                                   local_ptr<const DataT> src,
+                                   size_t numElements) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(local_ptr<DataT> dest,
+                                   global_ptr<const DataT> src,
+                                   size_t numElements, size_t srcStride) const
+----
+   a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
+
+a@
+[source]
+----
+template <typename DataT>
+device_event async_work_group_copy(global_ptr<DataT> dest,
+                                   local_ptr<const DataT> src,
+                                   size_t numElements, size_t destStride) const
+----
+    a@ Deprecated in SYCL 2020.
+      Has the same effect as the overload taking [code]#decorated_local_ptr#
+      and [code]#decorated_global_ptr# except that the dest and src parameters
+      are [code]#multi_ptr#s with [code]#access::decorated::legacy#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6962,6 +6962,20 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
+accessor_ptr<access::decorated::legacy> get_pointer() const noexcept
+----
+   a@ Returns a [code]#multi_ptr# to the start of this accessor's underlying
+      buffer, even if this is a <<ranged-accessor>> whose range does not start
+      at the beginning of the buffer.  The return value is unspecified if the
+      accessor is empty.
+
+This function may only be called from within a <<command>>.
+
+Deprecated in SYCL 2020.  Use [code]#get_multi_ptr# instead.
+
+a@
+[source]
+----
 template <access::decorated IsDecorated>
 accessor_ptr<IsDecorated> get_multi_ptr() const noexcept
 ----

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -119,10 +119,6 @@ Changes to buffers, images and accessors:
     [code]#accessor# have been changed to be [code]#const# types for read-only
     accessors.
 
-  * The [code]#accessor# member function [code]#get_pointer()# now returns
-    a raw pointer.  The [code]#get_multi_ptr()# member function was introduced
-    which returns the [code]#multi_ptr# class to the appropriate space.
-
   * The [code]#accessor# class now meets the {cpp} requirement of
     [code]#ReversibleContainer#.  This includes (but is not limited to)
     returning [code]#begin# and [code]#end# iterators, specifying a default

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -184,6 +184,7 @@ class accessor {
   cl::sycl::atomic<DataT, access::address_space::global_space>
   operator[](id<Dimensions> index) const;
 
+  /* Deprecated in SYCL 2020 */
   accessor_ptr<access::decorated::legacy> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -184,8 +184,12 @@ class accessor {
   cl::sycl::atomic<DataT, access::address_space::global_space>
   operator[](id<Dimensions> index) const;
 
-  /* Deprecated in SYCL 2020 */
-  accessor_ptr<access::decorated::legacy> get_pointer() const noexcept;
+  /* Deprecated in SYCL 2020
+  Available only when: (AccessTarget == target::device) */
+  global_ptr<DataT> get_pointer() const noexcept;
+
+  /* Available only when (AccessTarget == target::host_task) */
+  std::add_pointer_t<value_type> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept;

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -184,7 +184,7 @@ class accessor {
   cl::sycl::atomic<DataT, access::address_space::global_space>
   operator[](id<Dimensions> index) const;
 
-  std::add_pointer_t<value_type> get_pointer() const noexcept;
+  accessor_ptr<access::decorated::legacy> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -62,7 +62,8 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   /* Available only when: (Dimensions == 1) */
   reference operator[](size_t index) const;
 
-  std::add_pointer_t<value_type> get_pointer() const noexcept;
+  /* Deprecated in SYCL 2020 */
+  accessor_ptr<access::decorated::legacy> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -63,7 +63,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   reference operator[](size_t index) const;
 
   /* Deprecated in SYCL 2020 */
-  accessor_ptr<access::decorated::legacy> get_pointer() const noexcept;
+  local_ptr<DataT> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept;

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -75,25 +75,33 @@ template <int Dimensions = 1> class group {
                                      size_t numElements,
                                      size_t destStride) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
                                      size_t numElements) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
                                      size_t numElements) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -52,26 +52,26 @@ template <int Dimensions = 1> class group {
   // Deprecated in SYCL 2020. 
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
-                                     global_ptr<const DataT> src,
+                                     global_ptr<DataT> src,
                                      size_t numElements) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
-                                     local_ptr<const DataT> src,
+                                     local_ptr<DataT> src,
                                      size_t numElements) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
-                                     global_ptr<const DataT> src,
+                                     global_ptr<DataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
-                                     local_ptr<const DataT> src,
+                                     local_ptr<DataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -49,6 +49,32 @@ template <int Dimensions = 1> class group {
   void parallel_for_work_item(range<Dimensions> logicalRange,
                               const WorkItemFunctionT& func) const;
 
+  // Deprecated in SYCL 2020. 
+  template <typename DataT>
+  device_event async_work_group_copy(local_ptr<DataT> dest,
+                                     global_ptr<const DataT> src,
+                                     size_t numElements) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(global_ptr<DataT> dest,
+                                     local_ptr<const DataT> src,
+                                     size_t numElements) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(local_ptr<DataT> dest,
+                                     global_ptr<const DataT> src,
+                                     size_t numElements,
+                                     size_t srcStride) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(global_ptr<DataT> dest,
+                                     local_ptr<const DataT> src,
+                                     size_t numElements,
+                                     size_t destStride) const;
+
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
                                      decorated_global_ptr<const DataT> src,

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -12,7 +12,11 @@ enum class address_space : /* unspecified */ {
   generic_space
 };
 
-enum class decorated : /* unspecified */ { no, yes, legacy };
+enum class decorated : /* unspecified */ {
+  no,
+  yes,
+  legacy // Deprecated in SYCL 2020
+};
 
 } // namespace access
 
@@ -23,7 +27,7 @@ template <typename T> struct remove_decoration {
 template <typename T> using remove_decoration_t = remove_decoration<T>::type;
 
 template <typename ElementType, access::address_space Space,
-          access::decorated DecorateAddress>
+          access::decorated DecorateAddress = access::decorated::legacy>
 class multi_ptr {
  public:
   static constexpr bool is_decorated =

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -63,7 +63,7 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
 
   std::add_pointer_t<value_type> get_raw() const;
 
-  get_decorated() const;
+  pointer_t get_decorated() const;
 
   // Implicit conversion to the underlying pointer type
   operator ElementType*() const;

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -61,6 +61,10 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   // Returns the underlying OpenCL C pointer
   pointer_t get() const;
 
+  std::add_pointer_t<value_type> get_raw() const;
+
+  get_decorated() const;
+
   // Implicit conversion to the underlying pointer type
   operator ElementType*() const;
 

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -50,26 +50,26 @@ template <int Dimensions = 1> class nd_item {
   // Deprecated in SYCL 2020. 
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
-                                     global_ptr<const DataT> src,
+                                     global_ptr<DataT> src,
                                      size_t numElements) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
-                                     local_ptr<const DataT> src,
+                                     local_ptr<DataT> src,
                                      size_t numElements) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
-                                     global_ptr<const DataT> src,
+                                     global_ptr<DataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
-                                     local_ptr<const DataT> src,
+                                     local_ptr<DataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -47,6 +47,33 @@ template <int Dimensions = 1> class nd_item {
 
   nd_range<Dimensions> get_nd_range() const;
 
+  // Deprecated in SYCL 2020. 
+  template <typename DataT>
+  device_event async_work_group_copy(local_ptr<DataT> dest,
+                                     global_ptr<const DataT> src,
+                                     size_t numElements) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(global_ptr<DataT> dest,
+                                     local_ptr<const DataT> src,
+                                     size_t numElements) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(local_ptr<DataT> dest,
+                                     global_ptr<const DataT> src,
+                                     size_t numElements,
+                                     size_t srcStride) const;
+
+  // Deprecated in SYCL 2020.
+  template <typename DataT>
+  device_event async_work_group_copy(global_ptr<DataT> dest,
+                                     local_ptr<const DataT> src,
+                                     size_t numElements,
+                                     size_t destStride) const;
+
+
   template <typename DataT>
   device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
                                      decorated_global_ptr<const DataT> src,

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -73,26 +73,33 @@ template <int Dimensions = 1> class nd_item {
                                      size_t numElements,
                                      size_t destStride) const;
 
-
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
                                      size_t numElements) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
                                      size_t numElements) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_local_ptr<DataT> dest,
-                                     decorated_global_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
                                      size_t numElements,
                                      size_t srcStride) const;
 
-  template <typename DataT>
-  device_event async_work_group_copy(decorated_global_ptr<DataT> dest,
-                                     decorated_local_ptr<const DataT> src,
+  /* Available only when: (std::is_same_v<DestDataT,
+       std::remove_const_t<SrcDataT>> == true) */
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
                                      size_t numElements,
                                      size_t destStride) const;
 


### PR DESCRIPTION
We have discovered that some of the changes in SYCL 2020 for `multi_ptr` have introduced breaking changes for SYCL 1.2.1 applications moving to SYCL 2020. At the time of these changes it was thought to be necessary but since then the SYCL working group has adopted a philosophy of deprecating interfaces before removing them outright.

This pull request aims to address these changes, such that SYCL 1.2.1 code will still be compatible with SYCL 2020 implementations, avoiding errors in moving from one version to the other and in portability between implementations.

### 1. Default `access::decorated` value for `multi_ptr`

The first issue that was identified was that the SYCL 2020 wording introduces the `access::decorated` template parameter in `multi_ptr`, however, does not provide a default. This means that any code which declares the `multi_ptr` without this template argument, as was the case in SYCL 1.2.1 would no longer compiler.

For example:

```
multi_ptr<float, access::address_space::global_space> multiPtr;
```

To solve this issue, this PR has the `multi_ptr` class template default to `access::decorated::legacy`. It also specifies in the `access::decorated` enum class that `access::decorated::legacy` is deprecated.

### 2. `accessor` returning a raw pointer

The second issue that was identified was that the SYCL 2020 wording changes the return type of `accessor::get_pointer` from a `multi_ptr` to a raw pointer. This means that any code which expects the return value of `accessor::get_pointer` to be a `multi_ptr` will fail to compile.

For example:

```
multi_ptr<float, access::address_space::global_space> multiPtr = acc.get_pointer();
```

or

```
float f4;
f4.load(offset, acc.get_pointer());
```

To solve this issue, this PR reverts back to `accessor::get_pointer` returning a `multi_ptr` with `access::decorated::legacy`. It also introduces wording for `accessor::get_pointer` which was previously missing and specifies that it is deprecated.

### 3. Missing interfaces for `multi_ptr` with `access::decorated::legacy`

The third issue that was identified was that the SYCL 2020 wording introduces new interfaces for the `multi_ptr` class; specifically the `multi_ptr::get_raw` and `multi_ptr::get_decorated` member functions, but not for the `access::decorated::legacy` specialization. This means any new code which uses these member functions will not be compatible with old code which uses the `access::decorated::legacy` specialization of `multi_ptr` and will therefore have to multi-version for the two specializations.

For example:

```
template <typename T, access::address_space AddressSpace, access::decorated IsDecorated>
void foo(multi_ptr<T, AddressSpace,IsDecorated> multiPtr) {
  T *ptr = multiPtr.get_decorated();
  // do something with ptr
}
```

To solve this issue, this PR adds the `multi_ptr::get_raw` and `multi_ptr::get_decorated` member functions to the `access::decorated::legacy` specialization of `multi_ptr` as well.

### 4. `async_work_group_copy` requiring `access::decorated::yes`

The fourth issue that was identified was that the SYCL 2020 wording changes the `nd_item::async_work_group_copy` and `group::async_work_group_copy` member functions such that they now take a `multi_ptr` with `access::decorated::yes` explicitly. This means that any code which uses the `access::decorated::legacy` specialization will not be able to call these functions.

For example:

```
multi_ptr<float, access::address_space::global_space> srcPtr = srcAcc.get_pointer();
multi_ptr<float, access::address_space::global_space> destPtr= destAcc.get_pointer();
async_work_group_copy(destPtr, srcPtr, numElements);
```
To solve this issue, this PR re-introduces the original SYCL 1.2.1 overloads of ` async_work_group_copy` which take a `multi_ptr` with `access::decorated::legacy`, and specifies them as deprecated.

Note, the examples for these are based on the previous changes being applied, however, those issues are all reproducible even if they weren't using other SYCL 2020 interfaces.

### Edits

* https://github.com/KhronosGroup/SYCL-Docs/pull/432/commits/b84963dbb7a353890317fcaa01c8c172a727ae68: Have `local_accessor::get_pointer() also return ` multi_ptr` for consistency and address comments.
* Rebased onto https://github.com/gmlueck/SYCL-Docs/tree/gmlueck/gentype-funcs.
* https://github.com/KhronosGroup/SYCL-Docs/pull/432/commits/a101c3b6618c9d28dba474fe5c9927934c9d9910: Removed constraints on the Space and IsDecorated template parameters for builtin functions taking a multi_ptr.
* https://github.com/KhronosGroup/SYCL-Docs/pull/432/commits/323de84e12d9df7b364a438260669cfd6df17a0c: Maintained builtin functions constraint on mutli_ptr parameters with constant_space and removed const qualifiers on global_ptr parameters to legacy `async_work_group_copy` overloads.
* https://github.com/KhronosGroup/SYCL-Docs/pull/432/commits/99c0b3b0a9527316bb7375d38779763ba83ff602: Added fixes based on feedback; fix for async_work_group_copy definition, removal of accessor_ptr for get_pointer() and additional get_pointer() declaration for the host_task case.