### PR TITLE
Clarify max work-group size

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1805,9 +1805,10 @@ info::device::max_work_group_size
       The minimum value is 1.
       This value is an upper limit and will not necessarily maximize
       performance.
-      Some kernels may not be able to execute this many work-items in a
-      work-group.
-      See also [code]#info::kernel_device_specific::work_group_size#.
+      The maximum number of work-items in a work-group depends on the kernel and
+      the implementation.
+      Use [code]#info::kernel_device_specific::work_group_size# to query this
+      limit.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1800,8 +1800,8 @@ info::device::max_work_group_size
 ----
 
     @ [.code]#size_t#
-   a@ Returns the maximum number of work-items in a work-group that this device
-      is capable of executing on a single compute unit.
+   a@ Returns the maximum number of work-items that this device
+      is capable of executing in a work-group .
       The minimum value is 1.
       This value is an upper limit and will not necessarily maximize
       performance.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1800,8 +1800,14 @@ info::device::max_work_group_size
 ----
 
     @ [.code]#size_t#
-   a@ Returns the maximum number of work-items that are permitted in a work-group executing a kernel on a single compute unit.
+   a@ Returns the maximum number of work-items in a work-group that this device
+      is capable of executing on a single compute unit.
       The minimum value is 1.
+      This value is an upper limit and will not necessarily maximize
+      performance.
+      Some kernels may not be able to execute this many work-items in a
+      work-group.
+      See also [code]#info::kernel_device_specific::work_group_size#.
 
 a@
 [source]
@@ -16072,7 +16078,9 @@ info::kernel_device_specific::work_group_size
 
     @ [code]#size_t#
    a@ Returns the maximum number of work-items in a work-group that can be used
-      to execute a kernel on a specific device.
+      to execute this kernel on the given device.
+      This value will always be less than or equal to the value returned from
+      [code]#info::device::max_work_group_size#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1800,8 +1800,8 @@ info::device::max_work_group_size
 ----
 
     @ [.code]#size_t#
-   a@ Returns the maximum number of work-items that this device
-      is capable of executing in a work-group .
+   a@ Returns the maximum number of work-items that this device is capable of
+      executing in a work-group.
       The minimum value is 1.
       This value is an upper limit and will not necessarily maximize
       performance.


### PR DESCRIPTION
Clarify the two information descriptors:

* `info::device::max_work_group_size`
* `info::kernel_device_specific::work_group_size`

These queries correspond to the OpenCL queries
`CL_DEVICE_MAX_WORK_GROUP_SIZE` and `CL_KERNEL_WORK_GROUP_SIZE`, and I shamelessly stole much of the description from the OpenCL specification.