### PR TITLE
Bump copyright dates to the new year

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 The Khronos Group, Inc.
+# Copyright 2021-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # CI to build asciidoctor spec targets, on push or manually

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Khronos Group, Inc.
+# Copyright 2021-2023 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # CI to build asciidoctor spec targets, on push or manually

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2023 The Khronos Group, Inc.
+Copyright (c) 2011-2024 The Khronos Group, Inc.
 
 This specification is protected by copyright laws and contains material proprietary
 to Khronos. Except as described by these terms, it or any components

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2023 The Khronos Group, Inc.
+Copyright (c) 2011-2024 The Khronos Group, Inc.
 
 The files in, and generated output documents from this SYCL-Docs project are
 under a mix of copyright and license statements. Refer to the individual files

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2011-2023 The Khronos Group, Inc.
+# Copyright 2011-2024 The Khronos Group, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2011-2022 The Khronos Group, Inc.
+# Copyright 2011-2023 The Khronos Group, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/chapters/copyright-spec.adoc
+++ b/adoc/chapters/copyright-spec.adoc
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2023 The Khronos Group, Inc.
+Copyright (c) 2011-2024 The Khronos Group, Inc.
 
 This Specification is protected by copyright laws and contains material
 proprietary to Khronos.

--- a/adoc/code/algorithms.cpp
+++ b/adoc/code/algorithms.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 buffer<int> inputBuf { 1024 };

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>

--- a/adoc/code/aspectTraitExample.cpp
+++ b/adoc/code/aspectTraitExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/attributes.cpp
+++ b/adoc/code/attributes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Kernel defined as a lambda

