### PR TITLE
Add clarification to event wait wording

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3838,7 +3838,7 @@ void wait_and_throw()
 Any uncomsumed <<async-error,asynchronous errors>> held by queues (or their
 associated contexts) which were used to enqueue commands associated with this
 event and any dependent events, are passed to the approriate <<async-handler>>
-as described in <<async.handler.priorities>>.
+as described in <<subsubsec:async.handler.priorities>>.
 
 [NOTE]
 ====

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3835,13 +3835,16 @@ void wait_and_throw()
    a@ Blocks until all commands associated with this event and any dependent
       events have completed.
 
-Any unconsumed <<async-error,asynchronous errors>> which were produced by the
-execution of commands associated with this event or any dependent events, are
-passed to the <<async-handler>> associated with the respective context.
+Any uncomsumed <<async-error,asynchronous errors>> held by queues (or their
+associated contexts) which were used to enqueue commands associated with this
+event and any dependent events, are passed to the approriate <<async-handler>>
+as described in <<async.handler.priorities>>.
 
-If no user defined <<async-handler>> is associated with the context, then an
-implementation-defined default <<async-handler>> is invoked to handle errors,
-as described in <<subsubsec:exception.nohandler>>.
+[NOTE]
+====
+This behaviour is equivalent to calling [code]#queue::throw_asynchronous()# on
+the queue associated with this event and any dependent events.
+====
 
 a@
 [source]
@@ -16471,6 +16474,7 @@ defined in <<subsubsec:exception.async>>.
 The default <<async-handler>> must in some way report all errors passed to it,
 when possible, and must then invoke [code]#std::terminate# or equivalent.
 
+[[subsubsec:async.handler.priorities]]
 ==== Priorities of async handlers
 
 If the SYCL runtime can associate an <<async-error>> with a specific queue,

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3835,10 +3835,10 @@ void wait_and_throw()
    a@ Blocks until all commands associated with this event and any dependent
       events have completed.
 
-Any uncomsumed <<async-error,asynchronous errors>> held by queues (or their
-associated contexts) which were used to enqueue commands associated with this
-event and any dependent events, are passed to the approriate <<async-handler>>
-as described in <<subsubsec:async.handler.priorities>>.
+At least all uncomsumed <<async-error,asynchronous errors>> held by queues (or
+their associated contexts) which were used to enqueue commands associated with
+this event and any dependent events, are passed to the approriate
+<<async-handler>> as described in <<subsubsec:async.handler.priorities>>.
 
 [NOTE]
 ====

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3824,46 +3824,40 @@ a@
 ----
 void wait()
 ----
-   a@ Wait for the event and the command associated with
-      it to complete.
+   a@ Blocks until all commands associated with this event and any dependent
+      events have completed.
 
 a@
 [source]
 ----
 void wait_and_throw()
 ----
-   a@ Wait for the event and the command associated with
-      it to complete.
+   a@ Blocks until all commands associated with this event and any dependent
+      events have completed.
 
-Any unconsumed <<async-error,asynchronous errors>> from any context that the event
-was waiting on executions from will be passed to the
-<<async-handler>> associated with the context.
-If no user defined [code]#async_handler# is associated with
-the context, then an implementation-defined
-default <<async-handler>> is called to handle any errors, as
-described in <<subsubsec:exception.nohandler>>.
+Any unconsumed <<async-error,asynchronous errors>> which were produced by the
+execution of commands associated with this event or any dependent events, are
+passed to the <<async-handler>> associated with the respective context.
+
+If no user defined <<async-handler>> is associated with the context, then an
+implementation-defined default <<async-handler>> is invoked to handle errors,
+as described in <<subsubsec:exception.nohandler>>.
 
 a@
 [source]
 ----
 static void wait(const std::vector<event>& eventList)
 ----
-   a@ Synchronously wait on a list of events.
+   a@ Behaves as if calling [code]#event::wait()# on each event in
+      [code]#eventList#.
 
 a@
 [source]
 ----
 static void wait_and_throw(const std::vector<event>& eventList)
 ----
-   a@ Synchronously wait on a list of events.
-
-Any unconsumed <<async-error,asynchronous errors>> from any context that the event
-was waiting on executions from will be passed to the
-<<async-handler>> associated with the context.
-If no user defined [code]#async_handler# is associated with
-the context, then an implementation-defined
-default <<async-handler>> is called to handle any errors, as
-described in <<subsubsec:exception.nohandler>>.
+   a@ Behaves as if calling [code]#event::wait_and_throw()# on each event in
+      [code]#eventList#.
 
 a@
 [source]


### PR DESCRIPTION
**Motivation**

It was discovered that the current wording for `event::wait_and_throw` was ambiguous.

_Table 34_
> Wait for the event and the command associated with it to complete.
> 
> Any unconsumed async-error from any context that the event was waiting on executions from will be passed to the async_handler associated with the context. If no user defined async_handler is associated with the context, then an implementation-defined default async_handler is called to handle any errors, as described in [Section 4.13.1.2].

The above wording suggests that only errors produced by commands associated with this event are waiting on are passed to the async handler, however, the use of the phrase "any context that the event was waiting on executions from" suggests that the intention was to pass errors produced by commands of this event and any dependent events.

**Summary**

In this patch, I have modified the wording of the `event::wait_and_throw()` member functions to clarify that they will throw asynchronous errors for this event and all dependent events to their respective async handlers.

While changing this I have also modified the wording around the waiting behavior for both the `event::wait` and `event::wait_and_throw` member functions to match that which is used in the ISO C++ specification; to state that the function blocks until all commands have been completed. This wording could be extended to also include a synchronization clause, however, since these functions are still using the original format, I've just kept this to the effects clause for now.

Finally, I have modified the wording of the static `event::wait()` and `event::wait_and_throw()` functions to be based on the definitions in member functions to avoid duplication of wording.

**Target**

This patch is targeting SYCL 2020 as a clarification.