### PR TITLE
Fix a table contexts swapped problem.

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2052,8 +2052,9 @@ a@
 info::device::max_parameter_size
 ----
 
-    @ [.code]#size_t#
-   a@ Returns the maximum size in bytes of the arguments that can be passed to a kernel. The minimum value is 1024 if this SYCL [code]#device# is not of device type [code]#info::device_type::custom#. For this minimum value, only a maximum of 128 arguments can be passed to a kernel.
+    @ [.code]#uint32_t#
+   a@ Returns the minimum value in bits of the largest supported SYCL built-in
+      data type if this SYCL [code]#device# is not of device type [code]#info::device_type::custom#.
 
 a@
 [source]
@@ -2061,9 +2062,8 @@ a@
 info::device::mem_base_addr_align
 ----
 
-    @ [.code]#uint32_t#
-   a@ Returns the minimum value in bits of the largest supported SYCL built-in
-      data type if this SYCL [code]#device# is not of device type [code]#info::device_type::custom#.
+    @ [.code]#size_t#
+   a@ Returns the maximum size in bytes of the arguments that can be passed to a kernel. The minimum value is 1024 if this SYCL [code]#device# is not of device type [code]#info::device_type::custom#. For this minimum value, only a maximum of 128 arguments can be passed to a kernel.
 
 a@
 [source]


### PR DESCRIPTION
The contents of `info::device::max_parameter_size` and `info::device::mem_base_addr_align` are swapped, fixed with this PR.