### PR TITLE
Add "half" to geometric functions

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -25427,12 +25427,16 @@ following types:
 
 * [code]#float#
 * [code]#double#
+* [code]#half#
 * [code]#marray<float, N>#, where [code]#N# is 2, 3, or 4
 * [code]#marray<double, N>#, where [code]#N# is 2, 3, or 4
+* [code]#marray<half, N>#, where [code]#N# is 2, 3, or 4
 * [code]#vec<float, N>#, where [code]#N# is 2, 3, or 4
 * [code]#vec<double, N>#, where [code]#N# is 2, 3, or 4
+* [code]#vec<half, N>#, where [code]#N# is 2, 3, or 4
 * [code]#+__swizzled_vec__<float, N>+#, where [code]#N# is 2, 3, or 4
 * [code]#+__swizzled_vec__<double, N>+#, where [code]#N# is 2, 3, or 4
+* [code]#+__swizzled_vec__<half, N>+#, where [code]#N# is 2, 3, or 4
 
 The term _float geometric type_ represents these types:
 
@@ -25461,16 +25465,22 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#Geo3or4Float1# is one of the following types:
 ** [code]#marray<float, 3>#
 ** [code]#marray<double, 3>#
+** [code]#marray<half, 3>#
 ** [code]#marray<float, 4>#
 ** [code]#marray<double, 4>#
+** [code]#marray<half, 4>#
 ** [code]#vec<float, 3>#
 ** [code]#vec<double, 3>#
+** [code]#vec<half, 3>#
 ** [code]#vec<float, 4>#
 ** [code]#vec<double, 4>#
+** [code]#vec<half, 4>#
 ** [code]#+__swizzled_vec__<float, 3>+#
 ** [code]#+__swizzled_vec__<double, 3>+#
+** [code]#+__swizzled_vec__<half, 3>+#
 ** [code]#+__swizzled_vec__<float, 4>+#
 ** [code]#+__swizzled_vec__<double, 4>+#
+** [code]#+__swizzled_vec__<half, 4>+#;
 * If [code]#Geo3or4Float1# is [code]#marray#, then [code]#Geo3or4Float2# must
   be the same as [code]#Geo3or4Float1#; and
 * If [code]#Geo3or4Float1# is [code]#vec# or the [code]#+__swizzled_vec__+#


### PR DESCRIPTION
We seem to have unintentionally omitted `half` support from the Geometric Functions.  These functions derive from OpenCL, which does have "half" variations.  We added `half` to all the other builtin functions, so we just seem to have missed the Geometric ones.

Note that the `fast_distance`, `fast_length`, and `fast_normalize` functions do NOT have `half` variants (or `double` variants).  This is intentional, and it matches OpenCL.  The rationale is that these three functions all rely on the half-precision functions, which are only defined for `float`.

Closes internal issue 660.