### PR TITLE
Editorial fix in vector section

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16936,9 +16936,6 @@ This type allows sharing of vectors between the host and its SYCL devices.
 The vector supports member functions that allow construction of a new vector
 from a swizzled set of component elements.
 
-[code]#vec<typename _DataT_, int _NumElements_># is a vector type that compiles
-down to a <<backend>> built-in vector type on SYCL devices, where possible, and
-provides compatible support on the host when not possible.
 The [code]#vec# class is templated on its number of elements and its element
 type.
 The number of elements parameter, _NumElements_, can be one of: 1, 2, 3, 4, 8 or 16.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -16937,8 +16937,8 @@ The vector supports member functions that allow construction of a new vector
 from a swizzled set of component elements.
 
 [code]#vec<typename _DataT_, int _NumElements_># is a vector type that compiles
-down to a <<backend>> built-in vector types on SYCL devices, where possible, and
-provides compatible support on the host or when it is not possible.
+down to a <<backend>> built-in vector type on SYCL devices, where possible, and
+provides compatible support on the host when not possible.
 The [code]#vec# class is templated on its number of elements and its element
 type.
 The number of elements parameter, _NumElements_, can be one of: 1, 2, 3, 4, 8 or 16.


### PR DESCRIPTION
This fix makes the wording better, but I'm actually not sure what it means to have compatible support on the host when device support isn't possible.  Should the later part of this sentence be dropped totally, since I don't think there is alternate host emulation?  There is independently compatible support for the vector types on the host, unrelated to what the device supports, AFAICT.