### PR TITLE
Add kernel_device_specific::local_static_mem_size

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16015,6 +16015,22 @@ info::kernel_device_specific::private_mem_size
 a@
 [source]
 ----
+info::kernel_device_specific::local_static_mem_size
+----
+
+    @ [code]#size_t#
+   a@ Returns the amount of local memory, in bytes, used statically by each
+      work-group in the kernel. This value may include any local memory needed
+      by an implementation to execute the kernel, including that used by the
+      language built-ins and variables declared in work-group scope inside a
+      hierarchical parallel kernel.
+
+It does not include local memory to be allocated for arguments to the kernel
+declared as [code]#local_accessor#.
+
+a@
+[source]
+----
 info::kernel_device_specific::max_num_sub_groups
 ----
 
@@ -16050,6 +16066,19 @@ info::kernel_device_specific::compile_sub_group_size
 
 |====
 
+[NOTE]
+====
+The _guaranteed_ minimum amount of local memory available for dynamic allocation
+through [code]#local_accessor# can be calculated by subtracting the value
+returned for [code]#info::kernel_device_specific::local_static_mem_size# from
+the value returned for [code]#info::device::local_mem_size# (see
+<<sec:device-class>>). 
+
+Backends may support reuse of local memory for multiple allocations, resulting
+in more local memory being available for dynamic allocation through
+[code]#local_accessor#, but are not required to do so and relying on this 
+behavior may result in non-portable code.
+====
 
 === The [code]#device_image# class
 

--- a/adoc/headers/kernelInfo.h
+++ b/adoc/headers/kernelInfo.h
@@ -17,6 +17,7 @@ struct work_group_size;
 struct compile_work_group_size;
 struct preferred_work_group_size_multiple;
 struct private_mem_size;
+struct local_static_mem_size;
 struct max_num_sub_groups;
 struct compile_num_sub_groups;
 struct max_sub_group_size;


### PR DESCRIPTION
The SYCL specification, in table 138 in [§4.11.13.2](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_kernel_information_descriptors), defines a device-specific kernel information descriptor info::kernel_device_specific::private_mem_size to query for the private memory used by each work-item. This matches OpenCL's [CL_KERNEL_PRIVATE_MEM_SIZE](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_KERNEL_PRIVATE_MEM_SIZE).

OpenCL also defines [CL_KERNEL_LOCAL_MEM_SIZE](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_KERNEL_LOCAL_MEM_SIZE) to query for the local memory used by a kernel, but SYCL does not define an equivalent device-specific kernel information descriptor. This could be useful to users, especially if local memory was used by the implementation for builtins, e.g., for reduction.

This adds a device-specific kernel information descriptor for the amount of local memory used *statically* by a kernel. In contrast to OpenCL, this only includes local memory used by the implementation (and variables with work-group scope inside hierarchical parallel kernels), but not local memory dynamically allocated for `local_accessor` as that would be unknown at the time of the query. This is also indicated by the naming of the descriptor.

This fixes #452.