### PR TITLE
Fix description of get_access() 

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4689,7 +4689,8 @@ accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler,
       mode and target in the command group buffer.  The accessor is a
       <<ranged-accessor>>, where the range starts at the given offset from the
       beginning of the buffer.  The value of target can be
-      [code]#target::device# or [code]#target::constant_buffer#.
+      [code]#target::device#, [code]#target::constant_buffer# or
+      [code]#target::host_task.
 
 Throws an [code]#exception# with the [code]#errc::invalid# error code if
 the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4662,8 +4662,9 @@ accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler)
 ----
    a@ Returns a valid [code]#accessor# to the buffer with the specified
       access mode and target in the command group buffer.
-      The value of target can be [code]#target::device# or
-      [code]#target::constant_buffer#.
+      The value of target can be [code]#target::device#,
+      [code]#target::constant_buffer# or
+      [code]#target::host_task.
 
 a@
 [source]


### PR DESCRIPTION
Allow the target of the accessor to be target::host_task.
Based on a comment by @AerialMantis.