### PR TITLE
Limit vec alignment to 64 bytes

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17654,6 +17654,13 @@ functions.
 
 In no case, however, is the alignment guaranteed to be greater than 64 bytes.
 
+[NOTE]
+====
+The alignment guarantee is limited to 64 bytes because some host compilers
+(e.g. on Microsoft Windows) limit the maximum alignment of function parameters
+to this value.
+====
+
 
 ==== Performance note
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17652,6 +17652,8 @@ This is true for both host and device code in order to allow for instances
 of the [code]#vec# class template to be passed to SYCL kernel
 functions.
 
+In no case, however, is the alignment guaranteed to be greater than 64 bytes.
+
 
 ==== Performance note
 


### PR DESCRIPTION
We currently require `vec` to be aligned according to its total storage size.  For example, a `vec<uint32_t, 8>` must be aligned on a 32 byte boundary (32 = sizeof(uint32_t) * 8).  This comes from OpenCL, which has the same requirement.  The largest required alignment is for `vec<double, 16>`, which is typically 128 bytes.

However, this is problematic in SYCL because we want to support a variety of host compilers.  The MSVC compiler has a limit of 64 byte alignment for function parameters.  Therefore, the SYCL alignment requirements makes it impossible to pass a `vec<double, 16>` as a function parameter when compiling with MSVC.  This is particularly problematic because many of the SYCL "builtin" math function take `vec` as a parameter type.

We therefore propose weakening the alignment requirement to make it possible to support MSVC.  Of course, implementations are still allowed to align `vec` more highly if this results in more efficient code.

We considered removing the special alignment requirements entirely for `vec` and leaving this as an implementation detail.  However, existing code may depend on this alignment, so we opted for the most conservative change that still allows MSVC to work.  Therefore, we propose capping the required alignment to 64 bytes.