### PR TITLE
Deprecate item's conversion operator to an item with offset

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11686,8 +11686,11 @@ a@
 [source]
 ----
 operator item<Dimensions, true>() const
+    // Deprecated in SYCL 2020.
 ----
-   a@ Available only when: [code]#WithOffset == false#
+   a@ Deprecated in SYCL 2020.
+
+Available only when: [code]#WithOffset == false#
 
 Returns an [code]#item# representing the same information as the object holds
 but also includes the offset set to 0. This conversion allow users to seamlessly

--- a/adoc/headers/item.h
+++ b/adoc/headers/item.h
@@ -24,6 +24,7 @@ template <int Dimensions = 1, bool WithOffset = true> class item {
   // only available if WithOffset is true
   id<Dimensions> get_offset() const;
 
+  // Deprecated in SYCL 2020.
   // only available if WithOffset is false
   operator item<Dimensions, true>() const;
 


### PR DESCRIPTION
Since the offset has been deprecated it was an oversight not to deprecate this operator as well.