### PR TITLE
Introduce a default constructor for sycl::range

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11032,6 +11032,13 @@ include::{header_dir}/range.h[lines=4..-1]
 a@
 [source]
 ----
+range()
+----
+   a@ Construct a SYCL [code]#range# with the value [code]#0# for each dimension.
+
+a@
+[source]
+----
 range(size_t dim0)
 ----
    a@ Construct a 1D range with value dim0.

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -6,6 +6,8 @@ template <int Dimensions = 1> class range {
  public:
   static constexpr int dimensions = Dimensions;
 
+  range();
+
   /* The following constructor is only available in the range class
    * specialization where: Dimensions==1 */
   range(size_t dim0);


### PR DESCRIPTION
As discussed in last week's call, this adds a default constructor for `sycl::range` that initializes all components to 0, analogous to `id`'s default constructor, making it more convenient to use in generic contexts. I initially brought this up over three years ago in #90, and there has been some disagreement on whether to initialize all components to 0 or 1. We finally agreed to all 0s for consistency with `sycl::id` (among other reasons).

Resolves #90.