### PR TITLE
Update copyright notice to revision 10

### DIFF
--- a/adoc/chapters/copyright-spec.adoc
+++ b/adoc/chapters/copyright-spec.adoc
@@ -1,10 +1,11 @@
-Copyright (c) 2011-2023 The Khronos Group, Inc.
+Copyright 2011-2024 The Khronos Group Inc.
 
 This Specification is protected by copyright laws and contains material
 proprietary to Khronos.
 Except as described by these terms, it or any components may not be reproduced,
 republished, distributed, transmitted, displayed, broadcast or otherwise
 exploited in any manner without the express prior written permission of Khronos.
+
 Khronos grants a conditional copyright license to use and reproduce the
 unmodified Specification for any purpose, without fee or royalty, EXCEPT no
 licenses to any patent, trademark or other intellectual property rights are
@@ -23,26 +24,25 @@ from or in connection with these materials.
 
 This Specification has been created under the Khronos Intellectual Property
 Rights Policy, which is Attachment A of the Khronos Group Membership Agreement
-available at https://www.khronos.org/files/member_agreement.pdf, and which
-defines the terms 'Scope', 'Compliant Portion', and 'Necessary Patent Claims'.
+available at https://www.khronos.org/files/member_agreement.pdf.
 Parties desiring to implement the Specification and make use of Khronos
 trademarks in relation to that implementation, and receive reciprocal patent
 license protection under the Khronos Intellectual Property Rights Policy must
 become Adopters and confirm the implementation as conformant under the process
 defined by Khronos for this Specification; see https://www.khronos.org/adopters.
 
+The Khronos Intellectual Property Rights Policy defines the terms 'Scope',
+'Compliant Portion', and 'Necessary Patent Claims'.
+
 Some parts of this Specification are purely informative and so are EXCLUDED from
 the Scope of this Specification.
-// Jon: how much do we want to say about Informative spec sections? No
-// convention in use at present. Could also add a "technical terminology"
-// section and link from the following paragraph.
-// The <<introduction-conventions>> section of the
-// <<introduction>> defines how these parts of the Specification are identified.
+<<sec:nonnormativerefs>> defines how these parts of the Specification are
+identified.
 
-Where this Specification uses technical terminology, defined in the <<glossary>>
-or otherwise, that refer to enabling technologies that are not expressly set
-forth in this Specification, those enabling technologies are EXCLUDED from the
-Scope of this Specification.
+Where this Specification uses technical terminology, defined in the Glossary or
+otherwise, that refer to enabling technologies that are not expressly set forth
+in this Specification, those enabling technologies are EXCLUDED from the Scope
+of this Specification.
 For clarity, enabling technologies not disclosed with particularity in this
 Specification (e.g. semiconductor manufacturing technology, hardware
 architecture, processor architecture or microarchitecture, memory architecture,
@@ -57,25 +57,26 @@ the definition of Necessary Patent Claims, all recommended or optional features,
 behaviors and functionality set forth in this Specification, if implemented, are
 considered to be included as Compliant Portions.
 
-Where this Specification includes normative references to external documents,
-only the specifically identified sections of those external documents are
-INCLUDED in the Scope of this Specification.
-If not created by Khronos, those external documents may contain contributions
-from non-members of Khronos not covered by the Khronos Intellectual Property
-Rights Policy.
+Where this Specification identifies specific sections of external references,
+only those specifically identified sections define normative functionality.
+The Khronos Intellectual Property Rights Policy excludes external references to
+materials and associated enabling technology not created by Khronos from the
+Scope of this Specification, and any licenses that may be required to implement
+such referenced materials and associated technologies must be obtained
+separately and may involve royalty payments.
 
-ifndef::ratified_core_spec[]
-This document contains extensions which are not ratified by Khronos, and as such
-is not a ratified Specification, though it contains text from (and is a superset
-of) the ratified SYCL Specification.
-The ratified version of the SYCL Specification can be found at
-https://www.khronos.org/registry/SYCL .
-endif::ratified_core_spec[]
-
-Khronos and Vulkan are registered trademarks, and SPIR-V is a trademark of The
-Khronos Group Inc.
-OpenCL is a trademark of Apple Inc.
-and OpenGL is a registered trademarks of Hewlett Packard Enterprise, all used
-under license by Khronos.
+Khronos(R) and Vulkan(R) are registered trademarks, and 3D Commerce(TM),
+ANARI(TM), Kamaros(TM), KTX(TM), glTF(TM), NNEF(TM), OpenVG(TM), OpenVX(TM),
+SPIR(TM), SPIR-V(TM), SYCL(TM), Vulkan SC(TM), and WebGL(TM) are trademarks of
+The Khronos Group Inc.
+OpenXR(TM) is a trademark owned by The Khronos Group Inc.
+and is registered as a trademark in China, the European Union, Japan and the
+United Kingdom.
+OpenCL(TM) is a trademark of Apple Inc.
+used under license by Khronos.
+OpenGL(R) is a registered trademark and the OpenGL ES(TM) and OpenGL SC(TM)
+logos are trademarks of Hewlett Packard Enterprise used under license by
+Khronos.
+ASTC is a trademark of ARM Holdings PLC.
 All other product names, trademarks, and/or company names are used solely for
 identification and belong to their respective owners.


### PR DESCRIPTION
Update the copyright notice to the latest Khronos template, which is revision 10.  Also update the copyright date to the current year.

This commit also fixes an unresolved issue with the previous notice by adding a reference to the section that describes how to identify the non-normative parts of the spec.