### PR TITLE
Remove reference to "denorms are flushed to zero"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -25659,9 +25659,6 @@ with the following exceptions:
     value of the floating-point values in the result vector are undefined.
   . If the sum of squares is less than [code]#FLT_MIN# then the
     implementation may return back [code]#p#.
-  . If the device is in "`denorms are flushed to zero`" mode, individual
-    operand elements with magnitude less than [code]#sqrt(FLT_MIN)# may
-    be flushed to zero before proceeding with the calculation.
 --
 
 The return type is [code]#GeoFloat# unless [code]#GeoFloat# is the


### PR DESCRIPTION
This appears to be an error from when we transcribed these function definitions from OpenCL.  There is no mode called "denorms are flushed to zero" in SYCL.  In OpenCL, this corresponds to the compiler flag "-cl-denorms-are-zero", but SYCL does not define any compiler flags.

Vendors could define a compiler flag like this if they want.  In this case, it would be the vendor's responsibility to document the effect.

Closes internal issue 657.