### PR TITLE
Don't require an implementation to expose at least one device

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -849,9 +849,10 @@ a@
 default_selector_v
 ----
    a@ Select a SYCL [code]#device# from any supported <<backend>>
-      based on an implementation-defined heuristic. Since all
-      implementations must support at least one device, this selector
-      must always return a device.
+      based on an implementation-defined heuristic. The SYCL class
+      constructor using it must throw an [code]#exception#
+      with the [code]#errc::runtime# error code if no
+      device can be found.
 
 [NOTE]
 ====

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -373,8 +373,7 @@ The [code]#cl::sycl::byte# has been deprecated and now the {cpp17}
 [code]#std::byte# should be used instead.
 
 A SYCL implementation is no longer required to provide a host device.
-Instead, an implementation is only required to provide at least one
-device.  Implementations are still allowed to provide devices that are
+Implementations are still allowed to provide devices that are
 implemented on the host, but it is no longer required.  The specification
 no longer defines any special semantics for a "host device" and APIs
 specific to the host device have been removed.


### PR DESCRIPTION
As discussed in last week's meeting, we're removing the requirement for an implementation to expose at least one device. This is mainly to avoid undefined behavior in cases where for example all devices are hidden from the implementation through environment variables such as `CUDA_VISIBLE_DEVICES`.

It looks like the only location that really needed changing was the wording regarding the default device selector. Other than that, I wasn't sure whether we may also want to add an additional sentence or two to the descriptions of the default constructors for `platform`, `context` and `queue`, which currently say something like

> Constructs a SYCL platform instance that is a copy of the platform which contains the device returned by default_selector_v.