### PR TITLE
[SYCL] Address multi_ptr in spec vs intel/llvm mismatches

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9822,12 +9822,6 @@ bool operator>=(std::nullptr_t, const multi_ptr& rhs)
 The following is the overview of the legacy interface from 1.2.1 provided
 for the [code]#multi_ptr# class.
 
-This legacy class supports the deprecated [code]#address_space::constant_space#
-address space, which can be used to represent a pointer to <<constant-memory>>.
-Pointers to <<constant-memory>> have an implementation-defined address space,
-and each implementation can define whether it is legal to assign such a pointer
-to a generic address pointer.
-
 [source,,linenums]
 ----
 include::{header_dir}/multipointerlegacy.h[lines=4..-1]

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -375,19 +375,24 @@ multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read, target::device, IsPlaceholder>)
     -> multi_ptr<const T, access::address_space::global_space, access::decorated::no>;
+
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
+
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read_write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
+
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer,
                    IsPlaceholder>)
     -> multi_ptr<T, access::address_space::constant_space, access::decorated::no>;
+
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
+
 template <typename T, int Dimensions>
 multi_ptr(local_accessor<T, Dimensions>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -373,23 +373,19 @@ multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 
 // Deduction guides
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::read, access::target::device,
-                   IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, access_mode::read, target::device, IsPlaceholder>)
     -> multi_ptr<const T, access::address_space::global_space,
                  access::decorated::no>;
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::write, access::target::device,
-                   IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, access_mode::write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::read_write,
-                   access::target::device, IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, access_mode::read_write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer,
                    IsPlaceholder>)
-    -> multi_ptr<T, access::address_space::constant_space,
-                 access::decorated::legacy>;
+    -> multi_ptr<T, access::address_space::constant_space, access::decorated::no>;
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -372,32 +372,26 @@ template <access::address_space Space, access::decorated DecorateAddress,
 multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 
 // Deduction guides
-template <typename T, int Dimensions, access::placeholder IsPlaceholder,
-          typename PropertyListT>
+template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read, access::target::device,
-                   IsPlaceholder, PropertyListT>)
+                   IsPlaceholder>)
     -> multi_ptr<const T, access::address_space::global_space,
                  access::decorated::no>;
-template <typename T, int Dimensions, access::placeholder IsPlaceholder,
-          typename PropertyListT>
+template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::write, access::target::device,
-                   IsPlaceholder, PropertyListT>)
+                   IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
-template <typename T, int Dimensions, access::placeholder IsPlaceholder,
-          typename PropertyListT>
+template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read_write,
-                   access::target::device, IsPlaceholder, PropertyListT>)
+                   access::target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
-template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
-          typename PropertyListT>
+template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer,
-                   IsPlaceholder, PropertyListT>)
+                   IsPlaceholder>)
     -> multi_ptr<T, access::address_space::constant_space,
                  access::decorated::legacy>;
-template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
-          typename PropertyListT>
-multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder,
-                   PropertyListT>)
+template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
+multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
 template <typename T, int Dimensions>
 multi_ptr(local_accessor<T, Dimensions>)

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -374,7 +374,7 @@ multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 // Deduction guides
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read, target::device, IsPlaceholder>)
-    -> multi_ptr<const T, access::address_space::global_space,access::decorated::no>;
+    -> multi_ptr<const T, access::address_space::global_space, access::decorated::no>;
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -309,8 +309,7 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   // Available only when:
   //   Space == access::address_space::constant_space &&
   //   (std::is_const_v<VoidType> || !std::is_const_v<ElementType>)
-  template <typename ElementType, int Dimensions,
-            access::placeholder IsPlaceholder>
+  template <typename ElementType, int Dimensions, access::placeholder IsPlaceholder>
   multi_ptr(
       accessor<ElementType, Dimensions, access_mode::read, target::constant_buffer, IsPlaceholder>);
 

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -304,7 +304,7 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   pointer get() const;
 
   // Conversion to the underlying pointer type
