### PR TITLE
Remove unusable asciidoc attribute

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -578,7 +578,5 @@ See <<sec:usm>>
     <<global-id>> or the combination of its <<work-group-id>> and its
     <<local-id>> within a <<work-group>>.
 
-:work-items: <<work-item, work-items>>
-
 
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%% end glossary %%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I *think* the intent here is to provide a plural alias for the `work-item` glossary term. Since this attribute is defined at the very end of the spec, though, it's not used anywhere and not usable anywhere.

If this alias is needed, then it needs to be defined somewhere like `adoc/config/attribs.adoc`.