### PR TITLE
Improve default allocator wording

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4119,7 +4119,7 @@ STL-based libraries (e.g, Intel's TBB provides an allocator).
 ==== Default allocators
 
 A default allocator is always defined by the implementation.
-For allocations greater than size zero, it is guaranteed to return
+For allocations greater than size zero, when successful it is guaranteed to return
 non-[code]#nullptr# and new memory positions every call.
 The default allocator for const buffers will remove the const-ness of the type
 (therefore, the default allocator for a buffer of type [code]#const int# will be

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4119,8 +4119,8 @@ STL-based libraries (e.g, Intel's TBB provides an allocator).
 ==== Default allocators
 
 A default allocator is always defined by the implementation.
-For allocations greater than size zero, when successful it is guaranteed to return
-non-[code]#nullptr# and new memory positions every call.
+For allocations greater than size zero, when successful it is guaranteed to
+return non-[code]#nullptr# and new memory positions every call.
 The default allocator for const buffers will remove the const-ness of the type
 (therefore, the default allocator for a buffer of type [code]#const int# will be
 an [code]#Allocator<int>)#.


### PR DESCRIPTION
The spec currently implies (by my reading) that the default allocator can never fail (even on e.g. memory exhaustion).  So the spec makes  a stronger guarantee than the named allocator requirement, which probably isn't implementable.

The modified wording weakens the guarantee to allow allocations to fail.