### PR TITLE
Add restriction to "vec::as"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16989,7 +16989,12 @@ a@
 ----
 template <typename asT> asT as() const
 ----
-   a@ Bitwise reinterprets this SYCL [code]#vec# as a SYCL [code]#vec# of a different element type and number of elements specified by [code]#asT#. The new SYCL [code]#vec# type must have the same storage size in bytes as this SYCL [code]#vec#.
+   a@ Bitwise reinterprets this SYCL [code]#vec# as a SYCL [code]#vec# of a
+      different element type and number of elements specified by [code]#asT#.
+      The new SYCL [code]#vec# type must have the same storage size in bytes as
+      this SYCL [code]#vec#, and the size of the elements in the new SYCL
+      [code]#vec# ([code]#NumElements * sizeof(DataT)#) must be the same as the
+      size of the elements in this SYCL [code]#vec#.
 
 a@
 [source]


### PR DESCRIPTION
This change was prompted by a discussion in KhronosGroup/SYCL-CTS#756, relating to a test of `vec::as`.  That test tried to use `vec::as` to reinterpret a `sycl::vec<float, 3>` as `sycl::vec<int, 4>`, which is legal according to the spec because they both have the same storage size.  (This is because a `vec` of length 3 has the same storage size as a `vec` of length 4.)  However, the semantics are unclear because the content of the 4th element is undefined for a 3 element `vec`.

It seems reasonable to simply state that such a use of `vec::as` is not allowed.  I think our intent was to allow `vec::as` to reinterpret only the bits of defined elements in a `vec`, which is what this change does.