### PR TITLE
Fix longstanding informational messages

### DIFF
--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -136,7 +136,7 @@ ATTRIBOPTS   = --attribute revdate="$(SPECDATE)" \
   --attribute generated=$(GENERATED) \
   --attribute refprefix \
   $(VERSIONATTRIBS)
-ADOCMISCOPTS = --require asciidoctor-diagram --failure-level ERROR
+ADOCMISCOPTS = --require asciidoctor-diagram --failure-level INFO
 ADOCEXTS     = --require $(CURDIR)/config/spec-macros.rb \
 	--require $(CURDIR)/config/rouge_sycl.rb
 ADOCOPTS     = --doctype book $(ADOCMISCOPTS) $(ATTRIBOPTS) \

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -338,7 +338,7 @@ different queues.  When a <<command-group>> is submitted to a SYCL <<queue>>,
 the requirements of the kernel execution are captured.  The implementation can
 start executing a kernel as soon as its requirements have been satisfied.
 
-==== <<backend, SYCL backend>> resources managed by the SYCL application
+==== Backend resources managed by the SYCL application
 
 The SYCL runtime integrated with the SYCL application will manage
 the resources required by the <<backend-api>>

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16359,7 +16359,7 @@ object passed to the <<async-handler>> is constructed by the <<sycl-runtime>>.
 
 
 [[subsubsec:exception.nohandler]]
-==== Behavior without an <<async-handler>>
+==== Behavior without an async handler
 
 If an asynchronous error occurs in a queue or context that has no user-supplied
 asynchronous error handler object <<async-handler>>, then an implementation-defined
@@ -16369,7 +16369,7 @@ a user-supplied <<async-handler>> would be, as defined in
 report all errors passed to it, when possible, and must then invoke
 [code]#std::terminate# or equivalent.
 
-==== Priorities of <<async-handler,async handlers>>
+==== Priorities of async handlers
 
 If the SYCL runtime can associate an <<async-error>> with a specific queue,
 then:


### PR DESCRIPTION
The build of the spec has long generated the following informational messages:

```
asciidoctor: INFO: possible invalid reference: backend
asciidoctor: INFO: possible invalid reference: async-handler
```

These were caused by using a reference to a glossary term in the title of a section.  I don't see anything in Asciidoc saying that this is forbidden, so it might be a bug in Asciidoctor.  However, they don't seem that valuable, and it's helpful to have a clean build of the spec.

This commit removes these references and also changes the build process, so that an INFO message will cause a failure.  This will ensure that we don't accidentally introduce new INFO messages in the future.