### PR TITLE
Fix definition of "nextafter" for double and half

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -22379,10 +22379,10 @@ template<typename NonScalar1, typename NonScalar2>     (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ The next representable single-precision floating-point value
-following [code]#x# in the direction of [code]#y#.  Thus, if [code]#y# is less
-than [code]#x#, [code]#nextafter# returns the largest representable
-floating-point number less than [code]#x#.
+_Returns:_ The next representable floating-point value following [code]#x# in
+the direction of [code]#y#.  Thus, if [code]#y# is less than [code]#x#,
+[code]#nextafter# returns the largest representable floating-point number less
+than [code]#x#.
 
 *Overload (4):*
 
@@ -22399,8 +22399,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#float#, [code]#double#, or [code]#half#.
 
 _Returns:_ For each element of [code]#x# and [code]#y#, the
-next representable single-precision floating-point value following [code]#x[i]#
-in the direction of [code]#y[i]#.
+next representable floating-point value following [code]#x[i]# in the direction
+of [code]#y[i]#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the


### PR DESCRIPTION
The `nextafter` function returns the next floating-point value that is representable in the given type.  The previous description was wrong because it specifically stated that it returns the next "single-precision" value.

I think we adopted the previous wording from OpenCL, and the OpenCL committee recently fixed this same wording in their spec.

Closes internal issue 661.