### PR TITLE
Update reqd_sub_group_size argument name.

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -569,7 +569,7 @@ a future version of the specification and is not recommended for use in new code
 a@
 [source]
 ----
-reqd_sub_group_size(dim)
+reqd_sub_group_size(size)
 ----
    a@ Indicates that the kernel must be compiled and executed with the specified
       sub-group size. The argument to the attribute must be an integral constant


### PR DESCRIPTION
`dim` name is tipically used to denote the dimension (see reqd_work_group_size attribute description). In this case we set the size characterisitic, rather than the dimension.