### PR TITLE
Clarify group synchronization behavior

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19977,6 +19977,14 @@ include::{header_dir}/groups/broadcast.h[lines=4..-1]
     trivially copyable type.
 +
 --
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the broadcast operation.
+
+_Synchronization:_ The call to this function in each work-item happens before
+the broadcast operation begins execution.
+The completion of the broadcast operation happens before any work-item blocking
+on the same synchronization point is unblocked.
+
 _Returns:_ The value of [code]#x# from the work-item with the smallest linear id
 within group [code]#g#.
 --
@@ -19988,6 +19996,14 @@ within group [code]#g#.
 --
 _Preconditions:_ [code]#local_linear_id# must be the same for all work-items in
 the group and must be in the range [code]#[0, get_local_linear_range())#.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the broadcast operation.
+
+_Synchronization:_ The call to this function in each work-item happens before
+the broadcast operation begins execution.
+The completion of the broadcast operation happens before any work-item blocking
+on the same synchronization point is unblocked.
 
 _Returns:_ The value of [code]#x# from the work-item with the specified linear
 id within group [code]#g#.
@@ -20002,6 +20018,14 @@ _Preconditions:_ [code]#local_id# must be the same for all work-items in the
 group, and its dimensionality must match the dimensionality of the group.
 The value of [code]#local_id# in each dimension must be greater than or equal to
 0 and less than the value of [code]#get_local_range()# in the same dimension.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the broadcast operation.
