### PR TITLE
Fix an editorial mistake in "vec"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17570,7 +17570,7 @@ Where [code]#OP# is: [code]#==#, [code]#!=#, [code]#<#, [code]#>#, [code]#+<=+#,
 a@
 [source]
 ----
-vec& operator~(const vec& v)
+vec operator~(const vec& v)
 ----
    a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
 
@@ -22255,7 +22255,7 @@ template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (4)
 
 *Overloads (1) - (3):*
 
-_Effects_: Computes the approximate value of [code]#a * b + c#.  Whether or how
+_Effects:_ Computes the approximate value of [code]#a * b + c#.  Whether or how
 the product of [code]#a * b# is rounded and how supernormal or subnormal
 intermediate products are handled is not defined.  The [code]#mad# function is
 intended to be used where speed is preferred over accuracy.


### PR DESCRIPTION
I'm fairly certain this is an editorial mistake with the definition of `vec::operator~`.  The synopses of the `vec` class shows the correct return type, so this just updates the table to match.