### PR TITLE
Use hyphens in reference names

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -129,8 +129,8 @@ void h() {
 }
 ----
 
-In order for the SYCL device compiler to correctly compile <<device function, device functions>>, all
-functions in the source file, whether <<device function, device functions>> or not, must be
+In order for the SYCL device compiler to correctly compile <<device-function, device functions>>, all
+functions in the source file, whether <<device-function, device functions>> or not, must be
 syntactically correct functions according to this specification. A syntactically
 correct function adheres to at least the minimum required {cpp} version
 defined in <<sec:progmodel.minimumcppversion>>.

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -17,7 +17,7 @@
     An accessor is a class which allows a <<command>> to access data managed
     by a <<buffer>> or <<image>> class or allows a <<sycl-kernel-function>>
     to access local memory on a <<device>>.  Accessors are also used to express
-    the dependencies among the different <<command group, command groups>>.
+    the dependencies among the different <<command-group, command groups>>.
     For the full description please refer to <<subsec:accessors>>
 
 [[application-scope]]application scope::

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -708,7 +708,7 @@ is represented by a [code]#cl_kernel# and must be compiled and linked via a
 [code]#cl_program# using [code]#clBuildProgram#,
 [code]#clCompileProgram# and [code]#clLinkProgram#.
 
-For OpenCL <<backend>> this detail is abstracted away by <<kernel bundle,kernel bundles>> and
+For OpenCL <<backend>> this detail is abstracted away by <<kernel-bundle,kernel bundles>> and
 a [code]#kernel_bundle# object containing all <<sycl-kernel-function,SYCL kernel functions>>
 is retrieved by calling the free function [code]#get_kernel_bundle#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14343,7 +14343,7 @@ overhead associated with recompilation of the kernel's bundle.
 Specialization constants must be declared using the [code]#specialization_id#
 class with the following restrictions:
 
-* the template parameter [code]#T# must be a <<device copyable>> type;
+* the template parameter [code]#T# must be a <<device-copyable>> type;
 * the [code]#specialization_id# variable must be declared as [code]#constexpr#;
 * the [code]#specialization_id# variable must be declared in either namespace
   scope or in class scope;
@@ -14546,7 +14546,7 @@ invoked directly by the SYCL runtime, regardless of which <<device>> the
 
 A <<host-task>> is enqueued on a <<queue>> via the [code]#host_task#
 member function of the [code]#handler# class.
-The <<event>> returned by the submission of the associated <<command group>>
+The <<event>> returned by the submission of the associated <<command-group>>
 enters the completed state (corresponding to a status of
 [code]#info::event_command_status::complete#) once the invocation of the
 provided {cpp} callable has returned.
@@ -19800,7 +19800,7 @@ T operator()(const T& x, const T& y) const
 SYCL provides a number of functions that expose functionality tied to groups of
 work-items (such as <<group-barrier,group barriers>> and collective operations).
 These group functions act as synchronization points and must be encountered in
-converged <<control flow>> by all work-items in the group.  If one work-item in
+converged <<control-flow>> by all work-items in the group.  If one work-item in
 a group calls a group function, then all work-items in that group must call
 exactly the same function under the same set of conditions --- calling the same
 function under different conditions (e.g. in different iterations of a loop, or


### PR DESCRIPTION
Some Asciidoc references to the glossary terms were using the name of the glossary term instead of the link name.  For glossary terms that have multiple words, this results in a reference that has a space in the name.  This space is causing problems in #481.

All these glossary terms have an anchor that is the same as the glossary term, but with a hyphen instead of the space that separates the words.  Change the references to use this anchor name instead of using the glossary term.