### PR TITLE
Fix local_accessor code section rendering

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8317,7 +8317,7 @@ void swap(local_accessor& other);
    a@ Swaps the contents of the current accessor with the contents of
       [code]#other#.
 
-@
+a@
 [source]
 ----
 local_ptr<DataT> get_pointer() const noexcept


### PR DESCRIPTION
This fixes rendering of `local_accessor` code section in `programming_interface.adoc`.

Before:
![local-accessor-api-before](https://github.com/KhronosGroup/SYCL-Docs/assets/69916350/fa6178e9-33f2-4d4e-9989-aef32b484cb9)

After:
![local-accessor-api-after](https://github.com/KhronosGroup/SYCL-Docs/assets/69916350/3e9d9c24-e61f-4544-b690-713aeecc278f)
