### PR TITLE
Add Alignment Imposition

### DIFF
--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -31,6 +31,7 @@
   * Verena Beckham, Codeplay
   * Aidan Belton, Codeplay
   * Gordon Brown, Codeplay
+  * Atharva Dubey, Codeplay
   * Morris Hafner, Codeplay
   * Alexander Johnston, Codeplay
   * Marios Katsigiannis, Codeplay
@@ -90,7 +91,6 @@
   * Peter Thoman, University of Innsbruck
   * Biagio Cosenza, University of Salerno
   * Paul Preney, University of Windsor
-  * Atharva Dubey, Codeplay
 
 // Jon: in other specs we credit Khronos staff who have helped.
 // Ronan: indeed! Just reading this while actually adding the... Khronos

--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -90,6 +90,7 @@
   * Peter Thoman, University of Innsbruck
   * Biagio Cosenza, University of Salerno
   * Paul Preney, University of Windsor
+  * Atharva Dubey, Codeplay
 
 // Jon: in other specs we credit Khronos staff who have helped.
 // Ronan: indeed! Just reading this while actually adding the... Khronos

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17218,7 +17218,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr)
 ----
-   a@ Loads the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#, into the components of this SYCL [code]#vec#.
+   a@ Loads the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#, into the components of this SYCL [code]#vec#. [code]#vec# must be aligned to the size of the data type of this SYCL vec.
 
 a@
 [source]
@@ -17226,7 +17226,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const
 ----
-   a@ Stores the components of this SYCL [code]#vec# into the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#.
+   a@ Stores the components of this SYCL [code]#vec# into the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#. [code]#vec# must be aligned to the size of the data type of this SYCL vec.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17218,7 +17218,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr)
 ----
-   a@ Loads [code]#NumElements# elements from consecutive addresses, with the starting address determined by incrementing [code]#ptr# by [code]#offset# provided in terms of number of elements of type [code]#DataT#,  into the components of this SYCL [code]#vec#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
+   a@ Loads [code]#NumElements# elements into the components of this SYCL [code]#vec#. These elements are loaded from consecutive addresses, where the starting address is computed by adding [code]#offset * NumElements * sizeof(DataT)# bytes to the address specified by the [code]#ptr#. The ptr must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]
@@ -17226,7 +17226,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const
 ----
-   a@ Stores [code]#NumElements# components of this SYCL [code]#vec# into consecutive addresses, with the starting address determined by incrementing [code]#ptr# by [code]#offset# provided in terms of number of elements of type [code]#DataT#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
+   a@ Stores [code]#NumElements# components of this SYCL [code]#vec# into consecutive addresses, with the starting address determined by adding [code]#offset * NumElements * sizeof(DataT)# to the address specified by the [code]#ptr#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17218,7 +17218,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr)
 ----
-   a@ Loads the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#, into the components of this SYCL [code]#vec#. [code]#vec# must be aligned to the size of the data type of this SYCL vec.
+   a@ Loads the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#, into the components of this SYCL [code]#vec#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]
@@ -17226,7 +17226,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const
 ----
-   a@ Stores the components of this SYCL [code]#vec# into the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#. [code]#vec# must be aligned to the size of the data type of this SYCL vec.
+   a@ Stores the components of this SYCL [code]#vec# into the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17218,7 +17218,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr)
 ----
-   a@ Loads the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#, into the components of this SYCL [code]#vec#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
+   a@ Loads [code]#NumElements# elements from consecutive addresses, with the starting address determined by incrementing [code]#ptr# by [code]#offset# provided in terms of number of elements of type [code]#DataT#,  into the components of this SYCL [code]#vec#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]
@@ -17226,7 +17226,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void store(size_t offset, multi_ptr<DataT, AddressSpace, IsDecorated> ptr) const
 ----
-   a@ Stores the components of this SYCL [code]#vec# into the values at the address of [code]#ptr# offset in elements of type [code]#DataT# by [code]#NumElements * offset#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
+   a@ Stores [code]#NumElements# components of this SYCL [code]#vec# into consecutive addresses, with the starting address determined by incrementing [code]#ptr# by [code]#offset# provided in terms of number of elements of type [code]#DataT#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17230,7 +17230,7 @@ a@
 template <access::address_space AddressSpace, access::decorated IsDecorated>
 void load(size_t offset, multi_ptr<const DataT, AddressSpace, IsDecorated> ptr)
 ----
-   a@ Loads [code]#NumElements# elements into the components of this SYCL [code]#vec#. These elements are loaded from consecutive addresses, where the starting address is computed by adding [code]#offset * NumElements * sizeof(DataT)# bytes to the address specified by the [code]#ptr#. The ptr must be aligned to [code]#alignof(DataT)#.
+   a@ Loads [code]#NumElements# elements into the components of this SYCL [code]#vec#. These elements are loaded from consecutive addresses, where the starting address is computed by adding [code]#offset * NumElements * sizeof(DataT)# bytes to the address specified by the [code]#ptr#. The [code]#ptr# must be aligned to [code]#alignof(DataT)#.
 
 a@
 [source]


### PR DESCRIPTION
Imposes an alignment requirements on the vectors passed to SYCL' vector class' `load/store` method.
Fixes the issue described in #508 