### PR TITLE
Fix typo with "accessor::get_pointer"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6927,7 +6927,7 @@ accessor was constructed.  For other accessors, returns the default constructed
 a@
 [source]
 ----
-global_ptr<access::decorated::legacy> get_pointer() const noexcept
+global_ptr<value_type> get_pointer() const noexcept
 ----
    a@ Available only when [code]#(AccessTarget == target::device)#.
 

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -186,7 +186,7 @@ class accessor {
 
   /* Deprecated in SYCL 2020
   Available only when: (AccessTarget == target::device) */
-  global_ptr<DataT> get_pointer() const noexcept;
+  global_ptr<value_type> get_pointer() const noexcept;
 
   /* Available only when: (AccessTarget == target::host_task) */
   std::add_pointer_t<value_type> get_pointer() const noexcept;


### PR DESCRIPTION
It appears that we introduced a typo with #432 with the return type of `accessor::get_pointer`.  In the synopsis, we specified it as:

```
global_ptr<DataT> get_pointer() const noexcept
```

But in the description, it seems that we made a typo and said:

```
global_ptr<access::decorated::legacy> get_pointer() const noexcept
```

I believe these are both wrong, and it should be:

```
global_ptr<value_type> get_pointer() const noexcept
```

Using `value_type` is better than `DataT` because `value_type` is const when the accessor is read-only.