### PR TITLE
Align description of logical `vec` operator overloads

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17422,8 +17422,6 @@ a@
 ----
 vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs)
 ----
-   a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
-
 Construct a new instance of the SYCL [code]#vec# class template with
 the same template parameters as the [code]#rhs# SYCL [code]#vec#
 with each element of the new SYCL [code]#vec# instance the result of


### PR DESCRIPTION
The code snippet for `vec` interface does not list any restrictions on `operator&&` and `operator||` and they are not listed in description of overloads `(vec, vec)` and `(vec, scalar)`.

However, they were listed in description of overloads for `(scalar, vec)` and there is no reasons for them to be there.

This commit aligns description of all overloads of logical `vec` operators by removing data types restriction for
`vec::operator&&(scalar, vec)` and `vec::operator||(scalar, vec)`.