### PR TITLE
Fix range for half-precision cos/sin/tan

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -23644,7 +23644,7 @@ template<typename NonScalar>      (2)
 
 *Overload (1):*
 
-_Preconditions:_ The value of [code]#x# must be in the range -216 to +216.
+_Preconditions:_ The value of [code]#x# must be in the range [-2^16^, +2^16^].
 
 _Returns:_ The cosine of [code]#x#.
 
@@ -23657,7 +23657,7 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type is [code]#float#.
 
 _Preconditions:_ The value of each element of [code]#x# must be in the range
--216 to +216.
+[-2^16^, +2^16^].
 
 _Returns:_ For each element of [code]#x#, the cosine of [code]#x[i]#.
 
@@ -24003,7 +24003,7 @@ template<typename NonScalar>      (2)
 
 *Overload (1):*
 
-_Preconditions:_ The value of [code]#x# must be in the range -216 to +216.
+_Preconditions:_ The value of [code]#x# must be in the range [-2^16^, +2^16^].
 
 _Returns:_ The sine of [code]#x#.
 
@@ -24016,7 +24016,7 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type is [code]#float#.
 
 _Preconditions:_ The value of each element of [code]#x# must be in the range
--216 to +216.
+[-2^16^, +2^16^].
 
 _Returns:_ For each element of [code]#x#, the sine of [code]#x[i]#.
 
@@ -24070,7 +24070,7 @@ template<typename NonScalar>      (2)
 
 *Overload (1):*
 
-_Preconditions:_ The value of [code]#x# must be in the range -216 to +216.
+_Preconditions:_ The value of [code]#x# must be in the range [-2^16^, +2^16^].
 
 _Returns:_ The tangent of [code]#x#.
 
@@ -24083,7 +24083,7 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type is [code]#float#.
 
 _Preconditions:_ The value of each element of [code]#x# must be in the range
--216 to +216.
+[-2^16^, +2^16^].
 
 _Returns:_ For each element of [code]#x#, the tangent of [code]#x[i]#.
 


### PR DESCRIPTION
Fix the precondition range for the half-precision `cos`, `sin`, and `tan` functions.  This appears to be a long-standing transcription bug when we first copied these function definitions from OpenCL.  Somehow we dropped the superscript notation, changing "2^16" into "216".

Also clarify that the range is inclusive, matching the definition in OpenCL 3.0.

Closes internal issue 659.