### PR TITLE
Clarify that capture by ref host_task requires caution

### DIFF
--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -31,6 +31,7 @@
   * Verena Beckham, Codeplay
   * Aidan Belton, Codeplay
   * Gordon Brown, Codeplay
+  * Hugh Delaney, Codeplay
   * Morris Hafner, Codeplay
   * Alexander Johnston, Codeplay
   * Marios Katsigiannis, Codeplay

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14622,6 +14622,15 @@ interoperability member functions provided by the [code]#interop_handle# class.
 
 Local <<accessor,accessors>> cannot be used within a <<host-task>>.
 
+[NOTE]
+====
+If a C++ lambda is passed to a <<host-task>>, the lambda may capture by
+reference or by value.
+Since the <<host-task>> callable executes asynchronously, care must be taken to
+ensure that lifetimes of objects captured by reference by a <<host-task>> lambda
+last at least until the <<host-task>> completes.
+====
+
 // TODO: access mode/target resolution rules
 
 [source,,linenums]


### PR DESCRIPTION
C++ lambdas if capturing by ref need to be aware of the lifetime of the referred-to objects. This adds this information here as well. 

Motivation:

https://github.com/oneapi-src/oneDNN/pull/1767