### PR TITLE
[reflow] Abbreviation "ch." does not end sentence

### DIFF
--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -1157,9 +1157,9 @@ All content in this section is non-normative.
 
 === Work-item functions
 
-The OpenCL 1.2 specification document <<opencl12, ch.
-6.12.1 in Table 6.7>> defines work-item functions that tell various information
-about the currently executing work-item in an OpenCL kernel.
+The OpenCL 1.2 specification document <<opencl12, ch. 6.12.1 in Table 6.7>>
+defines work-item functions that tell various information about the currently
+executing work-item in an OpenCL kernel.
 SYCL provides equivalent functionality through the item and group classes that
 are defined in <<subsec:item.class>>, <<nditem-class>> and <<group-class>>.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20587,8 +20587,7 @@ determined by their linear id.
 
 In SYCL the OpenCL math functions are available in the namespace [code]#sycl# on
 host and device with the same precision guarantees as defined in the OpenCL 1.2
-specification document <<opencl12, ch.
-7>> for host and device.
+specification document <<opencl12, ch. 7>> for host and device.
 For a SYCL platform the numerical requirements for host need to match the
 numerical requirements of the OpenCL math built-in functions.
 

--- a/adoc/scripts/reflow.py
+++ b/adoc/scripts/reflow.py
@@ -53,7 +53,7 @@ codePat = re.compile(r'code:(?P<param>\w+)')
 # A single letter followed by a period, typically a middle initial.
 endInitial = re.compile(r'^[A-Z]\.$')
 # An abbreviation, which does not (usually) end a line.
-endAbbrev = re.compile(r'(e\.g|i\.e|c\.f|vs|co|ltd)\.$', re.IGNORECASE)
+endAbbrev = re.compile(r'(e\.g|i\.e|c\.f|\bvs\b|\bco\b|\bltd\b|\bch\b)\.$', re.IGNORECASE)
 
 # Explicit Valid Usage list item with one or more leading asterisks
 # The re.DOTALL is needed to prevent vuPat.search() from stripping


### PR DESCRIPTION
Change the reflow script so that "ch." does not end a sentence. Also adjust the existing reflow abbreviations to match only whole words.