-  explicit operator pointer() const;
+  operator pointer() const;
 
   // Explicit conversion to a multi_ptr<ElementType>
   // Available only when: (std::is_const_v<ElementType> || !std::is_const_v<VoidType>)
@@ -372,18 +372,33 @@ template <access::address_space Space, access::decorated DecorateAddress,
 multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 
 // Deduction guides
-template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::read, target::device, IsPlaceholder>)
-    -> multi_ptr<const T, access::address_space::global_space, access::decorated::no>;
-
-template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::write, target::device, IsPlaceholder>)
+template <typename T, int Dimensions, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+multi_ptr(accessor<T, Dimensions, access_mode::read, access::target::device,
+                   IsPlaceholder, PropertyListT>)
+    -> multi_ptr<const T, access::address_space::global_space,
+                 access::decorated::no>;
+template <typename T, int Dimensions, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+multi_ptr(accessor<T, Dimensions, access_mode::write, access::target::device,
+                   IsPlaceholder, PropertyListT>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
-
-template <typename T, int Dimensions, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, access_mode::read_write, target::device, IsPlaceholder>)
+template <typename T, int Dimensions, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+multi_ptr(accessor<T, Dimensions, access_mode::read_write,
+                   access::target::device, IsPlaceholder, PropertyListT>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
-
+template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer,
+                   IsPlaceholder, PropertyListT>)
+    -> multi_ptr<T, access::address_space::constant_space,
+                 access::decorated::legacy>;
+template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder,
+          typename PropertyListT>
+multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder,
+                   PropertyListT>)
+    -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
 template <typename T, int Dimensions>
 multi_ptr(local_accessor<T, Dimensions>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -385,8 +385,7 @@ multi_ptr(accessor<T, Dimensions, access_mode::read_write, target::device, IsPla
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
 
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer,
-                   IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::constant_space, access::decorated::no>;
 
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
@@ -396,4 +395,5 @@ multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
 template <typename T, int Dimensions>
 multi_ptr(local_accessor<T, Dimensions>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
+
 } // namespace sycl

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -88,6 +88,15 @@ class multi_ptr {
   multi_ptr(
       accessor<AccDataT, Dimensions, Mode, target::local, IsPlaceholder>);
 
+  // Deprecated
+  // Available only when:
+  //   Space == access::address_space::constant_space &&
+  //   (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  //   (std::is_const_v<ElementType> || !std::is_const_v<AccDataT>)
+  template <typename AccDataT, int Dimensions, access::placeholder IsPlaceholder>
+  multi_ptr(
+      accessor<AccDataT, Dimensions, access_mode::read, target::constant_buffer, IsPlaceholder>);
+
   // Assignment and access operators
   multi_ptr& operator=(const multi_ptr&);
   multi_ptr& operator=(multi_ptr&&);
@@ -296,6 +305,15 @@ class multi_ptr<VoidType, Space, DecorateAddress> {
   multi_ptr(
       accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
 
+  // Deprecated
+  // Available only when:
+  //   Space == access::address_space::constant_space &&
+  //   (std::is_const_v<VoidType> || !std::is_const_v<ElementType>)
+  template <typename ElementType, int Dimensions,
+            access::placeholder IsPlaceholder>
+  multi_ptr(
+      accessor<ElementType, Dimensions, access_mode::read, target::constant_buffer, IsPlaceholder>);
+
   // Assignment operators
   multi_ptr& operator=(const multi_ptr&);
   multi_ptr& operator=(multi_ptr&&);
@@ -384,12 +402,12 @@ template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read_write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
 
-template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, Mode, access::target::constant_buffer, IsPlaceholder>)
-    -> multi_ptr<T, access::address_space::constant_space, access::decorated::no>;
+template <typename T, int Dimensions, access::placeholder IsPlaceholder>
+multi_ptr(accessor<T, Dimensions, access_mode::read, target::constant_buffer, IsPlaceholder>)
+    -> multi_ptr<const T, access::address_space::constant_space, access::decorated::no>;
 
 template <typename T, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
-multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
+multi_ptr(accessor<T, Dimensions, Mode, target::local, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
 
 template <typename T, int Dimensions>

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -374,8 +374,7 @@ multi_ptr<ElementType, Space, DecorateAddress> address_space_cast(ElementType*);
 // Deduction guides
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::read, target::device, IsPlaceholder>)
-    -> multi_ptr<const T, access::address_space::global_space,
-                 access::decorated::no>;
+    -> multi_ptr<const T, access::address_space::global_space,access::decorated::no>;
 template <typename T, int Dimensions, access::placeholder IsPlaceholder>
 multi_ptr(accessor<T, Dimensions, access_mode::write, target::device, IsPlaceholder>)
     -> multi_ptr<T, access::address_space::global_space, access::decorated::no>;
@@ -392,5 +391,4 @@ multi_ptr(accessor<T, Dimensions, Mode, access::target::local, IsPlaceholder>)
 template <typename T, int Dimensions>
 multi_ptr(local_accessor<T, Dimensions>)
     -> multi_ptr<T, access::address_space::local_space, access::decorated::no>;
-
 } // namespace sycl

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -43,15 +43,34 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   }
   ElementType* operator->() const;
 
-  // Only if Space == global_space
+  // Available only when:
+  // (Space == global_space || Space == generic_space) &&
+  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  // (std::is_const_v<ElementType> ||
+  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::device,
+  //                           IsPlaceholder>::value_type> 
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
   multi_ptr(
       accessor<ElementType, Dimensions, Mode, target::device, IsPlaceholder>);
 
-  // Only if Space == local_space
+  // Available only when:
+  // (Space == local_space || Space == generic_space) &&
+  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  // (std::is_const_v<ElementType> ||
+  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::local,
+  //                           IsPlaceholder>::value_type>
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
   multi_ptr(
       accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
+
+  // Available only when:
+  // (Space == local_space || Space == generic_space) &&
+  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  // (std::is_const_v<ElementType> ||
+  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::local,
+  //                           IsPlaceholder>::value_type>
+  template <typename AccDataT, int Dimensions>
+  multi_ptr(local_accessor<AccDataT, Dimensions>);
 
   // Only if Space == constant_space
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
@@ -69,11 +88,11 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   operator ElementType*() const;
 
   // Implicit conversion to a multi_ptr<void>
-  // Only available when ElementType is not const-qualified
+  // Available only when ElementType is not const-qualified
   operator multi_ptr<void, Space, access::decorated::legacy>() const;
 
   // Implicit conversion to a multi_ptr<const void>
-  // Only available when ElementType is const-qualified
+  // Available only when ElementType is const-qualified
   operator multi_ptr<const void, Space, access::decorated::legacy>() const;
 
   // Implicit conversion to multi_ptr<const ElementType, Space>
@@ -176,13 +195,29 @@ class [[deprecated]] multi_ptr<VoidType, Space, access::decorated::legacy> {
   multi_ptr& operator=(VoidType*);
   multi_ptr& operator=(std::nullptr_t);
 
-  // Only if Space == global_space
+  // Available only when:
+  // (Space == global_space || Space == generic_space) &&
+  // (std::is_const_v<VoidType> ||
+  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::device,
+  //                           IsPlaceholder>::value_type>)
   template <typename ElementType, int Dimensions, access_mode Mode>
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::device>);
 
-  // Only if Space == local_space
+  // Available only when:
+  // (Space == local_space || Space == generic_space) &&
+  // (std::is_const_v<VoidType> ||
+  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::local,
+  //                           IsPlaceholder>::value_type>)
   template <typename ElementType, int Dimensions, access_mode Mode>
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::local>);
+
+  // Available only when:
+  // (Space == local_space || Space == generic_space) &&
+  // (std::is_const_v<VoidType> ||
+  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::local,
+  //                           IsPlaceholder>::value_type>)
+  template <typename AccDataT, int Dimensions>
+  multi_ptr(local_accessor<AccDataT, Dimensions>);
 
   // Only if Space == constant_space
   template <typename ElementType, int Dimensions, access_mode Mode>

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -44,31 +44,30 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
   ElementType* operator->() const;
 
   // Available only when:
-  // (Space == global_space || Space == generic_space) &&
-  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
-  // (std::is_const_v<ElementType> ||
-  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::device,
-  //                           IsPlaceholder>::value_type> 
+  //   (Space == access::address_space::global_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  //   (std::is_const_v<ElementType> ||
+  //    !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::device,
+  //                              IsPlaceholder>::value_type>)
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
   multi_ptr(
       accessor<ElementType, Dimensions, Mode, target::device, IsPlaceholder>);
 
   // Available only when:
-  // (Space == local_space || Space == generic_space) &&
-  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
-  // (std::is_const_v<ElementType> ||
-  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::local,
-  //                           IsPlaceholder>::value_type>
+  //   (Space == access::address_space::local_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  //   (std::is_const_v<ElementType> || !std::is_const_v<AccDataT>)
   template <int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
   multi_ptr(
       accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder>);
 
   // Available only when:
-  // (Space == local_space || Space == generic_space) &&
-  // (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
-  // (std::is_const_v<ElementType> ||
-  // !std::is_const_v<accessor<AccDataT, Dimensions, Mode, target::local,
-  //                           IsPlaceholder>::value_type>
+  //   (Space == access::address_space::local_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&
+  //   (std::is_const_v<ElementType> || !std::is_const_v<AccDataT>)
   template <typename AccDataT, int Dimensions>
   multi_ptr(local_accessor<AccDataT, Dimensions>);
 
@@ -196,30 +195,29 @@ class [[deprecated]] multi_ptr<VoidType, Space, access::decorated::legacy> {
   multi_ptr& operator=(std::nullptr_t);
 
   // Available only when:
-  // (Space == global_space || Space == generic_space) &&
-  // (std::is_const_v<VoidType> ||
-  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::device,
-  //                           IsPlaceholder>::value_type>)
+  //   (Space == access::address_space::global_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_const_v<VoidType> ||
+  //    !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::device,
+  //                              IsPlaceholder>::value_type>)
   template <typename ElementType, int Dimensions, access_mode Mode>
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::device>);
 
   // Available only when:
-  // (Space == local_space || Space == generic_space) &&
-  // (std::is_const_v<VoidType> ||
-  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::local,
-  //                           IsPlaceholder>::value_type>)
+  //   (Space == access::address_space::local_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_const_v<VoidType> || !std::is_const_v<ElementType>)
   template <typename ElementType, int Dimensions, access_mode Mode>
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::local>);
 
   // Available only when:
-  // (Space == local_space || Space == generic_space) &&
-  // (std::is_const_v<VoidType> ||
-  // !std::is_const_v<accessor<ElementType, Dimensions, Mode, target::local,
-  //                           IsPlaceholder>::value_type>)
+  //   (Space == access::address_space::local_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_const_v<VoidType> || !std::is_const_v<ElementType>)
   template <typename AccDataT, int Dimensions>
   multi_ptr(local_accessor<AccDataT, Dimensions>);
 
-  // Only if Space == constant_space
+  // Only if Space == access::address_space::constant_space
   template <typename ElementType, int Dimensions, access_mode Mode>
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::constant_buffer>);
 


### PR DESCRIPTION
* Remove the 'explicit' keyword from the multi_ptr<VoidType>::operator pointer() function.
* Include a generic space constraint in the multi_ptr<Legacy>::ctor from accessor and accessor(local) to support generic_space.
* Implement the multi_ptr<Legacy>::ctor from local_accessor, including support for generic_space.
* Enable implicit conversion of multi_ptr from accessors with const types.
* Add deduction guides for the deprecated access::target::constant_buffer and access::target::local.
* Implement support for the constant_space specialization of non-legacy multi_ptr.