--- a/adoc/code/basicParallelForGeneric.cpp
+++ b/adoc/code/basicParallelForGeneric.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/basicParallelForIntegral.cpp
+++ b/adoc/code/basicParallelForIntegral.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/basicParallelForItem.cpp
+++ b/adoc/code/basicParallelForItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/basicParallelForNumber.cpp
+++ b/adoc/code/basicParallelForNumber.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/basicparallelfor.cpp
+++ b/adoc/code/basicparallelfor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/bundle-builtin-kernel.cpp
+++ b/adoc/code/bundle-builtin-kernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/bundle-kernel-introspection.cpp
+++ b/adoc/code/bundle-kernel-introspection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/bundle-pre-compile.cpp
+++ b/adoc/code/bundle-pre-compile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/bundle-spec-constants.cpp
+++ b/adoc/code/bundle-spec-constants.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/deviceHas.cpp
+++ b/adoc/code/deviceHas.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 class KernelFunctor {

--- a/adoc/code/explicitcopy.cpp
+++ b/adoc/code/explicitcopy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 const size_t nElems = 10u;

--- a/adoc/code/handlingErrorCode.cpp
+++ b/adoc/code/handlingErrorCode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 void catch_invalid_errors(sycl::context const& ctx) {

--- a/adoc/code/handlingException.cpp
+++ b/adoc/code/handlingException.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 void catch_any_errors(sycl::context const& ctx) {

--- a/adoc/code/lambdaNameExamples.cpp
+++ b/adoc/code/lambdaNameExamples.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Explicit kernel names can be optionally forward declared at namespace scope

--- a/adoc/code/largesample.cpp
+++ b/adoc/code/largesample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>

--- a/adoc/code/myfunctor.cpp
+++ b/adoc/code/myfunctor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 class RandomFiller {

--- a/adoc/code/mykernel.cpp
+++ b/adoc/code/mykernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Explicit kernel names can be optionally forward declared at namespace scope

--- a/adoc/code/parallelForWithKernelHandler.cpp
+++ b/adoc/code/parallelForWithKernelHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/parallelForWorkGroupWithKernelHandler.cpp
+++ b/adoc/code/parallelForWorkGroupWithKernelHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/parallelfor.cpp
+++ b/adoc/code/parallelfor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/parallelforbarrier.cpp
+++ b/adoc/code/parallelforbarrier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/parallelforworkgroup.cpp
+++ b/adoc/code/parallelforworkgroup.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/parallelforworkgroup2.cpp
+++ b/adoc/code/parallelforworkgroup2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/propertyExample.cpp
+++ b/adoc/code/propertyExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 {

--- a/adoc/code/queueShortcuts.cpp
+++ b/adoc/code/queueShortcuts.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 class MyKernel;

--- a/adoc/code/reduction.cpp
+++ b/adoc/code/reduction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 buffer<int> valuesBuf { 1024 };

--- a/adoc/code/singleTaskWithKernelHandler.cpp
+++ b/adoc/code/singleTaskWithKernelHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/singletask.cpp
+++ b/adoc/code/singletask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 myQueue.submit([&](handler& cgh) {

--- a/adoc/code/specialization_id.cpp
+++ b/adoc/code/specialization_id.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/subbuffer.cpp
+++ b/adoc/code/subbuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 buffer<int, 2> parent_buffer { range<2> {

--- a/adoc/code/sycl-external.cpp
+++ b/adoc/code/sycl-external.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/twoOptionalFeatures.cpp
+++ b/adoc/code/twoOptionalFeatures.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 queue q1(dev1);

--- a/adoc/code/usingSpecConstants.cpp
+++ b/adoc/code/usingSpecConstants.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sycl/sycl.hpp>

--- a/adoc/code/usm_device.cpp
+++ b/adoc/code/usm_device.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>

--- a/adoc/code/usm_shared.cpp
+++ b/adoc/code/usm_shared.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>

--- a/adoc/config/copyright-ccby.txt
+++ b/adoc/config/copyright-ccby.txt
@@ -1,3 +1,3 @@
-Copyright 2014-2023 The Khronos Group Inc.
+Copyright 2014-2024 The Khronos Group Inc.
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/adoc/config/copyright-ccby.txt
+++ b/adoc/config/copyright-ccby.txt
@@ -1,4 +1,3 @@
-Copyright (c) 2011-2021 Khronos Group, Inc. This work is licensed under a
-http://creativecommons.org/licenses/by/4.0/[Creative Commons
-Attribution 4.0 International License].
+Copyright 2014-2023 The Khronos Group Inc.
 
+SPDX-License-Identifier: CC-BY-4.0

--- a/adoc/config/katex_replace.rb
+++ b/adoc/config/katex_replace.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'

--- a/adoc/config/katex_replace/extension.rb
+++ b/adoc/config/katex_replace/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'

--- a/adoc/config/loadable_html.rb
+++ b/adoc/config/loadable_html.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'

--- a/adoc/config/loadable_html/extension.rb
+++ b/adoc/config/loadable_html/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'

--- a/adoc/config/rouge_sycl.rb
+++ b/adoc/config/rouge_sycl.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 puts "Loading rouge_sycl extensions for source code highlighting"

--- a/adoc/config/spec-macros.rb
+++ b/adoc/config/spec-macros.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/config/spec-macros/extension.rb
+++ b/adoc/config/spec-macros/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/headers/accessMode.h
+++ b/adoc/headers/accessMode.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessProperties.h
+++ b/adoc/headers/accessProperties.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessTags.h
+++ b/adoc/headers/accessTags.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorDeprecatedConstant.h
+++ b/adoc/headers/accessorDeprecatedConstant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorDeprecatedHost.h
+++ b/adoc/headers/accessorDeprecatedHost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorDeprecatedLocal.h
+++ b/adoc/headers/accessorDeprecatedLocal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorSampledImage.h
+++ b/adoc/headers/accessorSampledImage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/accessorUnsampledImage.h
+++ b/adoc/headers/accessorUnsampledImage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/algorithms/all_of.h
+++ b/adoc/headers/algorithms/all_of.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename Ptr, typename Predicate>

--- a/adoc/headers/algorithms/any_of.h
+++ b/adoc/headers/algorithms/any_of.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename Ptr, typename Predicate>

--- a/adoc/headers/algorithms/exclusive_scan.h
+++ b/adoc/headers/algorithms/exclusive_scan.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename InPtr, typename OutPtr,

--- a/adoc/headers/algorithms/inclusive_scan.h
+++ b/adoc/headers/algorithms/inclusive_scan.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename InPtr, typename OutPtr,

--- a/adoc/headers/algorithms/is_group.h
+++ b/adoc/headers/algorithms/is_group.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/algorithms/none_of.h
+++ b/adoc/headers/algorithms/none_of.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename Ptr, typename Predicate>

--- a/adoc/headers/algorithms/permute.h
+++ b/adoc/headers/algorithms/permute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename T>

--- a/adoc/headers/algorithms/reduce.h
+++ b/adoc/headers/algorithms/reduce.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename Ptr, typename BinaryOperation>

--- a/adoc/headers/algorithms/select.h
+++ b/adoc/headers/algorithms/select.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename T>

--- a/adoc/headers/algorithms/shift.h
+++ b/adoc/headers/algorithms/shift.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename T>

--- a/adoc/headers/aspectTraits.h
+++ b/adoc/headers/aspectTraits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/atomic.h
+++ b/adoc/headers/atomic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace cl {

--- a/adoc/headers/atomicoperations.h
+++ b/adoc/headers/atomicoperations.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace cl {

--- a/adoc/headers/atomicref.h
+++ b/adoc/headers/atomicref.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/backends.h
+++ b/adoc/headers/backends.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/buffer.h
+++ b/adoc/headers/buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/bundle/deviceImageClass.h
+++ b/adoc/headers/bundle/deviceImageClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/bundle/freeFunctions.h
+++ b/adoc/headers/bundle/freeFunctions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/bundle/kernelBundleClass.h
+++ b/adoc/headers/bundle/kernelBundleClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/bundle/kernelClass.h
+++ b/adoc/headers/bundle/kernelClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/bundle/kernelIdClass.h
+++ b/adoc/headers/bundle/kernelIdClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/commandGroup.h
+++ b/adoc/headers/commandGroup.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/common-byval.h
+++ b/adoc/headers/common-byval.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/common-reference.h
+++ b/adoc/headers/common-reference.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/context.h
+++ b/adoc/headers/context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/contextInfo.h
+++ b/adoc/headers/contextInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/device.h
+++ b/adoc/headers/device.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/deviceEnumClassAspect.h
+++ b/adoc/headers/deviceEnumClassAspect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/deviceEvent.h
+++ b/adoc/headers/deviceEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/deviceInfo.h
+++ b/adoc/headers/deviceInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/deviceSelector.h
+++ b/adoc/headers/deviceSelector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/event.h
+++ b/adoc/headers/event.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/eventInfo.h
+++ b/adoc/headers/eventInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/exception.h
+++ b/adoc/headers/exception.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/expressingParallelism/classKernelHandler.h
+++ b/adoc/headers/expressingParallelism/classKernelHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/expressingParallelism/classSpecializationId.h
+++ b/adoc/headers/expressingParallelism/classSpecializationId.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
+++ b/adoc/headers/expressingParallelism/kernelHandlerSynopsis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/functional.h
+++ b/adoc/headers/functional.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/groups/barrier.h
+++ b/adoc/headers/groups/barrier.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group>

--- a/adoc/headers/groups/broadcast.h
+++ b/adoc/headers/groups/broadcast.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename Group, typename T> T group_broadcast(Group g, T x); // (1)

--- a/adoc/headers/handler/useKernelBundle.h
+++ b/adoc/headers/handler/useKernelBundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 void use_kernel_bundle(

--- a/adoc/headers/hitem.h
+++ b/adoc/headers/hitem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/hostTask/classHandler/hostTask.h
+++ b/adoc/headers/hostTask/classHandler/hostTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 class handler {

--- a/adoc/headers/hostTask/classInteropHandle.h
+++ b/adoc/headers/hostTask/classInteropHandle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 class interop_handle;

--- a/adoc/headers/hostTask/classInteropHandle/constructors.h
+++ b/adoc/headers/hostTask/classInteropHandle/constructors.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 private:

--- a/adoc/headers/hostTask/classInteropHandle/getbackend.h
+++ b/adoc/headers/hostTask/classInteropHandle/getbackend.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 backend get_backend() const noexcept;

--- a/adoc/headers/hostTask/classInteropHandle/getnativeX.h
+++ b/adoc/headers/hostTask/classInteropHandle/getnativeX.h
@@ -1,6 +1,6 @@
 headers / hostTask / classInteropHandle /
     getnativeX.h
-    // Copyright (c) 2011-2023 The Khronos Group, Inc.
+    // Copyright (c) 2011-2024 The Khronos Group, Inc.
     // SPDX-License-Identifier: MIT
 
     template <backend Backend, typename DataT, int Dims, access_mode AccMode,

--- a/adoc/headers/hostTask/hostTaskSynopsis.h
+++ b/adoc/headers/hostTask/hostTaskSynopsis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/identity.h
+++ b/adoc/headers/identity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 template <typename BinaryOperation, typename AccumulatorT>

--- a/adoc/headers/imageProperties.h
+++ b/adoc/headers/imageProperties.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/imageSampler.h
+++ b/adoc/headers/imageSampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/interop/templateFunctionGetNative.h
+++ b/adoc/headers/interop/templateFunctionGetNative.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/interop/templateFunctionMakeX.h
+++ b/adoc/headers/interop/templateFunctionMakeX.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/interop/typeTraitsBackendTraits.h
+++ b/adoc/headers/interop/typeTraitsBackendTraits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/item.h
+++ b/adoc/headers/item.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/kernelInfo.h
+++ b/adoc/headers/kernelInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/marray.h
+++ b/adoc/headers/marray.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/memoryOrder.h
+++ b/adoc/headers/memoryOrder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/memoryScope.h
+++ b/adoc/headers/memoryScope.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl {

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/ndRange.h
+++ b/adoc/headers/ndRange.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/openclBackend/createBundle.h
+++ b/adoc/headers/openclBackend/createBundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 namespace sycl::opencl {

--- a/adoc/headers/openclBackend/samplerImagePair.h
+++ b/adoc/headers/openclBackend/samplerImagePair.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 struct sampler_1dimage_pair_t {

--- a/adoc/headers/openclcInterop.h
+++ b/adoc/headers/openclcInterop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 extern "C" typename sycl::decorated_global_ptr<std::int32_t>::pointer

--- a/adoc/headers/parallelFor.h
+++ b/adoc/headers/parallelFor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 void single_task(kernel* syclKernel);

--- a/adoc/headers/platform.h
+++ b/adoc/headers/platform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/platformInfo.h
+++ b/adoc/headers/platformInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/pointer.h
+++ b/adoc/headers/pointer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/priv.h
+++ b/adoc/headers/priv.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/properties.h
+++ b/adoc/headers/properties.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/queue.h
+++ b/adoc/headers/queue.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/queueInfo.h
+++ b/adoc/headers/queueInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/reducer.h
+++ b/adoc/headers/reducer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 // Exposition only

--- a/adoc/headers/reduction.h
+++ b/adoc/headers/reduction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: MIT
 
 template <typename BufferT, typename BinaryOperation>

--- a/adoc/headers/sampledImage.h
+++ b/adoc/headers/sampledImage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/stream.h
+++ b/adoc/headers/stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/subgroup.h
+++ b/adoc/headers/subgroup.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/synchronization.h
+++ b/adoc/headers/synchronization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/unsampledImage.h
+++ b/adoc/headers/unsampledImage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {

--- a/adoc/scripts/apiconventions.py
+++ b/adoc/scripts/apiconventions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2021-2023 The Khronos Group Inc.
+# Copyright 2021-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Generic alias for working group-specific API conventions interface.

--- a/adoc/scripts/doctransformer.py
+++ b/adoc/scripts/doctransformer.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 The Khronos Group Inc.
+# Copyright 2023-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/doctransformer.py
+++ b/adoc/scripts/doctransformer.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The Khronos Group Inc.
+# Copyright 2023-2023 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/genanchorlinks.py
+++ b/adoc/scripts/genanchorlinks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2020-2023 The Khronos Group, Inc.
+# Copyright (c) 2020-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Script that adds href to <a> anchors

--- a/adoc/scripts/reflib.py
+++ b/adoc/scripts/reflib.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2016-2023 The Khronos Group Inc.
+# Copyright 2016-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/reflow.py
+++ b/adoc/scripts/reflow.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2016-2023 The Khronos Group Inc.
+# Copyright 2016-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/spec_tools/conventions.py
+++ b/adoc/scripts/spec_tools/conventions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/syclconventions.py
+++ b/adoc/scripts/syclconventions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/adoc/scripts/update-copyright.sh
+++ b/adoc/scripts/update-copyright.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+# Copyright 2024-2024 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run this script at the beginning of the year to update the copyright dates
+# on all the source files.  Run it from the root of the repo.  The script only
+# updates copyright dates in the following forms:
+#
+# Copyright <begin-date>-<end-date> The Khronos Group
+# Copyright (c) <begin-date>-<end-date> The Khronos Group
+#
+# And it only updates the <end-date> if the original value is the previous year
+# (i.e. last year, assuming you run the script at the beginning of the year).
+#
+# We intentionally do not update copyright notices from other companies.
+#
+# The script also performs a check for Khronos copyright notices that do not
+# follow either of the patterns above.  If any such notices are found, they are
+# printed to stdout.  These lines should be examined and modified manually.
+
+thisyear=`date +%Y`
+lastyear=`expr $thisyear - 1`
+
+function update_code() {
+  file_name="$1"
+  # Update the copyright dates and names
+  sed -i \
+    -e "s/Copyright\\( (c)\\)\\? \\([12][0-9][0-9][0-9]\\)-$lastyear The Khronos Group/Copyright\\1 \\2-$thisyear The Khronos Group/g" \
+    "$file_name"
+}
+
+git ls-files | while read -r f ; do
+  update_code "$f"
+
+  # See if the file contains a Khronos copyright that was not updated.
+  # We skip the file for this script because the sed expression above causes
+  # a false report.
+  if [ "$f" != "adoc/scripts/update-copyright.sh" ]; then
+    grep -iH 'copyright.*khronos' "$f" | grep -v "[12][0-9][0-9][0-9]-$thisyear"
+  fi
+done

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2023 The Khronos Group, Inc.
+// Copyright (c) 2011-2024 The Khronos Group, Inc.
 //
 // SPDX-License-Identifier: CC-BY-4.0
 
@@ -88,7 +88,7 @@ include::config/attribs.adoc[]
 //      Khronos^{reg}^ SYCL^TM^ Working Group
 //      Editors: Ronan Keryell, Maria Rovatsou & Lee Howes
 //
-//      Copyright (c) 2011-2023 The Khronos Group, Inc. All Rights Reserved
+//      Copyright (c) 2011-2024 The Khronos Group, Inc. All Rights Reserved
 
 <<<<
 


### PR DESCRIPTION
Add a script which updates the copyright dates on all our source files, and then run that script to update all the dates.