### PR TITLE
Editorial fix for marray table

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17928,21 +17928,21 @@ a@
 ----
 iterator begin()
 ----
-   a@ Returns an iterator referring to the first element stored within the [code]#v# [code]#marray#.
+   a@ Returns an iterator referring to the first element stored within the [code]#marray#.
 
 a@
 [source]
 ----
 const_iterator begin() const
 ----
-   a@ Returns a const iterator referring to the first element stored within the [code]#v# [code]#marray#.
+   a@ Returns a const iterator referring to the first element stored within the [code]#marray#.
 
 a@
 [source]
 ----
 iterator end()
 ----
-   a@ Returns an iterator referring to the one past the last element stored within the [code]#v# [code]#marray#.
+   a@ Returns an iterator referring to the one past the last element stored within the [code]#marray#.
 
 a@
 [source]
@@ -17950,7 +17950,7 @@ a@
 const_iterator end() const
 ----
    a@ Returns a const iterator referring to the one past the last
-      element stored within the [code]#v# [code]#marray#.
+      element stored within the [code]#marray#.
 
 |====
 


### PR DESCRIPTION
I don't think the `v` makes sense