### PR TITLE
Fix bugs in SYCL2020 USM section

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10570,7 +10570,7 @@ a@
 [source]
 ----
 template <typename T>
-void* sycl::aligned_alloc_host(size_t alignment, size_t count,
+T* sycl::aligned_alloc_host(size_t alignment, size_t count,
                                const queue& syclQueue,
                                const property_list& propList = {})
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10734,6 +10734,12 @@ which must eventually be deallocated with [code]#sycl::free# in order to avoid
 a memory leak.  If there are not enough resources to allocate the requested
 memory, these functions return [code]#nullptr#.
 
+When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
+zero), these functions behave in a manner consistent with {cpp}
+[code]#std::malloc#.  The value returned is unspecified in this case, and the
+returned pointer may not be used to access storage.  If this pointer is not
+null, it must be passed to [code]#sycl::free# to avoid a memory leak.
+
 [[table.usm.param.allocs]]
 .Parameterized USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10354,7 +10354,7 @@ leak.  If there are not enough resources to allocate the requested memory,
 these functions return [code]#nullptr#.
 
 When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
-zero), these functions behave in a manor consistent with {cpp}
+zero), these functions behave in a manner consistent with {cpp}
 [code]#std::malloc#.  The value returned is unspecified in this case, and the
 returned pointer may not be used to access storage.  If this pointer is not
 null, it must be passed to [code]#sycl::free# to avoid a memory leak.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10485,6 +10485,12 @@ eventually be deallocated with [code]#sycl::free# in order to avoid a memory
 leak.  If there are not enough resources to allocate the requested memory,
 these functions return [code]#nullptr#.
 
+When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
+zero), these functions behave in a manner consistent with {cpp}
+[code]#std::malloc#.  The value returned is unspecified in this case, and the
+returned pointer may not be used to access storage.  If this pointer is not
+null, it must be passed to [code]#sycl::free# to avoid a memory leak.
+
 [[table.usm.host.allocs]]
 .Host USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]
@@ -10585,6 +10591,12 @@ these functions return a pointer to the newly allocated memory, which must
 eventually be deallocated with [code]#sycl::free# in order to avoid a memory
 leak.  If there are not enough resources to allocate the requested memory,
 these functions return [code]#nullptr#.
+
+When the allocation size is zero bytes ([code]#numBytes# or [code]#count# is
+zero), these functions behave in a manner consistent with {cpp}
+[code]#std::malloc#.  The value returned is unspecified in this case, and the
+returned pointer may not be used to access storage.  If this pointer is not
+null, it must be passed to [code]#sycl::free# to avoid a memory leak.
 
 [[table.usm.shared.allocs]]
 .Shared USM Allocation Functions


### PR DESCRIPTION
1. The templated aligned_alloc_host had the wrong return type, not matching the other templated signatures and clear intent of the API
1. Zero size malloc behavior was only specified for device allocations, when it needs to be specified for host and shared mallocs as well
1. Fix incorrect word use