### PR TITLE
Remove confusing wording about errors

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3184,7 +3184,6 @@ a@
 context get_context() const
 ----
 a@ Returns the SYCL queue's context.
-Reports errors using SYCL exception classes.
 The value returned must be equal to that returned by [code]#get_info<info::queue::context>()#.
 
 a@
@@ -3193,7 +3192,6 @@ a@
 device get_device() const
 ----
 a@ Returns the SYCL device the queue is associated with.
-Reports errors using SYCL exception classes.
 The value returned must be equal to that returned by [code]#get_info<info::queue::device>()#.
 
 a@


### PR DESCRIPTION
I noticed this while reviewing work on the SYCL reference guide.

The specification for the member functions `queue::get_context` and `queue::get_device` implied that they could throw an exception for an error scenario.  I cannot think of any reason these functions could fail because a queue always has a context and a device.  Therefore, I think we should remove these sentences.  For example, notice that there is no similar wording for `queue::is_in_order`, which also has no obvious reason to fail.