+
+_Synchronization:_ The call to this function in each work-item happens before
+the broadcast operation begins execution.
+The completion of the broadcast operation happens before any work-item blocking
+on the same synchronization point is unblocked.
 
 _Returns:_ The value of [code]#x# from the work-item with the specified id
 within group [code]#g#.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20072,8 +20072,8 @@ with the same type and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20091,8 +20091,8 @@ and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20107,8 +20107,8 @@ _Returns:_ true if [code]#pred(x)# returns true for any work-item in group
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20132,8 +20132,8 @@ with the same type and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20151,8 +20151,8 @@ and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20167,8 +20167,8 @@ _Returns:_ true if [code]#pred(x)# returns true for all work-items in group
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20192,8 +20192,8 @@ with the same type and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20211,8 +20211,8 @@ and state for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20227,8 +20227,8 @@ _Returns:_ true if [code]#pred(x)# returns false for all work-items in group
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20260,8 +20260,8 @@ _Preconditions:_ [code]#delta# must be the same for all work-items in the group.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20280,8 +20280,8 @@ _Preconditions:_ [code]#delta# must be the same for all work-items in the group.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20314,8 +20314,8 @@ _Preconditions:_ [code]#mask# must be the same for all work-items in the group.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20346,8 +20346,8 @@ include::{header_dir}/algorithms/select.h[lines=4..-1]
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20398,8 +20398,8 @@ must be the same for all work-items in group [code]#g#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20425,8 +20425,8 @@ _Preconditions:_ [code]#first#, [code]#last#, [code]#init# and the type of
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20449,8 +20449,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20473,8 +20473,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20537,15 +20537,15 @@ Note that [code]#first# may be equal to [code]#result#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-The value written to [code]#result# + _i_ is the exclusive scan of
-the values resulting from dereferencing the first _i_ values in the range
-[code]#[first, last)# and the identity value of [code]#binary_op# (as identified
-by [code]#sycl::known_identity#), using the operator [code]#binary_op#.
+The value written to [code]#result# + _i_ is the exclusive scan of the values
+resulting from dereferencing the first _i_ values in the range [code]#[first,
+last)# and the identity value of [code]#binary_op# (as identified by
+[code]#sycl::known_identity#), using the operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20574,15 +20574,15 @@ Note that [code]#first# may be equal to [code]#result#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-The value written to [code]#result# + _i_ is the exclusive scan of
-the values resulting from dereferencing the first _i_ values in the range
-[code]#[first, last)# and an initial value specified by [code]#init#, using the
-operator [code]#binary_op#.
+The value written to [code]#result# + _i_ is the exclusive scan of the values
+resulting from dereferencing the first _i_ values in the range [code]#[first,
+last)# and an initial value specified by [code]#init#, using the operator
+[code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20603,8 +20603,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20632,8 +20632,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20672,14 +20672,14 @@ Note that [code]#first# may be equal to [code]#result#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-The value written to [code]#result# + _i_ is the inclusive scan of
-the values resulting from dereferencing the first _i_ values in the range
-[code]#[first, last)#, using the operator [code]#binary_op#.
+The value written to [code]#result# + _i_ is the inclusive scan of the values
+resulting from dereferencing the first _i_ values in the range [code]#[first,
+last)#, using the operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20708,15 +20708,15 @@ Note that [code]#first# may be equal to [code]#result#.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-The value written to [code]#result# + _i_ is the inclusive scan of
-the values resulting from dereferencing the first _i_ values in the range
-[code]#[first, last)# and an initial value specified by [code]#init#, using the
-operator [code]#binary_op#.
+The value written to [code]#result# + _i_ is the inclusive scan of the values
+resulting from dereferencing the first _i_ values in the range [code]#[first,
+last)# and an initial value specified by [code]#init#, using the operator
+[code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20737,8 +20737,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
@@ -20764,8 +20764,8 @@ object.
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 
-_Synchronization:_ The call to this function in each work-item happens
-before the algorithm begins execution.
+_Synchronization:_ The call to this function in each work-item happens before
+the algorithm begins execution.
 The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19889,6 +19889,18 @@ SYCL provides a number of functions that expose functionality tied to groups of
 work-items (such as <<group-barrier,group barriers>> and collective operations).
 These group functions act as _synchronization points_ and must be encountered in
 converged <<control-flow>> by all work-items in the group.
+
+[NOTE]
+====
+The behavior of group functions is analogous to the behavior of the C++20
+[code]#std::barrier::arrive_and_wait# function, for an implementation-defined
+barrier object with an expected count equal to the number of work-items in the
+group.
+Any operation(s) performed by the group function behave as if they were defined
+in the barrier's completion function and were invoked as part of the barrier's
+phase completion step.
+====
+
 If one work-item in a group calls a group function, then all work-items in that
 group must call exactly the same function under the same set of conditions ---
 calling the same function under different conditions (e.g. in different

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19896,9 +19896,9 @@ The behavior of every group function is as follows:
     with the group function, then blocks until any operation(s) specified by the
     group function have completed.
 
-  * Once all work-items in the group have arrived, an unspecified
-    subset of those work-items cooperate to execute any operation(s) specified
-    by the group function.
+  * Once all work-items in the group have arrived, an unspecified subset of
+    those work-items cooperate to execute any operation(s) specified by the
+    group function.
 
   * When the set of cooperating work-items have completed execution of all
     operation(s) specified by the group function, all work-items blocked on the

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19992,19 +19992,15 @@ include::{header_dir}/groups/barrier.h[lines=4..-1]
     [code]#sycl::is_group_v<std::decay_t<Group>># is true.
 +
 --
-_Effects:_ The current work-item will wait at the barrier until all work-items
-in group [code]#g# have reached the barrier.
-In addition, the barrier performs <<mem-fence>> operations ensuring that memory
-accesses issued before the barrier are not re-ordered with those issued after
-the barrier: all work-items in group [code]#g# execute a release fence prior to
-arriving at the barrier, all work-items in group [code]#g# execute an acquire
-fence afterwards, and there is an implicit synchronization of these fences as if
-provided by an explicit atomic operation on an atomic object.
+_Effects:_ Blocks this work-item until all work-items in group [code]#g# have
+reached this synchronization point.
 
-By default, the scope of these fences is set to the narrowest scope including
-all work-items in group [code]#g# (as reported by [code]#Group::fence_scope#).
-This scope may be optionally overridden with a wider scope, specified by the
-[code]#fence_scope# argument.
+_Synchronization:_ The call to [code]#group_barrier# in each work-item happens
+before any work-item blocking on the same synchronization point is unblocked.
+Synchronization operations used in an implementation of [code]#group_barrier#
+must respect the memory scope specified by the [code]#scope# parameter, which
+defaults to the narrowest scope including all work-items in group [code]#g# (as
+reported by [code]#Group::fence_scope#).
 --
 
 [[sec:algorithms]]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19896,7 +19896,7 @@ The behavior of every group function is as follows:
     with the group function, then blocks until any operation(s) specified by the
     group function have completed.
 
-  * Once all work-items in the group have arrived, an implementation-defined
+  * Once all work-items in the group have arrived, an unspecified
     subset of those work-items cooperate to execute any operation(s) specified
     by the group function.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19992,8 +19992,8 @@ include::{header_dir}/groups/barrier.h[lines=4..-1]
     [code]#sycl::is_group_v<std::decay_t<Group>># is true.
 +
 --
-_Effects:_ Blocks this work-item until all work-items in group [code]#g# have
-reached this synchronization point.
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point.
 
 _Synchronization:_ The call to [code]#group_barrier# in each work-item happens
 before any work-item blocking on the same synchronization point is unblocked.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19890,6 +19890,23 @@ work-items (such as <<group-barrier,group barriers>> and collective operations).
 These group functions act as _synchronization points_ and must be encountered in
 converged <<control-flow>> by all work-items in the group.
 
+The behavior of every group function is as follows:
+
+  * Each work-item in the group arrives at the synchronization point associated
+    with the group function, then blocks until any operation(s) specified by the
+    group function have completed.
+
+  * Once all work-items in the group have arrived, an implementation-defined
+    subset of those work-items cooperate to execute any operation(s) specified
+    by the group function.
+
+  * When the set of cooperating work-items have completed execution of all
+    operation(s) specified by the group function, all work-items blocked on the
+    synchronization point associated with the group function are unblocked.
+
+The completion of the operation(s) specified by the group function happens
+before the returns from all calls that were unblocked.
+
 [NOTE]
 ====
 The behavior of group functions is analogous to the behavior of the C++20

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20069,6 +20069,14 @@ _Preconditions:_ [code]#first# and [code]#last# must be the same for all
 work-items in group [code]#g#, and [code]#pred# must be an immutable callable
 with the same type and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# returns true when applied to the result of
 dereferencing any iterator in the range [code]#[first, last)#.
 --
@@ -20080,6 +20088,14 @@ dereferencing any iterator in the range [code]#[first, last)#.
 _Preconditions:_ [code]#pred# must be an immutable callable with the same type
 and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred(x)# returns true for any work-item in group
 [code]#g#.
 --
@@ -20088,6 +20104,14 @@ _Returns:_ true if [code]#pred(x)# returns true for any work-item in group
     [code]#sycl::is_group_v<std::decay_t<Group>># is true.
 +
 --
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# is true for any work-item in group [code]#g#.
 --
 
@@ -20105,6 +20129,14 @@ _Preconditions:_ [code]#first# and [code]#last# must be the same for all
 work-items in group [code]#g#, and [code]#pred# must be an immutable callable
 with the same type and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# returns true when applied to the result of
 dereferencing all iterators in the range [code]#[first, last)#.
 --
@@ -20116,6 +20148,14 @@ dereferencing all iterators in the range [code]#[first, last)#.
 _Preconditions:_ [code]#pred# must be an immutable callable with the same type
 and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred(x)# returns true for all work-items in group
 [code]#g#.
 --
@@ -20124,6 +20164,14 @@ _Returns:_ true if [code]#pred(x)# returns true for all work-items in group
     [code]#sycl::is_group_v<std::decay_t<Group>># is true.
 +
 --
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# is true for all work-items in group [code]#g#.
 --
 
@@ -20141,6 +20189,14 @@ _Preconditions:_ [code]#first# and [code]#last# must be the same for all
 work-items in group [code]#g#, and [code]#pred# must be an immutable callable
 with the same type and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# returns false when applied to the result of
 dereferencing all iterators in the range [code]#[first, last)#.
 --
@@ -20152,6 +20208,14 @@ dereferencing all iterators in the range [code]#[first, last)#.
 _Preconditions:_ [code]#pred# must be an immutable callable with the same type
 and state for all work-items in group [code]#g#.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred(x)# returns false for all work-items in group
 [code]#g#.
 --
@@ -20160,6 +20224,14 @@ _Returns:_ true if [code]#pred(x)# returns false for all work-items in group
     [code]#sycl::is_group_v<std::decay_t<Group>># is true.
 +
 --
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ true if [code]#pred# is false for all work-items in group [code]#g#.
 --
 
@@ -20185,6 +20257,14 @@ include::{header_dir}/algorithms/shift.h[lines=4..-1]
 --
 _Preconditions:_ [code]#delta# must be the same for all work-items in the group.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ the value of [code]#x# from the work-item whose group local id
 ([code]#id#) is [code]#delta# larger than that of the calling work-item.
 [code]#pass:[id + delta]# may be greater than or equal to the group's linear
@@ -20196,6 +20276,14 @@ size, but the value returned in this case is unspecified.
 +
 --
 _Preconditions:_ [code]#delta# must be the same for all work-items in the group.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ the value of [code]#x# from the work-item whose group local id
 ([code]#id#) is [code]#delta# smaller than that of the calling work-item.
@@ -20223,6 +20311,14 @@ include::{header_dir}/algorithms/permute.h[lines=4..-1]
 --
 _Preconditions:_ [code]#mask# must be the same for all work-items in the group.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ the value of [code]#x# from the work-item whose group local id is
 equal to the bitwise exclusive OR of the calling work-item's group local id and
 [code]#mask#.
@@ -20247,6 +20343,14 @@ include::{header_dir}/algorithms/select.h[lines=4..-1]
     sub_group># is true and [code]#T# is a trivially copyable type.
 +
 --
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ the value of [code]#x# from the work-item with the group local id
 specified by [code]#remote_local_id#.
 The value of [code]#remote_local_id# may be outside of the group, but the value
@@ -20291,6 +20395,14 @@ _Preconditions:_ [code]#first#, [code]#last# and the type of [code]#binary_op#
 must be the same for all work-items in group [code]#g#.
 [code]#binary_op# must be an instance of a SYCL function object.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ The result of combining the values resulting from dereferencing all
 iterators in the range [code]#[first, last)# using the operator
 [code]#binary_op#, where the values are combined according to the generalized
@@ -20310,6 +20422,14 @@ _Preconditions:_ [code]#first#, [code]#last#, [code]#init# and the type of
 [code]#binary_op# must be the same for all work-items in group [code]#g#.
 [code]#binary_op# must be an instance of a SYCL function object.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ The result of combining the values resulting from dereferencing all
 iterators in the range [code]#[first, last)# and the initial value [code]#init#
 using the operator [code]#binary_op#, where the values are combined according to
@@ -20326,6 +20446,14 @@ _Mandates:_ [code]#binary_op(x, x)# must return a value of type [code]#T#.
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
 
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
+
 _Returns:_ The result of combining all the values of [code]#x# specified by each
 work-item in group [code]#g# using the operator [code]#binary_op#, where the
 values are combined according to the generalized sum defined in standard {cpp}.
@@ -20341,6 +20469,14 @@ _Mandates:_ [code]#binary_op(init, x)# must return a value of type [code]#T#.
 
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ The result of combining all the values of [code]#x# specified by each
 work-item in group [code]#g# and the initial value [code]#init# using the
@@ -20398,12 +20534,20 @@ _Preconditions:_ [code]#first#, [code]#last#, [code]#result# and the type of
 Note that [code]#first# may be equal to [code]#result#.
 ====
 
-_Effects:_ The value written to [code]#result# + _i_ is the exclusive scan of
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+The value written to [code]#result# + _i_ is the exclusive scan of
 the values resulting from dereferencing the first _i_ values in the range
 [code]#[first, last)# and the identity value of [code]#binary_op# (as identified
 by [code]#sycl::known_identity#), using the operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
 --
@@ -20427,12 +20571,20 @@ the type of [code]#binary_op# must be the same for all work-items in group
 Note that [code]#first# may be equal to [code]#result#.
 ====
 
-_Effects:_ The value written to [code]#result# + _i_ is the exclusive scan of
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+The value written to [code]#result# + _i_ is the exclusive scan of
 the values resulting from dereferencing the first _i_ values in the range
 [code]#[first, last)# and an initial value specified by [code]#init#, using the
 operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
 --
@@ -20447,6 +20599,14 @@ _Mandates:_ [code]#binary_op(x, x)# must return a value of type [code]#T#.
 
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ The value returned on work-item _i_ is the exclusive scan of the
 first _i_ values in group [code]#g# and the identity value of [code]#binary_op#
@@ -20468,6 +20628,14 @@ _Mandates:_ [code]#binary_op(init, x)# must return a value of type [code]#T#.
 
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ The value returned on work-item _i_ is the exclusive scan of the
 first _i_ values in group [code]#g# and an initial value specified by
@@ -20501,11 +20669,19 @@ _Preconditions:_ [code]#first#, [code]#last#, [code]#result# and the type of
 Note that [code]#first# may be equal to [code]#result#.
 ====
 
-_Effects:_ The value written to [code]#result# + _i_ is the inclusive scan of
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+The value written to [code]#result# + _i_ is the inclusive scan of
 the values resulting from dereferencing the first _i_ values in the range
 [code]#[first, last)#, using the operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
 --
@@ -20529,12 +20705,20 @@ the type of [code]#binary_op# must be the same for all work-items in group
 Note that [code]#first# may be equal to [code]#result#.
 ====
 
-_Effects:_ The value written to [code]#result# + _i_ is the inclusive scan of
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+The value written to [code]#result# + _i_ is the inclusive scan of
 the values resulting from dereferencing the first _i_ values in the range
 [code]#[first, last)# and an initial value specified by [code]#init#, using the
 operator [code]#binary_op#.
 The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
 --
@@ -20549,6 +20733,14 @@ _Mandates:_ [code]#binary_op(x, x)# must return a value of type [code]#T#.
 
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ The value returned on work-item _i_ is the inclusive scan of the
 first _i_ values in group [code]#g#, using the operator [code]#binary_op#.
@@ -20568,6 +20760,14 @@ _Mandates:_ [code]#binary_op(init, x)# must return a value of type [code]#T#.
 
 _Preconditions:_ [code]#binary_op# must be an instance of a SYCL function
 object.
+
+_Effects:_ Blocks until all work-items in group [code]#g# have reached this
+synchronization point, then executes the algorithm.
+
+_Synchronization:_ The call to this function in each work-item happens
+before the algorithm begins execution.
+The completion of the algorithm happens before any work-item blocking on the
+same synchronization point is unblocked.
 
 _Returns:_ The value returned on work-item _i_ is the inclusive scan of the
 first _i_ values in group [code]#g# and an initial value specified by

--- a/adoc/headers/groups/barrier.h
+++ b/adoc/headers/groups/barrier.h
@@ -3,4 +3,4 @@
 
 template <typename Group>
 void group_barrier(Group g,
-                   memory_scope fence_scope = Group::fence_scope); // (1)
+                   memory_scope scope = Group::fence_scope); // (1)


### PR DESCRIPTION
These changes build on https://github.com/KhronosGroup/SYCL-Docs/pull/484 to clarify the expected synchronization behavior of group barriers and algorithms.

The wording proposed here deliberately does not specify how a SYCL implementation must satisfy certain guarantees.  Previously, barriers were described in terms of fences and atomics, and we had discussed (offline) the possibility of defining algorithms similarly (or in terms of barriers).  The approach taken by `std::barrier` in ISO C++ is much simpler, giving implementations the freedom to use any combination of synchronization operations that guarantee certain events to happen before other events.
For example, it should be legal to implement `sycl::group_barrier` using any of the following: `std::atomic_thread_fence` + relaxed `std::atomic_ref`, release atomics paired with acquire atomics, a call to `std::barrier`, or any implementation-defined (backend-specific) functions that provide the desired memory ordering semantics.

There's a lot of duplication here now, but there are two reasons for that:

1) I wanted some feedback on the wording, and specifically whether we would like the "Effects" for each algorithm to mention the algorithm by name.

2) I wanted to separate the review of the clarifications from any later formatting changes.  The new table of overloads format that @gmlueck has been working on would allow us to combine some of these definitions.

Closes internal issue 576.