### PR TITLE
Fix prvalue to xvalue conversion address space assignment

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -737,8 +737,8 @@ The variable declarations get assigned to an address space depending on their
 scope and storage class:
 
   * Namespace scope
-  ** If the type is [code]#const#, the address space the declaration is assigned
-     to is implementation-defined.
+  ** If the type is [code]#const#, the address space of the declaration is
+     assigned to is implementation-defined.
      If the target of the SYCL backend can represent the generic address space,
      then the assigned address space must be compatible with the generic address
      space.
@@ -761,9 +761,11 @@ device kernel or code called by the device kernel.
   ** Static data members are treated the same way as for variable in namespace
      scope
 
-The result of a prvalue-to-xvalue conversion is assigned to the local address
-space if it happens in a hierarchical context or to the private address space
-otherwise.
+If a prvalue-to-xvalue conversion happens in a block scope or function parameter
+scope, the result is assigned to the local address space if it happens a
+hierarchical context otherwise it is assigned to the private address space.
+It the prvalue-to-xvalue conversion happens in another scope, the result is
+assigned in the same way as declaration in namespace scope.
 
 
 [[subsec:genericAddressSpace]]

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -737,8 +737,8 @@ The variable declarations get assigned to an address space depending on their
 scope and storage class:
 
   * Namespace scope
-  ** If the type is [code]#const#, the address space of the declaration is
-     assigned to is implementation-defined.
+  ** If the type is [code]#const#, the declaration is assigned to an
+     implementation-defined address space.
      If the target of the SYCL backend can represent the generic address space,
      then the assigned address space must be compatible with the generic address
      space.

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -761,8 +761,11 @@ device kernel or code called by the device kernel.
   ** Static data members are treated the same way as for variable in namespace
      scope
 
-If a prvalue-to-xvalue conversion happens in a block scope or function parameter
-scope, the result is assigned to the local address space if it happens a
+If a prvalue-to-xvalue conversion happens as part of the an initialization
+expression, then the result is assigned to the same address space as the entity
+being initialized.
+Otherwise, if the conversion happens in a block scope or function parameter
+scope, the result is assigned to the local address space if it happens in a
 hierarchical context otherwise it is assigned to the private address space.
 It the prvalue-to-xvalue conversion happens in another scope, the result is
 assigned in the same way as declaration in namespace scope.

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -761,7 +761,7 @@ device kernel or code called by the device kernel.
   ** Static data members are treated the same way as for variable in namespace
      scope
 
-If a prvalue-to-xvalue conversion happens as part of the an initialization
+If a prvalue-to-xvalue conversion happens as part of an initialization
 expression, then the result is assigned to the same address space as the entity
 being initialized.
 Otherwise, if the conversion happens in a block scope or function parameter


### PR DESCRIPTION
The common address deduction rules assumed prvalue-to-xvalue conversion can only happens inside a function.
The patch aligns the rules to match declaration rules.


It is a bit of a corner case, but the spec treated all 3 conversions bellow in the same way.

```cpp
constexpr const int& foo = 5;

class Foo {
public:
  static constexpr const int& foo = 42;
};

void bar() {
    const int& foo = 42;
}
```