### PR TITLE
Host allocation sharing via set final data - construction->destruction

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6044,7 +6044,7 @@ For example, the following could be used:
 
 However, optionally the [code]#buffer::set_final_data()# can be set to a
 [code]#std::weak_ptr# to enable copying data back, to another host memory
-address that is going to be valid after buffer construction.
+address that is going to be valid after buffer destruction.
 
 [source,,linenums]
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6044,7 +6044,7 @@ For example, the following could be used:
 
 However, optionally the [code]#buffer::set_final_data()# can be set to a
 [code]#std::weak_ptr# to enable copying data back, to another host memory
-address that is going to be valid after buffer destruction.
+address that will be valid when the buffer is destroyed.
 
 [source,,linenums]
 ----


### PR DESCRIPTION
I'm not completely sure of this fix, but I think "destruction" fits better here since `set_final_data` is called post-construction.  Maybe better to say "valid at buffer destruction" instead of "after", but that matters less.