### PR TITLE
Move cl::sycl::memory_order, atomic class and atomic operations to sycl namespace

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18977,10 +18977,8 @@ T* operator--() const
 
 The atomic types and operations on atomic types provided by SYCL 1.2.1 are
 deprecated in SYCL 2020, and will be removed in a future version of SYCL.
-The types and operations are made available in the [code]#cl::sycl::# namespace
-for backwards compatibility.
 
-The constructors and member functions for the [code]#cl::sycl::atomic# class are
+The constructors and member functions for the [code]#sycl::atomic# class are
 listed in <<table.atomics.constructors>> and <<table.atomics.members>>
 respectively.
 
@@ -18999,7 +18997,7 @@ include::{header_dir}/atomicoperations.h[lines=4..-1]
 
 
 [[table.atomics.constructors]]
-.Constructors of the [code]#cl::sycl::atomic# class template
+.Constructors of the [code]#sycl::atomic# class template
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Constructor @ Description
@@ -19020,7 +19018,7 @@ instance of SYCL [code]#atomic# which is associated with the pointer
 
 
 [[table.atomics.members]]
-.Member functions available on an object of type [code]#cl::sycl::atomic<T>#
+.Member functions available on an object of type [code]#sycl::atomic<T>#
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Member function @ Description

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -177,11 +177,11 @@ class accessor {
   /* Deprecated
   Available only when: (AccessMode == access_mode::atomic && Dimensions ==  0)
 */
-  operator cl::sycl::atomic<DataT, access::address_space::global_space>() const;
+  operator sycl::atomic<DataT, access::address_space::global_space>() const;
 
   /* Deprecated
   Available only when: (AccessMode == access_mode::atomic && Dimensions == 1) */
-  cl::sycl::atomic<DataT, access::address_space::global_space>
+  sycl::atomic<DataT, access::address_space::global_space>
   operator[](id<Dimensions> index) const;
 
   /* Deprecated in SYCL 2020

--- a/adoc/headers/atomic.h
+++ b/adoc/headers/atomic.h
@@ -5,9 +5,6 @@ namespace cl {
 namespace sycl {
 
 /* Deprecated in SYCL 2020 */
-enum class memory_order : /* unspecified */ { relaxed };
-
-/* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace =
                           access::address_space::global_space>
 class atomic {

--- a/adoc/headers/atomic.h
+++ b/adoc/headers/atomic.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace cl {
 namespace sycl {
 
 /* Deprecated in SYCL 2020 */
@@ -47,4 +46,3 @@ class atomic {
 };
 
 } // namespace sycl
-} // namespace cl

--- a/adoc/headers/atomicoperations.h
+++ b/adoc/headers/atomicoperations.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2011-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace cl {
 namespace sycl {
 /* Deprecated in SYCL 2020 */
 template <typename T, access::address_space AddressSpace>
@@ -60,4 +59,3 @@ template <typename T, access::address_space AddressSpace>
 T atomic_fetch_max(atomic<T, AddressSpace> object, T operand,
                    memory_order memoryOrder = memory_order::relaxed);
 } // namespace sycl
-} // namespace cl


### PR DESCRIPTION
Developers can use sycl::memory_order.