### PR TITLE
Clarify group function inputs must be initialized

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19975,6 +19975,9 @@ include::{header_dir}/groups/broadcast.h[lines=4..-1]
     trivially copyable type.
 +
 --
+_Preconditions:_ [code]#x# must be initialized by all work-items in group
+[code]#g#.
+
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the broadcast operation.
 
@@ -19994,6 +19997,7 @@ within group [code]#g#.
 --
 _Preconditions:_ [code]#local_linear_id# must be the same for all work-items in
 the group and must be in the range [code]#[0, get_local_linear_range())#.
+[code]#x# must be initialized by all work-items in group [code]#g#.
 
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the broadcast operation.
@@ -20016,6 +20020,7 @@ _Preconditions:_ [code]#local_id# must be the same for all work-items in the
 group, and its dimensionality must match the dimensionality of the group.
 The value of [code]#local_id# in each dimension must be greater than or equal to
 0 and less than the value of [code]#get_local_range()# in the same dimension.
+[code]#x# must be initialized by all work-items in group [code]#g#.
 
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the broadcast operation.
@@ -20394,6 +20399,9 @@ include::{header_dir}/algorithms/select.h[lines=4..-1]
     sub_group># is true and [code]#T# is a trivially copyable type.
 +
 --
+_Preconditions:_ [code]#x# must be initialized by all work-items in group
+[code]#g#.
+
 _Effects:_ Blocks until all work-items in group [code]#g# have reached this
 synchronization point, then executes the algorithm.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19928,6 +19928,19 @@ Any such restrictions on the arguments passed to a function are defined within
 the descriptions of those functions.
 Violating these restrictions results in undefined behavior.
 
+[NOTE]
+====
+One important restriction is that all inputs to group functions must be
+initialized on all work-items, even if it is known that some values will be
+discarded.
+For example, all work-items must initialize the value they pass to
+[code]#group_broadcast#, even though all but one value will be discarded.
+
+This is necessary for compatibility with standard C++ rules and ensures that
+compilers cannot perform optimizations that break the collective semantics of
+group functions.
+====
+
 All group functions are supported for the fundamental scalar types supported by
 SYCL (see <<table.types.fundamental>>) and instances of the SYCL [code]#vec# and
 [code]#marray# classes.


### PR DESCRIPTION
These clarifications were motivated by code that looks like this:

```c++
uint32_t x;                        // uninitialized variable
if (sg.leader()) {
  x = foo();                       // variable is initialized by the group leader only
}
x = sycl::group_broadcast(sg, x);  // value from group leader is broadcast to other work-items
```

Some SYCL developers (including me!) might expect that this code to be safe, because:
- The leader always initializes `x` before its value is broadcast to other work-items
- The `group_broadcast` call always returns the value from the leader, and values from other work-items are always discarded
- The result of the `group_broadcast` is always assigned to `x` in all work-items before it is used

However, because `group_broadcast` accepts `x` by value, C++ rules say that `group_broadcast` reads the uninitialized value(s) on all work-items. This is undefined behavior, and so compilers are free to optimize code like the above in surprising ways.  For example, a compiler may decide that since the call to `group_broadcast` is only legal if `x` is initialized, and `x` is only initialized if `sg.leader()` is true, `sg.leader()` must be unconditionally true and thus the branch can be eliminated.

The fix suggested by this commit is to clarify that the code above is illegal, and must be rewritten as:

```c++
uint32_t x  = 0;                   // initialized variable
if (sg.leader()) {
  x = foo();                       // variable is overwritten by the group leader only
}
x = sycl::group_broadcast(sg, x);  // value from group leader is broadcast to other work-items
```

Changing the declarations of the group functions to accept `T&` instead of `T` was considered as an alternative fix. Although it seems promising, there's no way for us (the writers of the SYCL specification) to change the definitions of other backend-specific APIs (e.g., in SPIR-V or CUDA) that may be used to implement these functions.  If the backend-specific APIs ultimately take the arguments by value, changing the SYCL interface may not be sufficient to prevent unsafe optimizations.