### PR TITLE
Update formatting for builtin functions

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20853,8 +20853,8 @@ determined by their linear id.
 [[sec:math-functions]]
 === Math functions
 
-<<table.math.functions>> describes the math functions that are available in the
-[code]#sycl# namespace in both host and device code.
+This section describes the math functions that are available in the [code]#sycl#
+namespace in both host and device code.
 
 The function descriptions in this section use the term _writeable address space_
 to represent the following address spaces:
@@ -20864,15 +20864,9 @@ to represent the following address spaces:
 * [code]#access::address_space::private_space#
 * [code]#access::address_space::generic_space#
 
-[[table.math.functions]]
-.Math functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float acos(float x)                (1)
 double acos(double x)              (2)
@@ -20881,7 +20875,6 @@ half acos(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ acos(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -20901,11 +20894,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float acosh(float x)                (1)
 double acosh(double x)              (2)
@@ -20914,7 +20905,6 @@ half acosh(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ acosh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -20935,11 +20925,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float acospi(float x)                (1)
 double acospi(double x)              (2)
@@ -20948,7 +20936,6 @@ half acospi(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ acospi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -20969,11 +20956,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float asin(float x)                (1)
 double asin(double x)              (2)
@@ -20982,7 +20967,6 @@ half asin(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ asin(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21002,11 +20986,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float asinh(float x)                (1)
 double asinh(double x)              (2)
@@ -21015,7 +20997,6 @@ half asinh(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ asinh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21036,11 +21017,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float asinpi(float x)                (1)
 double asinpi(double x)              (2)
@@ -21049,7 +21028,6 @@ half asinpi(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ asinpi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21069,11 +21047,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float atan(float y_over_x)                (1)
 double atan(double y_over_x)              (2)
@@ -21082,7 +21058,6 @@ half atan(half y_over_x)                  (3)
 template<typename NonScalar>              (4)
 /*return-type*/ atan(NonScalar y_over_x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21102,11 +21077,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float atan2(float y, float x)                       (1)
 double atan2(double y, double x)                    (2)
@@ -21115,7 +21088,6 @@ half atan2(half y, half x)                          (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ atan2(NonScalar1 y, NonScalar2 x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21142,11 +21114,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float atanh(float x)                (1)
 double atanh(double x)              (2)
@@ -21155,7 +21125,6 @@ half atanh(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ atanh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21176,11 +21145,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float atanpi(float x)                (1)
 double atanpi(double x)              (2)
@@ -21189,7 +21156,6 @@ half atanpi(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ atanpi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21209,11 +21175,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float atan2pi(float y, float x)                      (1)
 double atan2pi(double y, double x)                   (2)
@@ -21222,7 +21186,6 @@ half atan2pi(half y, half x)                         (3)
 template<typename NonScalar1, typename NonScalar2>   (4)
 /*return-type*/ atan2pi(NonScalar1 y, NonScalar2 x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21249,11 +21212,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cbrt(float x)                (1)
 double cbrt(double x)              (2)
@@ -21262,7 +21223,6 @@ half cbrt(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ cbrt(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21282,11 +21242,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float ceil(float x)                (1)
 double ceil(double x)              (2)
@@ -21295,7 +21253,6 @@ half ceil(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ ceil(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21317,11 +21274,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float copysign(float x, float y)                      (1)
 double copysign(double x, double y)                   (2)
@@ -21330,7 +21285,6 @@ half copysign(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>    (4)
 /*return-type*/ copysign(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21358,11 +21312,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cos(float x)                (1)
 double cos(double x)              (2)
@@ -21371,7 +21323,6 @@ half cos(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ cos(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21391,11 +21342,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cosh(float x)                (1)
 double cosh(double x)              (2)
@@ -21404,7 +21353,6 @@ half cosh(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ cosh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21425,11 +21373,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cospi(float x)                (1)
 double cospi(double x)              (2)
@@ -21438,7 +21384,6 @@ half cospi(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ cospi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21458,11 +21403,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float erfc(float x)                (1)
 double erfc(double x)              (2)
@@ -21471,7 +21414,6 @@ half erfc(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ erfc(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21492,11 +21434,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float erf(float x)                (1)
 double erf(double x)              (2)
@@ -21505,7 +21445,6 @@ half erf(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ erf(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21526,11 +21465,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp(float x)                (1)
 double exp(double x)              (2)
@@ -21539,7 +21476,6 @@ half exp(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ exp(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21560,11 +21496,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp2(float x)                (1)
 double exp2(double x)              (2)
@@ -21573,7 +21507,6 @@ half exp2(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ exp2(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21594,11 +21527,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp10(float x)                (1)
 double exp10(double x)              (2)
@@ -21607,7 +21538,6 @@ half exp10(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ exp10(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21628,11 +21558,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float expm1(float x)                (1)
 double expm1(double x)              (2)
@@ -21641,7 +21569,6 @@ half expm1(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ expm1(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21661,11 +21588,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fabs(float x)                (1)
 double fabs(double x)              (2)
@@ -21674,7 +21599,6 @@ half fabs(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ fabs(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21694,11 +21618,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fdim(float x, float y)                        (1)
 double fdim(double x, double y)                     (2)
@@ -21707,7 +21629,6 @@ half fdim(half x, half y)                           (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ fdim(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21734,11 +21655,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float floor(float x)                (1)
 double floor(double x)              (2)
@@ -21747,7 +21666,6 @@ half floor(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ floor(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21769,11 +21687,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fma(float a, float b, float c)                                     (1)
 double fma(double a, double b, double c)                                 (2)
@@ -21782,7 +21698,6 @@ half fma(half a, half b, half c)                                         (3)
 template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (4)
 /*return-type*/ fma(NonScalar1 a, NonScalar2 b, NonScalar3 c)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21818,11 +21733,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fmax(float x, float y)                                (1)
 double fmax(double x, double y)                             (2)
@@ -21834,7 +21747,6 @@ template<typename NonScalar1, typename NonScalar2>          (4)
 template<typename NonScalar>                                (5)
 /*return-type*/ fmax(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21879,11 +21791,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fmin(float x, float y)                                (1)
 double fmin(double x, double y)                             (2)
@@ -21895,7 +21805,6 @@ template<typename NonScalar1, typename NonScalar2>          (4)
 template<typename NonScalar>                                (5)
 /*return-type*/ fmin(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21940,11 +21849,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float fmod(float x, float y)                        (1)
 double fmod(double x, double y)                     (2)
@@ -21953,7 +21860,6 @@ half fmod(half x, half y)                           (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ fmod(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -21980,11 +21886,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                        (1)
 float fract(float x, Ptr iptr)
@@ -21998,7 +21902,6 @@ half fract(half x, Ptr iptr)
 template<typename NonScalar, typename Ptr>    (4)
 /*return-type*/ fract(NonScalar x, Ptr iptr)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22035,11 +21938,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                        (1)
 float frexp(float x, Ptr exp)
@@ -22053,7 +21954,6 @@ half frexp(half x, Ptr exp)
 template<typename NonScalar, typename Ptr>    (4)
 /*return-type*/ frexp(NonScalar x, Ptr exp)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22097,11 +21997,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float hypot(float x, float y)                       (1)
 double hypot(double x, double y)                    (2)
@@ -22110,7 +22008,6 @@ half hypot(half x, half y)                          (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ hypot(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22138,11 +22035,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 int ilogb(float x)                  (1)
 int ilogb(double x)                 (2)
@@ -22151,7 +22046,6 @@ int ilogb(half x)                   (3)
 template<typename NonScalar>        (4)
 /*return-type*/ ilogb(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22177,11 +22071,9 @@ number of element as [code]#NonScalar#.  If [code]#NonScalar# is [code]#vec# or
 the [code]#+__swizzled_vec__+# type, the return type is [code]#vec# of
 [code]#int32_t# with the same number of elements as [code]#NonScalar#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float ldexp(float x, int k)                         (1)
 double ldexp(double x, int k)                       (2)
@@ -22193,7 +22085,6 @@ template<typename NonScalar1, typename NonScalar2>  (4)
 template<typename NonScalar>                        (5)
 /*return-type*/ ldexp(NonScalar x, int k)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22236,11 +22127,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float lgamma(float x)                (1)
 double lgamma(double x)              (2)
@@ -22249,7 +22138,6 @@ half lgamma(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ lgamma(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22271,11 +22159,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                        (1)
 float lgamma_r(float x, Ptr signp)
@@ -22289,7 +22175,6 @@ half lgamma_r(half x, Ptr signp)
 template<typename NonScalar, typename Ptr>    (4)
 /*return-type*/ lgamma_r(NonScalar x, Ptr signp)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22329,11 +22214,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log(float x)                (1)
 double log(double x)              (2)
@@ -22342,7 +22225,6 @@ half log(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ log(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22363,11 +22245,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log2(float x)                (1)
 double log2(double x)              (2)
@@ -22376,7 +22256,6 @@ half log2(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ log2(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22396,11 +22275,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log10(float x)                (1)
 double log10(double x)              (2)
@@ -22409,7 +22286,6 @@ half log10(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ log10(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22430,11 +22306,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log1p(float x)                (1)
 double log1p(double x)              (2)
@@ -22443,7 +22317,6 @@ half log1p(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ log1p(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22463,11 +22336,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float logb(float x)                (1)
 double logb(double x)              (2)
@@ -22476,7 +22347,6 @@ half logb(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ logb(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22499,11 +22369,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float mad(float a, float b, float c)                                     (1)
 double mad(double a, double b, double c)                                 (2)
@@ -22512,7 +22380,6 @@ half mad(half a, half b, half c)                                         (3)
 template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (4)
 /*return-type*/ mad(NonScalar1 a, NonScalar2 b, NonScalar3 c)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22547,11 +22414,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float maxmag(float x, float y)                      (1)
 double maxmag(double x, double y)                   (2)
@@ -22560,7 +22425,6 @@ half maxmag(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ maxmag(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22589,11 +22453,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float minmag(float x, float y)                      (1)
 double minmag(double x, double y)                   (2)
@@ -22602,7 +22464,6 @@ half minmag(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ minmag(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22631,11 +22492,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                        (1)
 float modf(float x, Ptr iptr)
@@ -22649,7 +22508,6 @@ half modf(half x, Ptr iptr)
 template<typename NonScalar, typename Ptr>    (4)
 /*return-type*/ modf(NonScalar x, Ptr iptr)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22688,11 +22546,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float nan(uint32_t nancode)             (1)
 double nan(uint64_t nancode)            (2)
@@ -22701,7 +22557,6 @@ half nan(uint16_t nancode)              (3)
 template<typename NonScalar>            (4)
 /*return-type*/ nan(NonScalar nancode)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22720,31 +22575,30 @@ _Returns:_ A quiet NaN for each element of [code]#nancode#.  Each
 [code]#nancode[i]# may be placed in the significand of the resulting NaN.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<uint32_t, N># ![code]#marray<float, N>#
-![code]#marray<uint64_t, N># ![code]#marray<double, N>#
-![code]#marray<uint16_t, N># ![code]#marray<half, N>#
 
-![code]#vec<uint32_t, N># +
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<uint32_t, N># @[code]#marray<float, N>#
+@[code]#marray<uint64_t, N># @[code]#marray<double, N>#
+@[code]#marray<uint16_t, N># @[code]#marray<half, N>#
+
+@[code]#vec<uint32_t, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<uint32_t, N>#
-![code]#vec<float, N>#
+@[code]#vec<float, N>#
 
-![code]#vec<uint64_t, N># +
+@[code]#vec<uint64_t, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<uint64_t, N>#
-![code]#vec<double, N>#
+@[code]#vec<double, N>#
 
-![code]#vec<uint16_t, N># +
+@[code]#vec<uint16_t, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<uint16_t, N>#
-![code]#vec<half, N>#
-!====
+@[code]#vec<half, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float nextafter(float x, float y)                      (1)
 double nextafter(double x, double y)                   (2)
@@ -22753,7 +22607,6 @@ half nextafter(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>     (4)
 /*return-type*/ nextafter(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22784,11 +22637,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float pow(float x, float y)                         (1)
 double pow(double x, double y)                      (2)
@@ -22797,7 +22648,6 @@ half pow(half x, half y)                            (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ pow(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22824,11 +22674,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float pown(float x, int y)                          (1)
 double pown(double x, int y)                        (2)
@@ -22837,7 +22685,6 @@ half pown(half x, int y)                            (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ pown(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22864,11 +22711,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float powr(float x, float y)                        (1)
 double powr(double x, double y)                     (2)
@@ -22877,7 +22722,6 @@ half powr(half x, half y)                           (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ powr(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22909,11 +22753,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float remainder(float x, float y)                      (1)
 double remainder(double x, double y)                   (2)
@@ -22922,7 +22764,6 @@ half remainder(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>     (4)
 /*return-type*/ remainder(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -22955,11 +22796,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                                            (1)
 float remquo(float x, float y, Ptr quo)
@@ -22973,7 +22812,6 @@ half remquo(half x, half y, Ptr quo)
 template<typename NonScalar1, typename NonScalar2, typename Ptr>  (4)
 /*return-type*/ remquo(NonScalar1 x, NonScalar2 y, Ptr quo)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23027,11 +22865,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float rint(float x)                (1)
 double rint(double x)              (2)
@@ -23040,7 +22876,6 @@ half rint(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ rint(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23065,11 +22900,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float rootn(float x, int y)                         (1)
 double rootn(double x, int y)                       (2)
@@ -23078,7 +22911,6 @@ half rootn(half x, int y)                           (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ rootn(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23105,11 +22937,9 @@ The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float round(float x)                (1)
 double round(double x)              (2)
@@ -23118,7 +22948,6 @@ half round(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ round(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23141,11 +22970,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float rsqrt(float x)                (1)
 double rsqrt(double x)              (2)
@@ -23154,7 +22981,6 @@ half rsqrt(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ rsqrt(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23175,11 +23001,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sin(float x)                (1)
 double sin(double x)              (2)
@@ -23188,7 +23012,6 @@ half sin(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ sin(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23208,11 +23031,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Ptr>                           (1)
 float sincos(float x, Ptr cosval)
@@ -23226,7 +23047,6 @@ half sincos(half x, Ptr cosval)
 template<typename NonScalar, typename Ptr>       (4)
 /*return-type*/ sincos(NonScalar x, Ptr cosval)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23262,11 +23082,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sinh(float x)                (1)
 double sinh(double x)              (2)
@@ -23275,7 +23093,6 @@ half sinh(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ sinh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23295,11 +23112,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sinpi(float x)                (1)
 double sinpi(double x)              (2)
@@ -23308,7 +23123,6 @@ half sinpi(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ sinpi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23328,11 +23142,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sqrt(float x)                (1)
 double sqrt(double x)              (2)
@@ -23341,7 +23153,6 @@ half sqrt(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ sqrt(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23361,11 +23172,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tan(float x)                (1)
 double tan(double x)              (2)
@@ -23374,7 +23183,6 @@ half tan(half x)                  (3)
 template<typename NonScalar>      (4)
 /*return-type*/ tan(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23394,11 +23202,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tanh(float x)                (1)
 double tanh(double x)              (2)
@@ -23407,7 +23213,6 @@ half tanh(half x)                  (3)
 template<typename NonScalar>       (4)
 /*return-type*/ tanh(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23428,11 +23233,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tanpi(float x)                (1)
 double tanpi(double x)              (2)
@@ -23441,7 +23244,6 @@ half tanpi(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ tanpi(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23461,11 +23263,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tgamma(float x)                (1)
 double tgamma(double x)              (2)
@@ -23474,7 +23274,6 @@ half tgamma(half x)                  (3)
 template<typename NonScalar>         (4)
 /*return-type*/ tgamma(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23494,11 +23293,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float trunc(float x)                (1)
 double trunc(double x)              (2)
@@ -23507,7 +23304,6 @@ half trunc(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ trunc(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -23528,14 +23324,14 @@ integral value using the round to zero rounding mode.
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 === Native precision math functions
 
-<<table.native.math.functions>> describes the native precision math functions
-that are available in the [code]#sycl::native# namespace in both host and device
-code.
+This section describes the native precision math functions that are available in
+the [code]#sycl::native# namespace in both host and device code.
 
 The precision requirements and the set of legal input values for these functions
 are defined in the backend specification.
@@ -23543,22 +23339,15 @@ The intent is that these functions might make use of native device functionality
 which has better performance than their counterparts in <<sec:math-functions>>,
 but they may sacrifice accuracy or limit the set of legal input values.
 
-[[table.native.math.functions]]
-.Native precision math functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cos(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ cos(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23578,18 +23367,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float divide(float x, float y)                      (1)
 
 template<typename NonScalar1, typename NonScalar2>  (2)
 /*return-type*/ divide(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overload (1):*
 
@@ -23610,18 +23396,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ exp(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23642,18 +23425,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp2(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ exp2(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23674,18 +23454,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp10(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ exp10(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23706,18 +23483,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ log(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23738,18 +23512,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log2(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ log2(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23769,18 +23540,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log10(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ log10(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23801,18 +23569,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float powr(float x, float y)                        (1)
 
 template<typename NonScalar1, typename NonScalar2>  (2)
 /*return-type*/ powr(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overload (1):*
 
@@ -23838,18 +23603,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float recip(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ recip(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23869,18 +23631,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float rsqrt(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ rsqrt(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23901,18 +23660,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sin(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ sin(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23932,18 +23688,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sqrt(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ sqrt(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23963,18 +23716,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tan(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ tan(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -23993,36 +23743,29 @@ _Returns:_ For each element of [code]#x#, the tangent of [code]#x[i]#.
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 === Half precision math functions
 
-<<table.half.math.functions>> describes the half precision math functions that
-are available in the [code]#sycl::half_precision# namespace in both host and
-device code.
+This section describes the half precision math functions that are available in
+the [code]#sycl::half_precision# namespace in both host and device code.
 
 The precision requirements for these functions are defined in the backend
 specification.
 The intent is that these functions have higher performance than their
 counterparts in <<sec:math-functions>>, but they have lower accuracy.
 
-[[table.half.math.functions]]
-.Half precision math functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float cos(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ cos(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24047,18 +23790,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float divide(float x, float y)                      (1)
 
 template<typename NonScalar1, typename NonScalar2>  (2)
 /*return-type*/ divide(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overload (1):*
 
@@ -24079,18 +23819,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ exp(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24111,18 +23848,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp2(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ exp2(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24143,18 +23877,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float exp10(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ exp10(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24175,18 +23906,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ log(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24207,18 +23935,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log2(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ log2(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24238,18 +23963,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float log10(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ log10(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24270,18 +23992,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float powr(float x, float y)                        (1)
 
 template<typename NonScalar1, typename NonScalar2>  (2)
 /*return-type*/ powr(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overload (1):*
 
@@ -24307,18 +24026,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float recip(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ recip(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24338,18 +24054,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float rsqrt(float x)                (1)
 
 template<typename NonScalar>        (2)
 /*return-type*/ rsqrt(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24370,18 +24083,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sin(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ sin(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24406,18 +24116,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float sqrt(float x)                (1)
 
 template<typename NonScalar>       (2)
 /*return-type*/ sqrt(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24437,18 +24144,15 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 float tan(float x)                (1)
 
 template<typename NonScalar>      (2)
 /*return-type*/ tan(NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -24472,14 +24176,15 @@ _Returns:_ For each element of [code]#x#, the tangent of [code]#x[i]#.
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 [[sec:integer-functions]]
 === Integer functions
 
-<<table.integer.functions>> describes the integer math functions that are
-available in the [code]#sycl# namespace in both host and device code.
+This section describes the integer math functions that are available in the
+[code]#sycl# namespace in both host and device code.
 
 The function descriptions in this section use the term _generic integer type_ to
 represent the following types:
@@ -24523,20 +24228,13 @@ represent the following types:
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<uint32_t, N>#
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<uint64_t, N>#
 
-[[table.integer.functions]]
-.Integer functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>
 /*return-type*/ abs(GenInt x)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
@@ -24549,16 +24247,13 @@ The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ abs_diff(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24579,16 +24274,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ add_sat(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24608,16 +24300,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ hadd(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24637,16 +24326,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rhadd(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24666,11 +24352,9 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>    (1)
 /*return-type*/ clamp(GenInt1 x, GenInt2 minval, GenInt3 maxval)
@@ -24679,7 +24363,6 @@ template<typename NonScalar>                                      (2)
 /*return-type*/ clamp(NonScalar x, NonScalar::value_type minval,
                       NonScalar::value_type maxval)
 ----
-!====
 
 *Overload (1):*
 
@@ -24724,16 +24407,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>
 /*return-type*/ clz(GenInt x)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
@@ -24747,16 +24427,13 @@ The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>
 /*return-type*/ ctz(GenInt x)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
@@ -24770,16 +24447,13 @@ The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_hi(GenInt1 a, GenInt2 b, GenInt3 c)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24800,16 +24474,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_sat(GenInt1 a, GenInt2 b, GenInt3 c)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24830,11 +24501,9 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ max(GenInt1 x, GenInt2 y)
@@ -24842,7 +24511,6 @@ template<typename GenInt1, typename GenInt2>               (1)
 template<typename NonScalar>                               (2)
 /*return-type*/ max(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overload (1):*
 
@@ -24878,11 +24546,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ min(GenInt1 x, GenInt2 y)
@@ -24890,7 +24556,6 @@ template<typename GenInt1, typename GenInt2>               (1)
 template<typename NonScalar>                               (2)
 /*return-type*/ min(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overload (1):*
 
@@ -24926,16 +24591,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ mul_hi(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24958,16 +24620,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rotate(GenInt1 v, GenInt2 count)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -24994,16 +24653,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ sub_sat(GenInt1 x, GenInt2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25023,16 +24679,13 @@ The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename UInt8Bit1, typename UInt8Bit2>
 /*return-type*/ upsample(UInt8Bit1 hi, UInt8Bit2 lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25054,16 +24707,13 @@ type [code]#uint16_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#uint16_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Int8Bit, typename UInt8Bit>
 /*return-type*/ upsample(Int8Bit hi, UInt8Bit lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25087,16 +24737,13 @@ type [code]#int16_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#int16_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename UInt16Bit1, typename UInt16Bit2>
 /*return-type*/ upsample(UInt16Bit1 hi, UInt16Bit2 lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25118,16 +24765,13 @@ type [code]#uint32_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#uint32_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Int16Bit, typename UInt16Bit>
 /*return-type*/ upsample(Int16Bit hi, UInt16Bit lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25152,16 +24796,13 @@ type [code]#int32_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#int32_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename UInt32Bit1, typename UInt32Bit2>
 /*return-type*/ upsample(UInt32Bit1 hi, UInt32Bit2 lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25183,16 +24824,13 @@ type [code]#uint64_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#uint64_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Int32Bit, typename UInt32Bit>
 /*return-type*/ upsample(Int32Bit hi, UInt32Bit lo)
 ----
-!====
 
 _Constraints:_ Available only if one of the following conditions is met:
 
@@ -25217,16 +24855,13 @@ type [code]#int64_t# and the same number of elements as the inputs.
 Otherwise, the return type is [code]#vec# with element type [code]#int64_t#
 and the same number of elements as the inputs.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>
 /*return-type*/ popcount(GenInt x)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
@@ -25239,16 +24874,13 @@ The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Int32Bit1, typename Int32Bit2, typename Int32Bit3>
 /*return-type*/ mad24(Int32Bit1 x, Int32Bit2 y, Int32Bit3 z)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25283,16 +24915,13 @@ The return type is [code]#Int32Bit1# unless [code]#Int32Bit1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Int32Bit1, typename Int32Bit2>
 /*return-type*/ mul24(Int32Bit1 x, Int32Bit2 y)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25324,13 +24953,14 @@ returns [code]#x[i] * y[i]# for each element of [code]#x# and [code]#y#.
 The return type is [code]#Int32Bit1# unless [code]#Int32Bit1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 === Common functions
 
-<<table.common.functions>> describes the common functions that are available in
-the [code]#sycl# namespace in both host and device code.
+This section describes the common functions that are available in the
+[code]#sycl# namespace in both host and device code.
 
 The function descriptions in this section use the term _generic floating point
 type_ to represent the following types:
@@ -25348,15 +24978,9 @@ type_ to represent the following types:
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
 
-[[table.common.functions]]
-.Common functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>    (1)
 /*return-type*/ clamp(GenFloat1 x, GenFloat2 minval, GenFloat3 maxval)
@@ -25365,7 +24989,6 @@ template<typename NonScalar>                                            (2)
 /*return-type*/ clamp(NonScalar x, NonScalar::value_type minval,
                       NonScalar::value_type maxval)
 ----
-!====
 
 *Overload (1):*
 
@@ -25410,16 +25033,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat>
 /*return-type*/ degrees(GenFloat radians)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenFloat# is a _generic floating point
 type_ as defined above.
@@ -25434,11 +25054,9 @@ The return type is [code]#GenFloat# unless [code]#GenFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ max(GenFloat1 x, GenFloat2 y)
@@ -25446,7 +25064,6 @@ template<typename GenFloat1, typename GenFloat2>           (1)
 template<typename NonScalar>                               (2)
 /*return-type*/ max(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overload (1):*
 
@@ -25489,11 +25106,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ min(GenFloat1 x, GenFloat2 y)
@@ -25501,7 +25116,6 @@ template<typename GenFloat1, typename GenFloat2>           (1)
 template<typename NonScalar>                               (2)
 /*return-type*/ min(NonScalar x, NonScalar::value_type y)
 ----
-!====
 
 *Overload (1):*
 
@@ -25544,11 +25158,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
 /*return-type*/ mix(GenFloat1 x, GenFloat2 y, GenFloat3 a)
@@ -25556,7 +25168,6 @@ template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
 template<typename NonScalar1, typename NonScalar2>                         (2)
 /*return-type*/ mix(NonScalar1 x, NonScalar2 y, NonScalar1::value_type a)
 ----
-!====
 
 *Overload (1):*
 
@@ -25599,16 +25210,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat>
 /*return-type*/ radians(GenFloat degrees)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenFloat# is a _generic floating point
 type_ as defined above.
@@ -25623,11 +25231,9 @@ The return type is [code]#GenFloat# unless [code]#GenFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2>               (1)
 /*return-type*/ step(GenFloat1 edge, GenFloat2 x)
@@ -25635,7 +25241,6 @@ template<typename GenFloat1, typename GenFloat2>               (1)
 template<typename NonScalar>                                   (2)
 /*return-type*/ step(NonScalar::value_type edge, NonScalar x)
 ----
-!====
 
 *Overload (1):*
 
@@ -25671,16 +25276,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
 /*return-type*/ smoothstep(GenFloat1 edge0, GenFloat2 edge1, GenFloat3 x)
 ----
-!====
 
 *Overload (1):*
 
@@ -25706,7 +25308,7 @@ _Returns:_ When the inputs are scalars, returns 0.0 if [code]#+x <= edge0+# and
 and 1 when [code]#edge0 < x < edge1#.  This is useful in cases where you would
 want a threshold function with a smooth transition.  This is equivalent to:
 
-[source]
+[source,role=codebox]
 ----
 GenFloat1 t;
 t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
@@ -25716,7 +25318,7 @@ return t * t * (3 - 2 * t);
 When the inputs are not scalars, returns the following value for each element
 of [code]#edge0#, [code]#edge1#, and [code]#x#:
 
-[source]
+[source,role=codebox]
 ----
 GenFloat1::value_type t;
 t = clamp((x[i] - edge0[i]) / (edge1[i] - edge0[i]), 0, 1);
@@ -25727,17 +25329,14 @@ The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename NonScalar>                                                          (2)
 /*return-type*/ smoothstep(NonScalar::value_type edge0, NonScalar::value_type edge1,
                            NonScalar x)
 ----
-!====
 
 *Overload (2):*
 
@@ -25751,7 +25350,7 @@ may be NaN.
 
 _Returns:_ The following value for each element of [code]#x#:
 
-[source]
+[source,role=codebox]
 ----
 NonScalar::value_type t;
 t = clamp((x[i] - edge0) / (edge1 - edge0), 0, 1);
@@ -25762,16 +25361,13 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenFloat>
 /*return-type*/ sign(GenFloat x)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GenFloat# is a _generic floating point
 type_ as defined above.
@@ -25784,14 +25380,15 @@ each element of [code]#x#.
 The return type is [code]#GenFloat# unless [code]#GenFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 [[sec:geometric-functions]]
 === Geometric functions
 
-<<table.geometric.functions>> describes the geometric functions that are
-available in the [code]#sycl# namespace in both host and device code.
+This section describes the geometric functions that are available in the
+[code]#sycl# namespace in both host and device code.
 
 The function descriptions in this section use two terms that refer to a specific
 list of types.
@@ -25821,20 +25418,13 @@ The term _float geometric type_ represents these types:
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#, where
   [code]#N# is 2, 3, or 4
 
-[[table.geometric.functions]]
-.Geometric functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Geo3or4Float1, typename Geo3or4Float2>
 /*return-type*/ cross(Geo3or4Float1 p0, Geo3or4Float2 p1)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25871,16 +25461,13 @@ The return type is [code]#Geo3or4Float1# unless [code]#Geo3or4Float1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ dot(GeoFloat1 p0, GeoFloat2 p1)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25897,16 +25484,13 @@ _Returns:_ The dot product of [code]#p0# and [code]#p1#.
 The return type is [code]#GeoFloat1# if the input types are scalar.  Otherwise,
 the return type is [code]#GeoFloat1::value_type#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ distance(GeoFloat1 p0, GeoFloat2 p1)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25924,16 +25508,13 @@ as [code]#length(p0 - p1)#.
 The return type is [code]#GeoFloat1# if the input types are scalar.  Otherwise,
 the return type is [code]#GeoFloat1::value_type#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat>
 /*return-type*/ length(GeoFloat p)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GeoFloat# is a _generic geometric type_
 as defined above.
@@ -25944,16 +25525,13 @@ _Returns:_ The length of vector [code]#p#, i.e.,
 The return type is [code]#GeoFloat# if the input type is scalar.  Otherwise,
 the return type is [code]#GeoFloat::value_type#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat>
 /*return-type*/ normalize(GeoFloat p)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GeoFloat# is a _generic geometric type_
 as defined above.
@@ -25964,16 +25542,13 @@ The return type is [code]#GeoFloat# unless [code]#GeoFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ fast_distance(GeoFloat1 p0, GeoFloat2 p1)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -25990,16 +25565,13 @@ _Returns:_ The value [code]#fast_length(p0 - p1)#.
 The return type is [code]#GeoFloat1# if the input type is scalar.  Otherwise,
 the return type is [code]#GeoFloat1::value_type#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_length(GeoFloat p)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_
 as defined above.
@@ -26010,16 +25582,13 @@ _Returns:_ The length of vector [code]#p# computed as:
 The return type is [code]#GeoFloat# if the input type is scalar.  Otherwise,
 the return type is [code]#GeoFloat::value_type#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_normalize(GeoFloat p)
 ----
-!====
 
 _Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_
 as defined above.
@@ -26031,7 +25600,7 @@ computed as
 The result shall be within 8192 ulps error from the infinitely precise result
 of
 
-[source]
+[source,role=codebox]
 ----
 if (all(p == 0.0f))
   result = p;
@@ -26051,14 +25620,15 @@ with the following exceptions:
 The return type is [code]#GeoFloat# unless [code]#GeoFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 
 [[sec:relational-functions]]
 === Relational functions
 
-<<table.relational.functions>> describes the relational functions that are
-available in the [code]#sycl# namespace in both host and device code.
+This section describes the relational functions that are available in the
+[code]#sycl# namespace in both host and device code.
 These functions perform various relational comparisons on [code]#vec#,
 [code]#marray#, and scalar types.
 
@@ -26101,15 +25671,9 @@ The term _vector element type_ represents these types:
 * [code]#double#
 * [code]#half#
 
-[[table.relational.functions]]
-.Relational functions
-[separator="@"]
-|====
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isequal(float x, float y)                       (1)
 bool isequal(double x, double y)                     (2)
@@ -26118,7 +25682,6 @@ bool isequal(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>   (4)
 /*return-type*/ isequal(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26144,32 +25707,31 @@ returns the value [code]#((x[i] == y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isnotequal(float x, float y)                       (1)
 bool isnotequal(double x, double y)                     (2)
@@ -26178,7 +25740,6 @@ bool isnotequal(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>      (4)
 /*return-type*/ isnotequal(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26204,32 +25765,31 @@ returns the value [code]#((x[i] != y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isgreater(float x, float y)                       (1)
 bool isgreater(double x, double y)                     (2)
@@ -26238,7 +25798,6 @@ bool isgreater(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>     (4)
 /*return-type*/ isgreater(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26264,32 +25823,31 @@ returns the value [code]#((x[i] > y[i]) ? -1 : 0)# for each element
 of [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isgreaterequal(float x, float y)                       (1)
 bool isgreaterequal(double x, double y)                     (2)
@@ -26298,7 +25856,6 @@ bool isgreaterequal(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>          (4)
 /*return-type*/ isgreaterequal(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26324,32 +25881,31 @@ returns the value [code]#((x[i] >= y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isless(float x, float y)                       (1)
 bool isless(double x, double y)                     (2)
@@ -26358,7 +25914,6 @@ bool isless(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>  (4)
 /*return-type*/ isless(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26384,32 +25939,31 @@ returns the value [code]#((x[i] < y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool islessequal(float x, float y)                       (1)
 bool islessequal(double x, double y)                     (2)
@@ -26418,7 +25972,6 @@ bool islessequal(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>       (4)
 /*return-type*/ islessequal(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26444,32 +25997,31 @@ returns the value [code]#+((x[i] <= y[i]) ? -1 : 0)+# for each element of
 [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool islessgreater(float x, float y)                       (1)
 bool islessgreater(double x, double y)                     (2)
@@ -26478,7 +26030,6 @@ bool islessgreater(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>         (4)
 /*return-type*/ islessgreater(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26505,32 +26056,31 @@ _Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
 and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isfinite(float x)                 (1)
 bool isfinite(double x)                (2)
@@ -26539,7 +26089,6 @@ bool isfinite(half x)                  (3)
 template<typename NonScalar>           (4)
 /*return-type*/ isfinite(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26560,32 +26109,31 @@ returns -1 for each element of [code]#x# if [code]#x[i]# is a finite value and
 returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isinf(float x)                 (1)
 bool isinf(double x)                (2)
@@ -26594,7 +26142,6 @@ bool isinf(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ isinf(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26616,32 +26163,31 @@ returns -1 for each element of [code]#x# if [code]#x[i]# has an infinity
 value and returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isnan(float x)                 (1)
 bool isnan(double x)                (2)
@@ -26650,7 +26196,6 @@ bool isnan(half x)                  (3)
 template<typename NonScalar>        (4)
 /*return-type*/ isnan(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26671,32 +26216,31 @@ returns -1 for each element of [code]#x# if [code]#x[i]# has a NaN value and
 returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isnormal(float x)                 (1)
 bool isnormal(double x)                (2)
@@ -26705,7 +26249,6 @@ bool isnormal(half x)                  (3)
 template<typename NonScalar>           (4)
 /*return-type*/ isnormal(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26726,32 +26269,31 @@ returns -1 for each element of [code]#x# if [code]#x[i]# has a normal value and
 returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isordered(float x, float y)                       (1)
 bool isordered(double x, double y)                     (2)
@@ -26760,7 +26302,6 @@ bool isordered(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>     (4)
 /*return-type*/ isordered(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26791,32 +26332,31 @@ _Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
 of [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool isunordered(float x, float y)                       (1)
 bool isunordered(double x, double y)                     (2)
@@ -26825,7 +26365,6 @@ bool isunordered(half x, half y)                         (3)
 template<typename NonScalar1, typename NonScalar2>       (4)
 /*return-type*/ isunordered(NonScalar1 x, NonScalar2 y)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26855,32 +26394,31 @@ returns the value [code]#((isnan(x[i]) || isnan(y[i]) ? -1 : 0)# for each
 element of [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar1 ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar1 @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 bool signbit(float x)                 (1)
 bool signbit(double x)                (2)
@@ -26889,7 +26427,6 @@ bool signbit(half x)                  (3)
 template<typename NonScalar>          (4)
 /*return-type*/ signbit(NonScalar x)
 ----
-!====
 
 *Overloads (1) - (3):*
 
@@ -26910,32 +26447,31 @@ returns -1 for each element of [code]#x# if the sign bit of [code]#x[i]# is set
 and returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
-[options="header",cols="70%,30%"]
-!====
-!NonScalar ! Return Type
-![code]#marray<float, N># +
+
+[options="header",separator="@",cols="70%,30%"]
+|====
+@NonScalar @ Return Type
+@[code]#marray<float, N># +
  [code]#marray<double, N># +
  [code]#marray<half, N>#
-![code]#marray<bool, N>#
+@[code]#marray<bool, N>#
 
-![code]#vec<float, N># +
+@[code]#vec<float, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, N>#
-![code]#vec<int32_t, N>#
+@[code]#vec<int32_t, N>#
 
-![code]#vec<double, N># +
+@[code]#vec<double, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, N>#
-![code]#vec<int64_t, N>#
+@[code]#vec<int64_t, N>#
 
-![code]#vec<half, N># +
+@[code]#vec<half, N># +
  [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, N>#
-![code]#vec<int16_t, N>#
-!====
+@[code]#vec<int16_t, N>#
+|====
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ any(GenInt x)
@@ -26943,7 +26479,6 @@ template<typename GenInt>      (1)
 template<typename GenInt>      (2)  /* deprecated */
 bool any(GenInt x)
 ----
-!====
 
 *Overload (1):*
 
@@ -26989,11 +26524,9 @@ most significant bit of [code]#x# is set.  When [code]#x# is [code]#marray#,
 returns a Boolean telling whether the most significant bit of any element
 in [code]#x# is set.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ all(GenInt x)
@@ -27001,7 +26534,6 @@ template<typename GenInt>      (1)
 template<typename GenInt>      (2)  /* deprecated */
 bool all(GenInt x)
 ----
-!====
 
 *Overload (1):*
 
@@ -27047,16 +26579,13 @@ most significant bit of [code]#x# is set.  When [code]#x# is [code]#marray#,
 returns a Boolean telling whether the most significant bit of all elements
 in [code]#x# are set.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename GenType1, typename GenType2, typename GenType3>
 /*return-type*/ bitselect(GenType1 a, GenType2 b, GenType3 c)
 ----
-!====
 
 _Constraints:_ Available only if all of the following conditions are met:
 
@@ -27088,11 +26617,9 @@ The return type is [code]#GenType1# unless [code]#GenType1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
 
-a@
-[frame=all,grid=none]
-!====
-a!
-[source]
+'''
+
+[source,role=codebox]
 ----
 template<typename Scalar>                                                (1)
 Scalar select(Scalar a, Scalar b, bool c)
@@ -27100,7 +26627,6 @@ Scalar select(Scalar a, Scalar b, bool c)
 template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (2)
 /*return-type*/ select(NonScalar1 a, NonScalar2 b, NonScalar3 c)
 ----
-!====
 
 *Overload (1):*
 
@@ -27145,7 +26671,8 @@ of [code]#a#, [code]#b#, and [code]#c#.
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-|====
+
+'''
 
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%% end builtin_functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -25280,8 +25280,12 @@ corresponding [code]#vec#.
 
 [source,role=codebox]
 ----
-template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
+template<typename GenFloat1, typename GenFloat2, typename GenFloat3>                  (1)
 /*return-type*/ smoothstep(GenFloat1 edge0, GenFloat2 edge1, GenFloat3 x)
+
+template<typename NonScalar>                                                          (2)
+/*return-type*/ smoothstep(NonScalar::value_type edge0, NonScalar::value_type edge1,
+                           NonScalar x)
 ----
 
 *Overload (1):*
@@ -25328,15 +25332,6 @@ return t * t * (3 - 2 * t);
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
 corresponding [code]#vec#.
-
-'''
-
-[source,role=codebox]
-----
-template<typename NonScalar>                                                          (2)
-/*return-type*/ smoothstep(NonScalar::value_type edge0, NonScalar::value_type edge1,
-                           NonScalar x)
-----
 
 *Overload (2):*
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20949,8 +20949,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the value
-[code]#acos(x[i]) / {pi}#.
+_Returns:_ For each element of [code]#x#, the value [code]#acos(x[i]) / {pi}#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21288,8 +21287,8 @@ template<typename NonScalar1, typename NonScalar2>    (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ The value of [code]#x# with its sign changed to match
-the sign of [code]#y#.
+_Returns:_ The value of [code]#x# with its sign changed to match the sign of
+[code]#y#.
 
 *Overload (4):*
 
@@ -21366,8 +21365,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the hyperbolic cosine of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the hyperbolic cosine of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21648,8 +21646,8 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1# and [code]#NonScalar2# is
   [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the value
-[code]#x[i] - y[i]# if [code]#x[i] > y[i]#, otherwise +0.
+_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i] -
+y[i]# if [code]#x[i] > y[i]#, otherwise +0.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21703,8 +21701,8 @@ template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (4)
 
 _Returns:_ The correctly rounded floating-point representation of the sum of
 [code]#c# with the infinitely precise product of [code]#a# and [code]#b#.
-Rounding of intermediate products shall not occur. Edge case behavior is per
-the IEEE 754-2008 standard.
+Rounding of intermediate products shall not occur.
+Edge case behavior is per the IEEE 754-2008 standard.
 
 *Overload (4):*
 
@@ -21723,11 +21721,11 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1#, [code]#NonScalar2#, and
   [code]#NonScalar3# is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#a#, [code]#b#, and [ode]#c#; the
-correctly rounded floating-point representation of the sum of [code]#c[i]# with
-the infinitely precise product of [code]#a[i]# and [code]#b[i]#.  Rounding of
-intermediate products shall not occur. Edge case behavior is per the IEEE
-754-2008 standard.
+_Returns:_ For each element of [code]#a#, [code]#b#, and [ode]#c#; the correctly
+rounded floating-point representation of the sum of [code]#c[i]# with the
+infinitely precise product of [code]#a[i]# and [code]#b[i]#.
+Rounding of intermediate products shall not occur.
+Edge case behavior is per the IEEE 754-2008 standard.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21750,8 +21748,9 @@ template<typename NonScalar>                                (5)
 
 *Overloads (1) - (3):*
 
-_Returns:_ [code]#y# if [code]#x < y#, otherwise [code]#x#. If one argument is
-a NaN, returns the other argument. If both arguments are NaNs, returns a NaN.
+_Returns:_ [code]#y# if [code]#x < y#, otherwise [code]#x#.
+If one argument is a NaN, returns the other argument.
+If both arguments are NaNs, returns a NaN.
 
 *Overload (4):*
 
@@ -21768,8 +21767,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#float#, [code]#double#, or [code]#half#.
 
 _Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#y[i]#
-if [code]#x[i] < y[i]#, otherwise [code]#x[i]#. If one element is a NaN, the
-result is the other element. If both elements are NaNs, the result is NaN.
+if [code]#x[i] < y[i]#, otherwise [code]#x[i]#.
+If one element is a NaN, the result is the other element.
+If both elements are NaNs, the result is NaN.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21783,9 +21783,10 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the value [code]#y# if
-[code]#x[i] < y#, otherwise [code]#x[i]#. If one value is a NaN, the result is
-the other value. If both value are NaNs, the result is a NaN.
+_Returns:_ For each element of [code]#x#, the value [code]#y# if [code]#x[i] <
+y#, otherwise [code]#x[i]#.
+If one value is a NaN, the result is the other value.
+If both value are NaNs, the result is a NaN.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21808,8 +21809,9 @@ template<typename NonScalar>                                (5)
 
 *Overloads (1) - (3):*
 
-_Returns:_ [code]#y# if [code]#y < x#, otherwise [code]#x#. If one argument is
-a NaN, returns the other argument. If both arguments are NaNs, returns a NaN.
+_Returns:_ [code]#y# if [code]#y < x#, otherwise [code]#x#.
+If one argument is a NaN, returns the other argument.
+If both arguments are NaNs, returns a NaN.
 
 *Overload (4):*
 
@@ -21826,8 +21828,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#float#, [code]#double#, or [code]#half#.
 
 _Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#y[i]#
-if [code]#y[i] < x[i]#, otherwise [code]#x[i]#. If one element is a NaN, the
-result is the other element. If both elements are NaNs, the result is NaN.
+if [code]#y[i] < x[i]#, otherwise [code]#x[i]#.
+If one element is a NaN, the result is the other element.
+If both elements are NaNs, the result is NaN.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21841,9 +21844,10 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the value [code]#y# if
-[code]#y < x[i]#, otherwise [code]#x[i]#. If one value is a NaN, the result is
-the other value. If both value are NaNs, the result is a NaN.
+_Returns:_ For each element of [code]#x#, the value [code]#y# if [code]#y <
+x[i]#, otherwise [code]#x[i]#.
+If one value is a NaN, the result is the other value.
+If both value are NaNs, the result is a NaN.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21879,8 +21883,8 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1# and [code]#NonScalar2# is
   [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the value
-[code]#x[i] - y[i] * trunc(x[i]/y[i])#.
+_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i] -
+y[i] * trunc(x[i]/y[i])#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21923,16 +21927,16 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#double#, or [code]#half#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#ElementType# equal to
   [code]#NonScalar#, unless [code]#NonScalar# is the [code]#+__swizzled_vec__+#
-  type, in which case the [code]#ElementType# is the corresponding
-  [code]#vec#; and
+  type, in which case the [code]#ElementType# is the corresponding [code]#vec#;
+  and
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
 _Effects:_ Writes the value [code]#floor(x)# to [code]#iptr#.
 
-_Returns:_ For each element of [code]#x#, the value
-[code]#fmin(x[i] - floor(x[i]), nextafter(T{1.0}, T{0.0}) )#, where
-[code]#T# is the element type of [code]#x#.
+_Returns:_ For each element of [code]#x#, the value [code]#fmin(x[i] -
+floor(x[i]), nextafter(T{1.0}, T{0.0}) )#, where [code]#T# is the element type
+of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -21961,10 +21965,12 @@ _Constraints:_ Available only if [code]#Ptr# is [code]#multi_ptr# with
 [code]#ElementType# of [code]#int# and with [code]#Space# equal to one of the
 _writeable address spaces_ as defined above.
 
-_Effects:_ Extracts the mantissa and exponent from [code]#x#.  The mantissa is
-a floating point number whose magnitude is in the interval +[0.5, 1)+ or 0.  The
-extracted mantissa and exponent are such that mantissa * 2^exp^ equals
-[code]#x#.  The exponent is written to [code]#exp#.
+_Effects:_ Extracts the mantissa and exponent from [code]#x#.
+The mantissa is a floating point number whose magnitude is in the interval
++[0.5, 1)+ or 0.
+The extracted mantissa and exponent are such that mantissa * 2^exp^ equals
+[code]#x#.
+The exponent is written to [code]#exp#.
 
 _Returns:_ The mantissa of [code]#x#.
 
@@ -21976,20 +21982,20 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type with element type [code]#float#,
   [code]#double#, or [code]#half#;
 * [code]#Ptr# is [code]#multi_ptr# with the following [code]#ElementType#:
-** If [code]#NonScalar# is [code]#marray#, [code]#ElementType# is
-   [code]#marray# of [code]#int# with the same number of elements as
-   [code]#NonScalar#;
+** If [code]#NonScalar# is [code]#marray#, [code]#ElementType# is [code]#marray#
+   of [code]#int# with the same number of elements as [code]#NonScalar#;
 ** If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number
-   of elements as [code]#NonScalar#;
+   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number of
+   elements as [code]#NonScalar#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
 _Effects:_ Extracts the mantissa and exponent from each element of [code]#x#.
 Each mantissa is a floating point number whose magnitude is in the interval
-+[0.5, 1)+ or 0.  Each extracted mantissa and exponent are such that
-mantissa * 2^exp^ equals [code]#x[i]#.  The exponent of each element of
-[code]#x# is written to [code]#exp#.
++[0.5, 1)+ or 0.
+Each extracted mantissa and exponent are such that mantissa * 2^exp^ equals
+[code]#x[i]#.
+The exponent of each element of [code]#x# is written to [code]#exp#.
 
 _Returns:_ For each element of [code]#x#, the mantissa of [code]#x[i]#.
 
@@ -22011,8 +22017,8 @@ template<typename NonScalar1, typename NonScalar2>  (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ The value of the square root of x^2^ + y^2^ without undue overflow
-or underflow.
+_Returns:_ The value of the square root of x^2^ + y^2^ without undue overflow or
+underflow.
 
 *Overload (4):*
 
@@ -22065,11 +22071,12 @@ _Returns:_ For each element of [code]#x#, compute the integral part of
 log~r~|x[i]| and return the result as an integer, where r is the value returned
 by [code]#std::numeric_limits<NonScalar::value_type)>::radix#.
 
-The return type depends on [code]#NonScalar#.  If [code]#NonScalar# is
-[code]#marray#, the return type is [code]#marray# of [code]#int# with the same
-number of element as [code]#NonScalar#.  If [code]#NonScalar# is [code]#vec# or
-the [code]#+__swizzled_vec__+# type, the return type is [code]#vec# of
-[code]#int32_t# with the same number of elements as [code]#NonScalar#.
+The return type depends on [code]#NonScalar#.
+If [code]#NonScalar# is [code]#marray#, the return type is [code]#marray# of
+[code]#int# with the same number of element as [code]#NonScalar#.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type, the
+return type is [code]#vec# of [code]#int32_t# with the same number of elements
+as [code]#NonScalar#.
 
 '''
 
@@ -22104,8 +22111,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#NonScalar2# is [code]#vec# or the [code]#+__swizzled_vec__+# type of
   [code]#int32_t# with the same number of elements as [code]#NonScalar1#.
 
-_Returns:_ For each element of [code]#x# and [code]#k#, the value
-[code]#x[i]# multiplied by 2^k[i]^.
+_Returns:_ For each element of [code]#x# and [code]#k#, the value [code]#x[i]#
+multiplied by 2^k[i]^.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22195,12 +22202,11 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type with element type [code]#float#,
   [code]#double#, or [code]#half#;
 * [code]#Ptr# is [code]#multi_ptr# with the following [code]#ElementType#:
-** If [code]#NonScalar# is [code]#marray#, [code]#ElementType# is
-   [code]#marray# of [code]#int# with the same number of elements as
-   [code]#NonScalar#;
+** If [code]#NonScalar# is [code]#marray#, [code]#ElementType# is [code]#marray#
+   of [code]#int# with the same number of elements as [code]#NonScalar#;
 ** If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number
-   of elements as [code]#NonScalar#;
+   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number of
+   elements as [code]#NonScalar#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
@@ -22238,8 +22244,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the natural logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the natural logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22299,8 +22304,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the base 10 logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the base 10 logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22383,10 +22387,11 @@ template<typename NonScalar1, typename NonScalar2, typename NonScalar3>  (4)
 
 *Overloads (1) - (3):*
 
-_Effects:_ Computes the approximate value of [code]#a * b + c#.  Whether or how
-the product of [code]#a * b# is rounded and how supernormal or subnormal
-intermediate products are handled is not defined.  The [code]#mad# function is
-intended to be used where speed is preferred over accuracy.
+_Effects:_ Computes the approximate value of [code]#a * b + c#.
+Whether or how the product of [code]#a * b# is rounded and how supernormal or
+subnormal intermediate products are handled is not defined.
+The [code]#mad# function is intended to be used where speed is preferred over
+accuracy.
 
 _Returns:_ The approximate value of [code]#a * b + c#.
 
@@ -22407,8 +22412,8 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1#, [code]#NonScalar2#, and
   [code]#NonScalar3# is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#a#, [code]#b#, and [ode]#c#; the
-The approximate value of [code]#a[i] * b[i] + c[i]#.
+_Returns:_ For each element of [code]#a#, [code]#b#, and [ode]#c#; the The
+approximate value of [code]#a[i] * b[i] + c[i]#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22446,8 +22451,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#float#, [code]#double#, or [code]#half#.
 
 _Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i]#
-if |x[i]| > |y[i]|, [code]#y[i]# if |y[i]| > |x[i]|, otherwise
-[code]#fmax(x[i], y[i])#.
+if |x[i]| > |y[i]|, [code]#y[i]# if |y[i]| > |x[i]|, otherwise [code]#fmax(x[i],
+y[i])#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22485,8 +22490,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#float#, [code]#double#, or [code]#half#.
 
 _Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i]#
-if |x[i]| < |y[i]|, [code]#y[i]# if |y[i]| < |x[i]|, otherwise
-[code]#fmin(x[i], y[i])#.
+if |x[i]| < |y[i]|, [code]#y[i]# if |y[i]| < |x[i]|, otherwise [code]#fmin(x[i],
+y[i])#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22515,8 +22520,8 @@ _Constraints:_ Available only if [code]#Ptr# is [code]#multi_ptr# with
 [code]#ElementType# equal to the same type as [code]#x# and with [code]#Space#
 equal to one of the _writeable address spaces_ as defined above.
 
-_Effects:_ The [code]#modf# function breaks the argument [code]#x# into
-integral and fractional parts, each of which has the same sign as the argument.
+_Effects:_ The [code]#modf# function breaks the argument [code]#x# into integral
+and fractional parts, each of which has the same sign as the argument.
 It stores the integral part to the object pointed to by [code]#iptr#.
 
 _Returns:_ The fractional part of the argument [code]#x#.
@@ -22530,15 +22535,16 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#double#, or [code]#half#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#ElementType# equal to
   [code]#NonScalar#, unless [code]#NonScalar# is the [code]#+__swizzled_vec__+#
-  type, in which case the [code]#ElementType# is the corresponding
-  [code]#vec#; and
+  type, in which case the [code]#ElementType# is the corresponding [code]#vec#;
+  and
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
 _Effects:_ The [code]#modf# function breaks each element of the argument
-[code]#x# into integral and fractional parts, each of which has the same sign
-as the element.  It stores the integral parts of each element to the object
-pointed to by [code]#iptr#.
+[code]#x# into integral and fractional parts, each of which has the same sign as
+the element.
+It stores the integral parts of each element to the object pointed to by
+[code]#iptr#.
 
 _Returns:_ The fractional parts of each element of the argument [code]#x#.
 
@@ -22560,8 +22566,8 @@ template<typename NonScalar>            (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ A quiet NaN. The [code]#nancode# may be placed
-in the significand of the resulting NaN.
+_Returns:_ A quiet NaN.
+The [code]#nancode# may be placed in the significand of the resulting NaN.
 
 *Overload (4):*
 
@@ -22571,8 +22577,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#uint32_t#, [code]#uint64_t#, or [code]#uint16_t#.
 
-_Returns:_ A quiet NaN for each element of [code]#nancode#.  Each
-[code]#nancode[i]# may be placed in the significand of the resulting NaN.
+_Returns:_ A quiet NaN for each element of [code]#nancode#.
+Each [code]#nancode[i]# may be placed in the significand of the resulting NaN.
 
 The return type depends on [code]#NonScalar#:
 
@@ -22611,9 +22617,9 @@ template<typename NonScalar1, typename NonScalar2>     (4)
 *Overloads (1) - (3):*
 
 _Returns:_ The next representable floating-point value following [code]#x# in
-the direction of [code]#y#.  Thus, if [code]#y# is less than [code]#x#,
-[code]#nextafter# returns the largest representable floating-point number less
-than [code]#x#.
+the direction of [code]#y#.
+Thus, if [code]#y# is less than [code]#x#, [code]#nextafter# returns the largest
+representable floating-point number less than [code]#x#.
 
 *Overload (4):*
 
@@ -22629,9 +22635,8 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1# and [code]#NonScalar2# is
   [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the
-next representable floating-point value following [code]#x[i]# in the direction
-of [code]#y[i]#.
+_Returns:_ For each element of [code]#x# and [code]#y#, the next representable
+floating-point value following [code]#x[i]# in the direction of [code]#y[i]#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22767,10 +22772,11 @@ template<typename NonScalar1, typename NonScalar2>     (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ The value [code]#r# such that [code]#r = x - n*y#, where [code]#n#
-is the integer nearest the exact value of [code]#x/y#.  If there are two
-integers closest to [code]#x/y#, [code]#n# shall be the even one.  If [code]#r#
-is zero, it is given the same sign as [code]#x#.
+_Returns:_ The value [code]#r# such that [code]#r = x - n*y#, where [code]#n# is
+the integer nearest the exact value of [code]#x/y#.
+If there are two integers closest to [code]#x/y#, [code]#n# shall be the even
+one.
+If [code]#r# is zero, it is given the same sign as [code]#x#.
 
 *Overload (4):*
 
@@ -22786,11 +22792,12 @@ _Constraints:_ Available only if all of the following conditions are met:
 * The element type of [code]#NonScalar1# and [code]#NonScalar2# is
   [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#r#
-such that [code]#r = x[i] - n*y[i]#, where [code]#n# is the integer nearest the
-exact value of [code]#x[i]/y[i]#.  If there are two integers closest to
-[code]#x[i]/y[i]#, [code]#n# shall be the even one.  If [code]#r# is zero, it
-is given the same sign as [code]#x[i]#.
+_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#r# such
+that [code]#r = x[i] - n*y[i]#, where [code]#n# is the integer nearest the exact
+value of [code]#x[i]/y[i]#.
+If there are two integers closest to [code]#x[i]/y[i]#, [code]#n# shall be the
+even one.
+If [code]#r# is zero, it is given the same sign as [code]#x[i]#.
 
 The return type is [code]#NonScalar1# unless [code]#NonScalar1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -22820,13 +22827,14 @@ _Constraints:_ Available only if [code]#Ptr# is [code]#multi_ptr# with
 _writeable address spaces_ as defined above.
 
 _Effects:_ Computes the value [code]#r# such that [code]#r = x - k*y#, where
-[code]#k# is the integer nearest the exact value of [code]#x/y#.  If there are
-two integers closest to [code]#x/y#, [code]#k# shall be the even one.  If
-[code]#r# is zero, it is given the same sign as [code]#x#.  This is the same
-value that is returned by the [code]#remainder# function.  The [code]#remquo#
-function also calculates the lower seven bits of the integral quotient
-[code]#x/y# and gives that value the same sign as [code]#x/y#.  It stores this
-signed value to the object pointed to by [code]#quo#.
+[code]#k# is the integer nearest the exact value of [code]#x/y#.
+If there are two integers closest to [code]#x/y#, [code]#k# shall be the even
+one.
+If [code]#r# is zero, it is given the same sign as [code]#x#.
+This is the same value that is returned by the [code]#remainder# function.
+The [code]#remquo# function also calculates the lower seven bits of the integral
+quotient [code]#x/y# and gives that value the same sign as [code]#x/y#.
+It stores this signed value to the object pointed to by [code]#quo#.
 
 _Returns:_ The value [code]#r# defined above.
 
@@ -22844,19 +22852,21 @@ _Constraints:_ Available only if all of the following conditions are met:
    [code]#marray# of [code]#int# with the same number of elements as
    [code]#NonScalar1#;
 ** If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number
-   of elements as [code]#NonScalar1#;
+   [code]#ElementType# is [code]#vec# of [code]#int32_t# with the same number of
+   elements as [code]#NonScalar1#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
 _Effects:_ Computes the value [code]#r# for each element of [code]#x# and
 [code]#y# such that [code]#r = x[i] - k*y[i]#, where [code]#k# is the integer
-nearest the exact value of [code]#x[i]/y[i]#.  If there are two integers
-closest to [code]#x[i]/y[i]#, [code]#k# shall be the even one.  If [code]#r# is
-zero, it is given the same sign as [code]#x[i]#.  This is the same value that
-is returned by the [code]#remainder# function.  The [code]#remquo# function
-also calculates the lower seven bits of the integral quotient
-[code]#x[i]/y[i]# and gives that value the same sign as [code]#x[i]/y[i]#.
+nearest the exact value of [code]#x[i]/y[i]#.
+If there are two integers closest to [code]#x[i]/y[i]#, [code]#k# shall be the
+even one.
+If [code]#r# is zero, it is given the same sign as [code]#x[i]#.
+This is the same value that is returned by the [code]#remainder# function.
+The [code]#remquo# function also calculates the lower seven bits of the integral
+quotient [code]#x[i]/y[i]# and gives that value the same sign as
+[code]#x[i]/y[i]#.
 It stores these signed values to the object pointed to by [code]#quo#.
 
 _Returns:_ The values of [code]#r# defined above.
@@ -22880,9 +22890,9 @@ template<typename NonScalar>       (4)
 *Overloads (1) - (3):*
 
 _Returns:_ The value [code]#x# rounded to an integral value (using round to
-nearest even rounding mode) in floating-point format.  Refer to <<opencl12,
-section 7.1 of the OpenCL 1.2 specification document>> for a description of the
-rounding modes.
+nearest even rounding mode) in floating-point format.
+Refer to <<opencl12, section 7.1 of the OpenCL 1.2 specification document>> for
+a description of the rounding modes.
 
 *Overload (4):*
 
@@ -23054,8 +23064,8 @@ _Constraints:_ Available only if [code]#Ptr# is [code]#multi_ptr# with
 [code]#ElementType# equal to the same type as [code]#x# and with [code]#Space#
 equal to one of the _writeable address spaces_ as defined above.
 
-_Effects:_ Compute the sine and cosine of [code]#x#.  The computed cosine is
-written to [code]#cosval#.
+_Effects:_ Compute the sine and cosine of [code]#x#.
+The computed cosine is written to [code]#cosval#.
 
 _Returns:_ The sine of [code]#x#.
 
@@ -23068,13 +23078,13 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#double#, or [code]#half#;
 * [code]#Ptr# is [code]#multi_ptr# with [code]#ElementType# equal to
   [code]#NonScalar#, unless [code]#NonScalar# is the [code]#+__swizzled_vec__+#
-  type, in which case the [code]#ElementType# is the corresponding
-  [code]#vec#; and
+  type, in which case the [code]#ElementType# is the corresponding [code]#vec#;
+  and
 * [code]#Ptr# is [code]#multi_ptr# with [code]#Space# equal to one of the
   _writeable address spaces_ as defined above.
 
-_Effects:_ Compute the sine and cosine of each element of [code]#x#.  The
-computed cosine values are written to [code]#cosval#.
+_Effects:_ Compute the sine and cosine of each element of [code]#x#.
+The computed cosine values are written to [code]#cosval#.
 
 _Returns:_ The sine of each element of [code]#x#.
 
@@ -23389,8 +23399,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the value
-[code]#x[i] / y[i]#.
+_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i] /
+y[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -23505,8 +23515,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the natural logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the natural logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -23562,8 +23571,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the base 10 logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the base 10 logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -23812,8 +23820,8 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x# and [code]#y#, the value
-[code]#x[i] / y[i]#.
+_Returns:_ For each element of [code]#x# and [code]#y#, the value [code]#x[i] /
+y[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -23928,8 +23936,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the natural logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the natural logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -23985,8 +23992,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the base 10 logarithm of
-[code]#x[i]#.
+_Returns:_ For each element of [code]#x#, the base 10 logarithm of [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24239,9 +24245,10 @@ template<typename GenInt>
 _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
 
-_Returns:_ When the input is a scalar, returns |x|.  Otherwise, returns |x[i]|
-for each element of [code]#x#.  The behavior is undefined if the result cannot
-be represented by the return type.
+_Returns:_ When the input is a scalar, returns |x|.
+Otherwise, returns |x[i]| for each element of [code]#x#.
+The behavior is undefined if the result cannot be represented by the return
+type.
 
 The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24260,15 +24267,16 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
-_Returns:_ When the inputs are scalars, returns |x - y|.  Otherwise, returns
-|x[i] - y[i]| for each element of [code]#x# and [code]#y#.  The subtraction is
-done without modulo overflow.  The behavior is undefined if the result cannot
-be represented by the return type.
+_Returns:_ When the inputs are scalars, returns |x - y|.
+Otherwise, returns |x[i] - y[i]| for each element of [code]#x# and [code]#y#.
+The subtraction is done without modulo overflow.
+The behavior is undefined if the result cannot be represented by the return
+type.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24287,14 +24295,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
-_Returns:_ When the inputs are scalars, returns [code]#x + y#.  Otherwise,
-returns [code]#x[i] + y[i]# for each element of [code]#x# and [code]#y#.  The
-addition operation saturates the result.
+_Returns:_ When the inputs are scalars, returns [code]#x + y#.
+Otherwise, returns [code]#x[i] + y[i]# for each element of [code]#x# and
+[code]#y#.
+The addition operation saturates the result.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24313,14 +24322,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Returns:_ When the inputs are scalars, returns [code]#(x + y) >> 1#.
 Otherwise, returns [code]#(x[i] + y[i]) >> 1# for each element of [code]#x# and
-[code]#y#.  The intermediate sum does not modulo overflow.
+[code]#y#.
+The intermediate sum does not modulo overflow.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24339,14 +24349,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Returns:_ When the inputs are scalars, returns [code]#(x + y + 1) >> 1#.
 Otherwise, returns [code]#(x[i] + y[i] + 1) >> 1# for each element of [code]#x#
-and [code]#y#.  The intermediate sum does not modulo overflow.
+and [code]#y#.
+The intermediate sum does not modulo overflow.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24372,20 +24383,20 @@ _Constraints:_ Available only if all of the following conditions are met:
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# and [code]#GenInt3# must be the same as [code]#GenInt1#;
   and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
 _Preconditions:_ If the inputs are scalars, the value of [code]#minval# must be
-less than or equal to the value of [code]#maxval#.  If the inputs are not
-scalars, each [code]#minval# must be less than or equal to the corresponding
-[code]#maxval# value.
+less than or equal to the value of [code]#maxval#.
+If the inputs are not scalars, each [code]#minval# must be less than or equal to
+the corresponding [code]#maxval# value.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#min(max(x, minval), maxval)#.  Otherwise, returns
-[code]#min(max(x[i], minval[i]), maxval[i])# for each element of [code]#x#,
-[code]#minval#, and [code]#maxval#.
+_Returns:_ When the inputs are scalars, returns [code]#min(max(x, minval),
+maxval)#.
+Otherwise, returns [code]#min(max(x[i], minval[i]), maxval[i])# for each element
+of [code]#x#, [code]#minval#, and [code]#maxval#.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24400,8 +24411,7 @@ type_ as defined above.
 _Preconditions:_ The value of [code]#minval# must be less than or equal to the
 value of [code]#maxval#.
 
-_Returns:_ [code]#min(max(x[i], minval), maxval)# for each element of
-[code]#x#.
+_Returns:_ [code]#min(max(x[i], minval), maxval)# for each element of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24419,9 +24429,9 @@ _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
 
 _Returns:_ When the input is a scalar, returns the number of leading 0-bits in
-[code]#x#, starting at the most significant bit position.  Otherwise, returns
-the number of leading 0-bits in each element of [code]#x#.  When a value is 0,
-the computed count is the size in bits of that value.
+[code]#x#, starting at the most significant bit position.
+Otherwise, returns the number of leading 0-bits in each element of [code]#x#.
+When a value is 0, the computed count is the size in bits of that value.
 
 The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24439,9 +24449,9 @@ _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
 
 _Returns:_ When the input is a scalar, returns the number of trailing 0-bits in
-[code]#x#.  Otherwise, returns the number of trailing 0-bits in each element of
-[code]#x#.  When a value is 0, the computed count is the size in bits of that
-value.
+[code]#x#.
+Otherwise, returns the number of trailing 0-bits in each element of [code]#x#.
+When a value is 0, the computed count is the size in bits of that value.
 
 The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24461,10 +24471,10 @@ _Constraints:_ Available only if all of the following conditions are met:
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# and [code]#GenInt3# must be the same as [code]#GenInt1#;
   and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
 _Returns:_ When the inputs are scalars, returns [code]#mul_hi(a, b)+c#.
 Otherwise, returns [code]#mul_hi(a[i], b[i])+c[i]# for each element of
@@ -24488,14 +24498,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# and [code]#GenInt3# must be the same as [code]#GenInt1#;
   and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# and [code]#GenInt3# must also be [code]#vec# or the
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns [code]#a * b + c#.  Otherwise,
-returns [code]#a[i] * b[i] + c[i]# for each element of [code]#a#, [code]#b#,
-and [code]#c#.  The operation saturates the result.
+_Returns:_ When the inputs are scalars, returns [code]#a * b + c#.
+Otherwise, returns [code]#a[i] * b[i] + c[i]# for each element of [code]#a#,
+[code]#b#, and [code]#c#.
+The operation saturates the result.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24519,15 +24530,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Returns:_ When the inputs are scalars, returns [code]#y# if [code]#x < y#
-otherwise [code]#x#.  When the inputs are not scalars, returns [code]#y[i]# if
-[code]#x[i] < y[i]# otherwise [code]#x[i]# for each element of [code]#x# and
-[code]#y#.
+otherwise [code]#x#.
+When the inputs are not scalars, returns [code]#y[i]# if [code]#x[i] < y[i]#
+otherwise [code]#x[i]# for each element of [code]#x# and [code]#y#.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24539,8 +24550,8 @@ _Constraints:_ Available only if [code]#NonScalar# is [code]#marray#,
 [code]#vec#, or the [code]#+__swizzled_vec__+# type and is a _generic integer
 type_ as defined above.
 
-_Returns:_ [code]#y# if [code]#x[i] < y# otherwise [code]#x[i]# for each
-element of [code]#x#.
+_Returns:_ [code]#y# if [code]#x[i] < y# otherwise [code]#x[i]# for each element
+of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24564,15 +24575,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Returns:_ When the inputs are scalars, returns [code]#y# if [code]#y < x#
-otherwise [code]#x#.  When the inputs are not scalars, returns [code]#y[i]# if
-[code]#y[i] < x[i]# otherwise [code]#x[i]# for each element of [code]#x# and
-[code]#y#.
+otherwise [code]#x#.
+When the inputs are not scalars, returns [code]#y[i]# if [code]#y[i] < x[i]#
+otherwise [code]#x[i]# for each element of [code]#x# and [code]#y#.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24584,8 +24595,8 @@ _Constraints:_ Available only if [code]#NonScalar# is [code]#marray#,
 [code]#vec#, or the [code]#+__swizzled_vec__+# type and is a _generic integer
 type_ as defined above.
 
-_Returns:_ [code]#y# if [code]#y < x[i]# otherwise [code]#x[i]# for each
-element of [code]#x#.
+_Returns:_ [code]#y# if [code]#y < x[i]# otherwise [code]#x[i]# for each element
+of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24604,17 +24615,18 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Effects:_ Computes [code]#x * y# and returns the high half of the product of
 [code]#x# and [code]#y#.
 
 _Returns:_ When the inputs are scalars, returns the high half of the product of
-[code]#x * y#.  Otherwise, returns the high half of the product of
-[code]#x[i] * y[i]# for each element of [code]#x# and [code]#y#.
+[code]#x * y#.
+Otherwise, returns the high half of the product of [code]#x[i] * y[i]# for each
+element of [code]#x# and [code]#y#.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24633,21 +24645,22 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
 _Effects:_ For each element in [code]#v#, the bits are shifted left by the
 number of bits given by the corresponding element in [code]#count# (subject to
-usual shift modulo rules described in the OpenCL 1.2 specification
-<<opencl12, section 6.3>>).  Bits shifted off the left side of the element are
-shifted back in from the right.
+usual shift modulo rules described in the OpenCL 1.2 specification <<opencl12,
+section 6.3>>).
+Bits shifted off the left side of the element are shifted back in from the
+right.
 
 _Returns:_ When the inputs are scalars, the result of rotating [code]#v# by
-[code]#count# as described above.  Otherwise, the result of rotating
-[code]#v[i]# by [code]#count[i]# for each element of [code]#v# and
-[code]#count#.
+[code]#count# as described above.
+Otherwise, the result of rotating [code]#v[i]# by [code]#count[i]# for each
+element of [code]#v# and [code]#count#.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24666,14 +24679,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GenInt1# is a _generic integer type_ as defined above;
 * If [code]#GenInt1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenInt2# must be the same as [code]#GenInt1#; and
-* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-  then [code]#GenInt2# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and both must have the same element type and
-  the same number of elements.
+* If [code]#GenInt1# is [code]#vec# or the [code]#+__swizzled_vec__+# type, then
+  [code]#GenInt2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+  type, and both must have the same element type and the same number of
+  elements.
 
-_Returns:_ When the inputs are scalars, returns [code]#x - y#.  Otherwise, returns
-[code]#x[i] - y[i]# for each element of [code]#x# and [code]#y#.  The subtraction
-operation saturates the result.
+_Returns:_ When the inputs are scalars, returns [code]#x - y#.
+Otherwise, returns [code]#x[i] - y[i]# for each element of [code]#x# and
+[code]#y#.
+The subtraction operation saturates the result.
 
 The return type is [code]#GenInt1# unless [code]#GenInt1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24696,16 +24710,16 @@ _Constraints:_ Available only if one of the following conditions is met:
   the [code]#+__swizzled_vec__+# type with element type [code]#uint8_t# and the
   same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((uint16_t)hi << 8) | lo#.  Otherwise, returns
-[code]#((uint16_t)hi[i] << 8) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((uint16_t)hi << 8) |
+lo#.
+Otherwise, returns [code]#((uint16_t)hi[i] << 8) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#uint16_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#uint16_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#uint16_t#
-and the same number of elements as the inputs.
+The return type is [code]#uint16_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#uint16_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#uint16_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24719,23 +24733,22 @@ _Constraints:_ Available only if one of the following conditions is met:
 
 * [code]#Int8Bit# is [code]#int8_t# and [code]#UInt8Bit# is [code]#uint8_t#;
 * [code]#Int8Bit# is [code]#marray# with element type [code]#int8_t# and
-  [code]#UInt8Bit# is [code]#marray# with element type [code]#uint8_t# and
-  both have the same number of elements; or
+  [code]#UInt8Bit# is [code]#marray# with element type [code]#uint8_t# and both
+  have the same number of elements; or
 * [code]#Int8Bit# is [code]#vec# or the [code]#+__swizzled_vec__+# type with
   element type [code]#int8_t# and [code]#UInt8Bit# is [code]#vec# or the
   [code]#+__swizzled_vec__+# type with element type [code]#uint8_t# and both
   have the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((int16_t)hi << 8) | lo#.  Otherwise, returns
-[code]#((int16_t)hi[i] << 8) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((int16_t)hi << 8) | lo#.
+Otherwise, returns [code]#((int16_t)hi[i] << 8) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#int16_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#int16_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#int16_t#
-and the same number of elements as the inputs.
+The return type is [code]#int16_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#int16_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#int16_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24748,22 +24761,22 @@ template<typename UInt16Bit1, typename UInt16Bit2>
 _Constraints:_ Available only if one of the following conditions is met:
 
 * [code]#UInt16Bit1# and [code]#UInt16Bit2# are both [code]#uint16_t#;
-* [code]#UInt16Bit1# and [code]#UInt16Bit2# are both [code]#marray# with
-  element type [code]#uint16_t# and the same number of elements; or
+* [code]#UInt16Bit1# and [code]#UInt16Bit2# are both [code]#marray# with element
+  type [code]#uint16_t# and the same number of elements; or
 * [code]#UInt16Bit1# and [code]#UInt16Bit2# are any combination of [code]#vec#
   or the [code]#+__swizzled_vec__+# type with element type [code]#uint16_t# and
   the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((uint32_t)hi << 16) | lo#.  Otherwise, returns
-[code]#((uint32_t)hi[i] << 16) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((uint32_t)hi << 16) |
+lo#.
+Otherwise, returns [code]#((uint32_t)hi[i] << 16) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#uint32_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#uint32_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#uint32_t#
-and the same number of elements as the inputs.
+The return type is [code]#uint32_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#uint32_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#uint32_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24775,8 +24788,7 @@ template<typename Int16Bit, typename UInt16Bit>
 
 _Constraints:_ Available only if one of the following conditions is met:
 
-* [code]#Int16Bit# is [code]#int16_t# and [code]#UInt16Bit# is
-  [code]#uint16_t#;
+* [code]#Int16Bit# is [code]#int16_t# and [code]#UInt16Bit# is [code]#uint16_t#;
 * [code]#Int16Bit# is [code]#marray# with element type [code]#int16_t# and
   [code]#UInt16Bit# is [code]#marray# with element type [code]#uint16_t# and
   both have the same number of elements; or
@@ -24785,16 +24797,16 @@ _Constraints:_ Available only if one of the following conditions is met:
   [code]#+__swizzled_vec__+# type with element type [code]#uint16_t# and both
   have the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((int32_t)hi << 16) | lo#.  Otherwise, returns
-[code]#((int32_t)hi[i] << 16) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((int32_t)hi << 16) |
+lo#.
+Otherwise, returns [code]#((int32_t)hi[i] << 16) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#int32_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#int32_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#int32_t#
-and the same number of elements as the inputs.
+The return type is [code]#int32_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#int32_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#int32_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24807,22 +24819,22 @@ template<typename UInt32Bit1, typename UInt32Bit2>
 _Constraints:_ Available only if one of the following conditions is met:
 
 * [code]#UInt32Bit1# and [code]#UInt32Bit2# are both [code]#uint32_t#;
-* [code]#UInt32Bit1# and [code]#UInt32Bit2# are both [code]#marray# with
-  element type [code]#uint32_t# and the same number of elements; or
+* [code]#UInt32Bit1# and [code]#UInt32Bit2# are both [code]#marray# with element
+  type [code]#uint32_t# and the same number of elements; or
 * [code]#UInt32Bit1# and [code]#UInt32Bit2# are any combination of [code]#vec#
   or the [code]#+__swizzled_vec__+# type with element type [code]#uint32_t# and
   the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((uint64_t)hi << 32) | lo#.  Otherwise, returns
-[code]#((uint64_t)hi[i] << 32) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((uint64_t)hi << 32) |
+lo#.
+Otherwise, returns [code]#((uint64_t)hi[i] << 32) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#uint64_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#uint64_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#uint64_t#
-and the same number of elements as the inputs.
+The return type is [code]#uint64_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#uint64_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#uint64_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24834,8 +24846,7 @@ template<typename Int32Bit, typename UInt32Bit>
 
 _Constraints:_ Available only if one of the following conditions is met:
 
-* [code]#Int32Bit# is [code]#int32_t# and [code]#UInt32Bit# is
-  [code]#uint32_t#;
+* [code]#Int32Bit# is [code]#int32_t# and [code]#UInt32Bit# is [code]#uint32_t#;
 * [code]#Int32Bit# is [code]#marray# with element type [code]#int32_t# and
   [code]#UInt32Bit# is [code]#marray# with element type [code]#uint32_t# and
   both have the same number of elements; or
@@ -24844,16 +24855,16 @@ _Constraints:_ Available only if one of the following conditions is met:
   [code]#+__swizzled_vec__+# type with element type [code]#uint32_t# and both
   have the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#((int64_t)hi << 32) | lo#.  Otherwise, returns
-[code]#((int64_t)hi[i] << 32) | lo[i]# for each element of [code]#hi# and
-[code]#lo#.
+_Returns:_ When the inputs are scalars, returns [code]#((int64_t)hi << 32) |
+lo#.
+Otherwise, returns [code]#((int64_t)hi[i] << 32) | lo[i]# for each element of
+[code]#hi# and [code]#lo#.
 
-The return type is [code]#int64_t# when the inputs are scalar.  When the
-inputs are [code]#marray#, the return type is [code]#marray# with element
-type [code]#int64_t# and the same number of elements as the inputs.
-Otherwise, the return type is [code]#vec# with element type [code]#int64_t#
-and the same number of elements as the inputs.
+The return type is [code]#int64_t# when the inputs are scalar.
+When the inputs are [code]#marray#, the return type is [code]#marray# with
+element type [code]#int64_t# and the same number of elements as the inputs.
+Otherwise, the return type is [code]#vec# with element type [code]#int64_t# and
+the same number of elements as the inputs.
 
 '''
 
@@ -24867,8 +24878,9 @@ _Constraints:_ Available only if [code]#GenInt# is a _generic integer type_ as
 defined above.
 
 _Returns:_ When the input is a scalar, returns the number of non-zero bits in
-[code]#x#.  Otherwise, returns the number of non-zero bits in [code]#x[i]# for
-each element of [code]#x#.
+[code]#x#.
+Otherwise, returns the number of non-zero bits in [code]#x[i]# for each element
+of [code]#x#.
 
 The return type is [code]#GenInt# unless [code]#GenInt# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24898,18 +24910,19 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#Int32Bit1#; and
 * If [code]#Int32Bit1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#Int32Bit2# and [code]#Int32Bit3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
-_Preconditions:_  If the inputs are signed scalars, the values of [code]#x# and
-[code]#y# must be in the range [-2^23^, 2^23^-1].  If the inputs are unsigned
-scalars, the values of [code]#x# and [code]#y# must be in the range
-[0, 2^24^-1].  If the inputs are not scalars, each element of [code]#x# and
-[code]#y# must be in these ranges.
+_Preconditions:_ If the inputs are signed scalars, the values of [code]#x# and
+[code]#y# must be in the range [-2^23^, 2^23^-1].
+If the inputs are unsigned scalars, the values of [code]#x# and [code]#y# must
+be in the range [0, 2^24^-1].
+If the inputs are not scalars, each element of [code]#x# and [code]#y# must be
+in these ranges.
 
-_Returns:_ When the inputs are scalars, returns [code]#x * y + z#.  Otherwise,
-returns [code]#x[i] * y[i] + z[i]# for each element of [code]#x#, [code]#y#,
-and [code]#z#.
+_Returns:_ When the inputs are scalars, returns [code]#x * y + z#.
+Otherwise, returns [code]#x[i] * y[i] + z[i]# for each element of [code]#x#,
+[code]#y#, and [code]#z#.
 
 The return type is [code]#Int32Bit1# unless [code]#Int32Bit1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -24941,14 +24954,16 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type, and both must have the same element type and
   the same number of elements.
 
-_Preconditions:_  If the inputs are signed scalars, the values of [code]#x# and
-[code]#y# must be in the range [-2^23^, 2^23^-1].  If the inputs are unsigned
-scalars, the values of [code]#x# and [code]#y# must be in the range
-[0, 2^24^-1].  If the inputs are not scalars, each element of [code]#x# and
-[code]#y# must be in these ranges.
+_Preconditions:_ If the inputs are signed scalars, the values of [code]#x# and
+[code]#y# must be in the range [-2^23^, 2^23^-1].
+If the inputs are unsigned scalars, the values of [code]#x# and [code]#y# must
+be in the range [0, 2^24^-1].
+If the inputs are not scalars, each element of [code]#x# and [code]#y# must be
+in these ranges.
 
-_Returns:_ When the inputs are scalars, returns [code]#x * y#.  Otherwise,
-returns [code]#x[i] * y[i]# for each element of [code]#x# and [code]#y#.
+_Returns:_ When the inputs are scalars, returns [code]#x * y#.
+Otherwise, returns [code]#x[i] * y[i]# for each element of [code]#x# and
+[code]#y#.
 
 The return type is [code]#Int32Bit1# unless [code]#Int32Bit1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25000,18 +25015,18 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#GenFloat1#; and
 * If [code]#GenFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenFloat2# and [code]#GenFloat3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
 _Preconditions:_ If the inputs are scalars, the value of [code]#minval# must be
-less than or equal to the value of [code]#maxval#.  If the inputs are not
-scalars, each element of [code]#minval# must be less than or equal to the
-corresponding element of [code]#maxval#.
+less than or equal to the value of [code]#maxval#.
+If the inputs are not scalars, each element of [code]#minval# must be less than
+or equal to the corresponding element of [code]#maxval#.
 
-_Returns:_ When the inputs are scalars, returns
-[code]#fmin(fmax(x, minval), maxval)#.  Otherwise, returns
-[code]#fmin(fmax(x[i], minval[i]), maxval[i])# for each element of [code]#x#,
-[code]#minval#, and [code]#maxval#.
+_Returns:_ When the inputs are scalars, returns [code]#fmin(fmax(x, minval),
+maxval)#.
+Otherwise, returns [code]#fmin(fmax(x[i], minval[i]), maxval[i])# for each
+element of [code]#x#, [code]#minval#, and [code]#maxval#.
 
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25078,13 +25093,14 @@ _Constraints:_ Available only if all of the following conditions are met:
   the same number of elements.
 
 _Preconditions:_ When the inputs are scalars, [code]#x# and [code]#y# must not
-be infinite or NaN.  When the inputs are not scalars, no element of [code]#x#
-or [code]#y# may be infinite or NaN.
+be infinite or NaN.
+When the inputs are not scalars, no element of [code]#x# or [code]#y# may be
+infinite or NaN.
 
 _Returns:_ When the inputs are scalars, returns [code]#y# if [code]#x < y#
-otherwise [code]#x#.  When the inputs are not scalars, returns [code]#y[i]# if
-[code]#x[i] < y[i]# otherwise [code]#x[i]# for each element of [code]#x# and
-[code]#y#.
+otherwise [code]#x#.
+When the inputs are not scalars, returns [code]#y[i]# if [code]#x[i] < y[i]#
+otherwise [code]#x[i]# for each element of [code]#x# and [code]#y#.
 
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25096,11 +25112,11 @@ _Constraints:_ Available only if [code]#NonScalar# is [code]#marray#,
 [code]#vec#, or the [code]#+__swizzled_vec__+# type and is a _generic floating
 point type_ as defined above.
 
-_Preconditions:_ No element of [code]#x# may be infinite or NaN.  The value of
-[code]#y# must not be infinite or NaN.
+_Preconditions:_ No element of [code]#x# may be infinite or NaN.
+The value of [code]#y# must not be infinite or NaN.
 
-_Returns:_ [code]#y# if [code]#x[i] < y# otherwise [code]#x[i]# for each
-element of [code]#x#.
+_Returns:_ [code]#y# if [code]#x[i] < y# otherwise [code]#x[i]# for each element
+of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25130,13 +25146,14 @@ _Constraints:_ Available only if all of the following conditions are met:
   the same number of elements.
 
 _Preconditions:_ When the inputs are scalars, [code]#x# and [code]#y# must not
-be infinite or NaN.  When the inputs are not scalars, no element of [code]#x#
-or [code]#y# may be infinite or NaN.
+be infinite or NaN.
+When the inputs are not scalars, no element of [code]#x# or [code]#y# may be
+infinite or NaN.
 
 _Returns:_ When the inputs are scalars, returns [code]#y# if [code]#y < x#
-otherwise [code]#x#.  When the inputs are not scalars, returns [code]#y[i]# if
-[code]#y[i] < x[i]# otherwise [code]#x[i]# for each element of [code]#x# and
-[code]#y#.
+otherwise [code]#x#.
+When the inputs are not scalars, returns [code]#y[i]# if [code]#y[i] < x[i]#
+otherwise [code]#x[i]# for each element of [code]#x# and [code]#y#.
 
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25148,11 +25165,11 @@ _Constraints:_ Available only if [code]#NonScalar# is [code]#marray#,
 [code]#vec#, or the [code]#+__swizzled_vec__+# type and is a _generic floating
 point type_ as defined above.
 
-_Preconditions:_ No element of [code]#x# may be infinite or NaN.  The value of
-[code]#y# must not be infinite or NaN.
+_Preconditions:_ No element of [code]#x# may be infinite or NaN.
+The value of [code]#y# must not be infinite or NaN.
 
-_Returns:_ [code]#y# if [code]#y < x[i]# otherwise [code]#x[i]# for each
-element of [code]#x#.
+_Returns:_ [code]#y# if [code]#y < x[i]# otherwise [code]#x[i]# for each element
+of [code]#x#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25179,17 +25196,18 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#GenFloat1#; and
 * If [code]#GenFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenFloat2# and [code]#GenFloat3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
-_Preconditions:_ If the inputs are scalars, the value of [code]#a# must be
-in the range [0.0, 1.0].  If the inputs are not scalars, each element of
-[code]#a# must be in the range [0.0, 1.0].
+_Preconditions:_ If the inputs are scalars, the value of [code]#a# must be in
+the range [0.0, 1.0].
+If the inputs are not scalars, each element of [code]#a# must be in the range
+[0.0, 1.0].
 
-_Returns:_ The linear blend of [code]#x# and [code]#y#.  When the inputs are
-scalars, returns [code]#x + (y - x) * a#.  Otherwise, returns
-[code]#x[i] + (y[i] - x[i]) * a[i]# for each element of [code]#x#, [code]#y#,
-and [code]#a#.
+_Returns:_ The linear blend of [code]#x# and [code]#y#.
+When the inputs are scalars, returns [code]#x + (y - x) * a#.
+Otherwise, returns [code]#x[i] + (y[i] - x[i]) * a[i]# for each element of
+[code]#x#, [code]#y#, and [code]#a#.
 
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25203,8 +25221,8 @@ point type_ as defined above.
 
 _Preconditions:_ The value of [code]#a# must be in the range [0.0, 1.0].
 
-_Returns:_ The linear blend of [code]#x# and [code]#y#, computed as
-[code]#x[i] + (y[i] - x[i]) * a# for each element of [code]#x# and [code]#y#.
+_Returns:_ The linear blend of [code]#x# and [code]#y#, computed as [code]#x[i]
++ (y[i] - x[i]) * a# for each element of [code]#x# and [code]#y#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25254,10 +25272,10 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type, and both must have the same element type and
   the same number of elements.
 
-_Returns:_ When the inputs are scalars, returns the value
-[code]#(x < edge) ? 0.0 : 1.0#.  When the inputs are not scalars, returns
-the value [code]#(x[i] < edge[i]) ? 0.0 : 1.0# for each element of [code]#x#
-and [code]#edge#.
+_Returns:_ When the inputs are scalars, returns the value [code]#(x < edge) ?
+0.0 : 1.0#.
+When the inputs are not scalars, returns the value [code]#(x[i] < edge[i]) ? 0.0
+: 1.0# for each element of [code]#x# and [code]#edge#.
 
 The return type is [code]#GenFloat1# unless [code]#GenFloat1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25298,19 +25316,21 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#GenFloat1#; and
 * If [code]#GenFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenFloat2# and [code]#GenFloat3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
 _Preconditions:_ If the inputs are scalar, [code]#edge0# must be less than
-[code]#edge1# and none of [code]#edge0#, [code]#edge1#, or [code]#x# may be
-NaN.  If the inputs are not scalar, each element of [code]#edge0# must be less
-than the corresponding element of [code]#edge1# and no element of
-[code]#edge0#, [code]#edge1#, or [code]#x# may be NaN.
+[code]#edge1# and none of [code]#edge0#, [code]#edge1#, or [code]#x# may be NaN.
+If the inputs are not scalar, each element of [code]#edge0# must be less than
+the corresponding element of [code]#edge1# and no element of [code]#edge0#,
+[code]#edge1#, or [code]#x# may be NaN.
 
 _Returns:_ When the inputs are scalars, returns 0.0 if [code]#+x <= edge0+# and
 1.0 if [code]#x >= edge1# and performs smooth Hermite interpolation between 0
-and 1 when [code]#edge0 < x < edge1#.  This is useful in cases where you would
-want a threshold function with a smooth transition.  This is equivalent to:
+and 1 when [code]#edge0 < x < edge1#.
+This is useful in cases where you would want a threshold function with a smooth
+transition.
+This is equivalent to:
 
 [source,role=codebox]
 ----
@@ -25319,8 +25339,8 @@ t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
 return t * t * (3 - 2 * t);
 ----
 
-When the inputs are not scalars, returns the following value for each element
-of [code]#edge0#, [code]#edge1#, and [code]#x#:
+When the inputs are not scalars, returns the following value for each element of
+[code]#edge0#, [code]#edge1#, and [code]#x#:
 
 [source,role=codebox]
 ----
@@ -25340,8 +25360,8 @@ _Constraints:_ Available only if [code]#NonScalar# is [code]#marray#,
 point type_ as defined above.
 
 _Preconditions:_ The value of [code]#edge0# must be less than [code]#edge1# and
-neither [code]#edge0# nor [code]#edge1# may be NaN.  No element of [code]#x#
-may be NaN.
+neither [code]#edge0# nor [code]#edge1# may be NaN.
+No element of [code]#x# may be NaN.
 
 _Returns:_ The following value for each element of [code]#x#:
 
@@ -25369,8 +25389,9 @@ type_ as defined above.
 
 _Returns:_ When the input is scalar, returns 1.0 if [code]#x > 0#, -0.0 if
 [code]#x == -0.0#, +0.0 if [code]#x == +0.0#, -1.0 if [code]#x < 0#, or 0.0 if
-[code]#x# is a NaN.  When the input is not scalar, returns these values for
-each element of [code]#x#.
+[code]#x# is a NaN.
+When the input is not scalar, returns these values for each element of
+[code]#x#.
 
 The return type is [code]#GenFloat# unless [code]#GenFloat# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -25442,8 +25463,8 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** [code]#+__swizzled_vec__+# that is convertible to [code]#vec<float, 4>#
 ** [code]#+__swizzled_vec__+# that is convertible to [code]#vec<double, 4>#
 ** [code]#+__swizzled_vec__+# that is convertible to [code]#vec<half, 4>#
-* If [code]#Geo3or4Float1# is [code]#marray#, then [code]#Geo3or4Float2# must
-  be the same as [code]#Geo3or4Float1#; and
+* If [code]#Geo3or4Float1# is [code]#marray#, then [code]#Geo3or4Float2# must be
+  the same as [code]#Geo3or4Float1#; and
 * If [code]#Geo3or4Float1# is [code]#vec# or the [code]#+__swizzled_vec__+#
   type, then [code]#Geo3or4Float2# must also be [code]#vec# or the
   [code]#+__swizzled_vec__+# type, and both must have the same element type and
@@ -25469,15 +25490,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GeoFloat1# is a _generic geometric type_ as defined above;
 * If [code]#GeoFloat1# is not [code]#vec# or the [code]#+__swizzled_vec__+#
   type, then [code]#GeoFloat2# must be the same as [code]#GeoFloat1#; and
-* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+#
-  type, then [code]#GeoFloat2# must also be [code]#vec# or the
+* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+  then [code]#GeoFloat2# must also be [code]#vec# or the
   [code]#+__swizzled_vec__+# type, and both must have the same element type and
   the same number of elements.
 
 _Returns:_ The dot product of [code]#p0# and [code]#p1#.
 
-The return type is [code]#GeoFloat1# if the input types are scalar.  Otherwise,
-the return type is [code]#GeoFloat1::value_type#.
+The return type is [code]#GeoFloat1# if the input types are scalar.
+Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
@@ -25492,16 +25513,16 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GeoFloat1# is a _generic geometric type_ as defined above;
 * If [code]#GeoFloat1# is not [code]#vec# or the [code]#+__swizzled_vec__+#
   type, then [code]#GeoFloat2# must be the same as [code]#GeoFloat1#; and
-* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+#
-  type, then [code]#GeoFloat2# must also be [code]#vec# or the
+* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+  then [code]#GeoFloat2# must also be [code]#vec# or the
   [code]#+__swizzled_vec__+# type, and both must have the same element type and
   the same number of elements.
 
-_Returns:_ The distance between [code]#p0# and [code]#p1#. This is calculated
-as [code]#length(p0 - p1)#.
+_Returns:_ The distance between [code]#p0# and [code]#p1#.
+This is calculated as [code]#length(p0 - p1)#.
 
-The return type is [code]#GeoFloat1# if the input types are scalar.  Otherwise,
-the return type is [code]#GeoFloat1::value_type#.
+The return type is [code]#GeoFloat1# if the input types are scalar.
+Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
@@ -25514,11 +25535,11 @@ template<typename GeoFloat>
 _Constraints:_ Available only if [code]#GeoFloat# is a _generic geometric type_
 as defined above.
 
-_Returns:_ The length of vector [code]#p#, i.e.,
-[code]#+sqrt(pow(p[0],2) + pow(p[1],2) + ...)+#.
+_Returns:_ The length of vector [code]#p#, i.e., [code]#+sqrt(pow(p[0],2) +
+pow(p[1],2) + ...)+#.
 
-The return type is [code]#GeoFloat# if the input type is scalar.  Otherwise,
-the return type is [code]#GeoFloat::value_type#.
+The return type is [code]#GeoFloat# if the input type is scalar.
+Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
@@ -25550,15 +25571,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 * [code]#GeoFloat1# is a _float geometric type_ as defined above;
 * If [code]#GeoFloat1# is not [code]#vec# or the [code]#+__swizzled_vec__+#
   type, then [code]#GeoFloat2# must be the same as [code]#GeoFloat1#; and
-* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+#
-  type, then [code]#GeoFloat2# must also be [code]#vec# or the
+* If [code]#GeoFloat1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+  then [code]#GeoFloat2# must also be [code]#vec# or the
   [code]#+__swizzled_vec__+# type, and both must have the same number of
   elements.
 
 _Returns:_ The value [code]#fast_length(p0 - p1)#.
 
-The return type is [code]#GeoFloat1# if the input type is scalar.  Otherwise,
-the return type is [code]#GeoFloat1::value_type#.
+The return type is [code]#GeoFloat1# if the input type is scalar.
+Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
@@ -25568,14 +25589,14 @@ template<typename GeoFloat>
 /*return-type*/ fast_length(GeoFloat p)
 ----
 
-_Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_
-as defined above.
+_Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_ as
+defined above.
 
 _Returns:_ The length of vector [code]#p# computed as:
 [code]#+half_precision::sqrt(pow(p[0],2) + pow(p[1],2) + ...)+#.
 
-The return type is [code]#GeoFloat# if the input type is scalar.  Otherwise,
-the return type is [code]#GeoFloat::value_type#.
+The return type is [code]#GeoFloat# if the input type is scalar.
+Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
@@ -25585,15 +25606,14 @@ template<typename GeoFloat>
 /*return-type*/ fast_normalize(GeoFloat p)
 ----
 
-_Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_
-as defined above.
+_Constraints:_ Available only if [code]#GeoFloat# is a _float geometric type_ as
+defined above.
 
 _Returns:_ A vector in the same direction as [code]#p# but with a length of 1
-computed as
-[code]#+p * half_precision::rsqrt(pow(p[0],2) + pow(p[1],2) + ...)+#.
+computed as [code]#+p * half_precision::rsqrt(pow(p[0],2) + pow(p[1],2) +
+...)+#.
 
-The result shall be within 8192 ulps error from the infinitely precise result
-of
+The result shall be within 8192 ulps error from the infinitely precise result of
 
 [source,role=codebox]
 ----
@@ -25691,13 +25711,13 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] == y[i])# for each element of [code]#x# and [code]#y#.  If
-[code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] ==
+y[i])# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns the value [code]#((x[i] == y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
@@ -25749,12 +25769,12 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] != y[i])# for each element of [code]#x# and [code]#y#.
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] !=
+y[i])# for each element of [code]#x# and [code]#y#.
 If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns the value [code]#((x[i] != y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
@@ -25807,15 +25827,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] > y[i])# for each element of [code]#x# and [code]#y#.  If
-[code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-returns the value [code]#((x[i] > y[i]) ? -1 : 0)# for each element
-of [code]#x# and [code]#y#.
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] >
+y[i])# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+returns the value [code]#((x[i] > y[i]) ? -1 : 0)# for each element of [code]#x#
+and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
 
@@ -25865,13 +25885,13 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] >= y[i])# for each element of [code]#x# and [code]#y#.  If
-[code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] >=
+y[i])# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns the value [code]#((x[i] >= y[i]) ? -1 : 0)# for each element of
 [code]#x# and [code]#y#.
 
@@ -25923,15 +25943,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] < y[i])# for each element of [code]#x# and [code]#y#.  If
-[code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-returns the value [code]#((x[i] < y[i]) ? -1 : 0)# for each element of
-[code]#x# and [code]#y#.
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] <
+y[i])# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+returns the value [code]#((x[i] < y[i]) ? -1 : 0)# for each element of [code]#x#
+and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
 
@@ -25981,13 +26001,13 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#+(x[i] <= y[i])+# for each element of [code]#x# and [code]#y#.  If
-[code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#+(x[i] <=
+y[i])+# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns the value [code]#+((x[i] <= y[i]) ? -1 : 0)+# for each element of
 [code]#x# and [code]#y#.
 
@@ -26039,16 +26059,15 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#(x[i] < y[i] || x[i] > y[i])# for each element of [code]#x# and
-[code]#y#.  If [code]#NonScalar1# is [code]#vec# or the
-[code]#+__swizzled_vec__+# type, returns the value
-[code]#((x[i] < y[i] || x[i] > y[i]) ? -1 : 0)# for each element of [code]#x#
-and [code]#y#.
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#(x[i] <
+y[i] || x[i] > y[i])# for each element of [code]#x# and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+returns the value [code]#((x[i] < y[i] || x[i] > y[i]) ? -1 : 0)# for each
+element of [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
 
@@ -26097,9 +26116,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each
-element of [code]#x# only if [code]#x[i]# is a finite value.  If
-[code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each element
+of [code]#x# only if [code]#x[i]# is a finite value.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns -1 for each element of [code]#x# if [code]#x[i]# is a finite value and
 returns 0 otherwise.
 
@@ -26151,11 +26170,11 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each
-element of [code]#x# only if [code]#x[i]# has an infinity value.  If
-[code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
-returns -1 for each element of [code]#x# if [code]#x[i]# has an infinity
-value and returns 0 otherwise.
+_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each element
+of [code]#x# only if [code]#x[i]# has an infinity value.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+returns -1 for each element of [code]#x# if [code]#x[i]# has an infinity value
+and returns 0 otherwise.
 
 The return type depends on [code]#NonScalar#:
 
@@ -26204,9 +26223,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each
-element of [code]#x# only if [code]#x[i]# has a NaN value.  If
-[code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each element
+of [code]#x# only if [code]#x[i]# has a NaN value.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns -1 for each element of [code]#x# if [code]#x[i]# has a NaN value and
 returns 0 otherwise.
 
@@ -26257,9 +26276,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each
-element of [code]#x# only if [code]#x[i]# has a normal value.  If
-[code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each element
+of [code]#x# only if [code]#x[i]# has a normal value.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns -1 for each element of [code]#x# if [code]#x[i]# has a normal value and
 returns 0 otherwise.
 
@@ -26313,18 +26332,18 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
 _Effects:_ Tests if each element of [code]#x# and [code]#y# are ordered.
 
 _Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#isequal(x[i], x[i]) && isequal(y[i], y[i])# for each element of
-[code]#x# and [code]#y#.  If [code]#NonScalar1# is [code]#vec# or the
-[code]#+__swizzled_vec__+# type, returns the value
-[code]#((isequal(x[i], x[i]) && isequal(y[i], y[i]) ? -1 : 0)# for each element
-of [code]#x# and [code]#y#.
+[code]#isequal(x[i], x[i]) && isequal(y[i], y[i])# for each element of [code]#x#
+and [code]#y#.
+If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+returns the value [code]#((isequal(x[i], x[i]) && isequal(y[i], y[i]) ? -1 : 0)#
+for each element of [code]#x# and [code]#y#.
 
 The return type depends on [code]#NonScalar1#:
 
@@ -26376,14 +26395,14 @@ _Constraints:_ Available only if all of the following conditions are met:
 ** Both [code]#NonScalar1# and [code]#NonScalar2# are [code]#marray#; or
 ** [code]#NonScalar1# and [code]#NonScalar2# are any combination of [code]#vec#
    and the [code]#+__swizzled_vec__+# type;
-* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements
-  and the same element type; and
+* [code]#NonScalar1# and [code]#NonScalar2# have the same number of elements and
+  the same element type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
 _Effects:_ Tests if each element of [code]#x# and [code]#y# are unordered.
 
-_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value
-[code]#isnan(x[i]) || isnan(y[i])# for each element of [code]#x# and [code]#y#.
+_Returns:_ If [code]#NonScalar1# is [code]#marray#, the value [code]#isnan(x[i])
+|| isnan(y[i])# for each element of [code]#x# and [code]#y#.
 If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns the value [code]#((isnan(x[i]) || isnan(y[i]) ? -1 : 0)# for each
 element of [code]#x# and [code]#y#.
@@ -26435,9 +26454,9 @@ _Constraints:_ Available only if all of the following conditions are met:
   [code]#+__swizzled_vec__+# type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each
-element of [code]#x# only if the sign bit of [code]#x[i]# is set.  If
-[code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
+_Returns:_ If [code]#NonScalar# is [code]#marray#, returns true for each element
+of [code]#x# only if the sign bit of [code]#x[i]# is set.
+If [code]#NonScalar# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
 returns -1 for each element of [code]#x# if the sign bit of [code]#x[i]# is set
 and returns 0 otherwise.
 
@@ -26490,9 +26509,10 @@ _Constraints:_ Available only if [code]#GenInt# is one of the following types:
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<int64_t, N>#
 
 _Returns:_ When [code]#x# is [code]#marray#, returns a Boolean telling whether
-any element of [code]#x# is true.  When [code]#x# is [code]#vec# or the
-[code]#+__swizzled_vec__+# type, returns the value 1 if any element in
-[code]#x# has its most significant bit set, otherwise returns the value 0.
+any element of [code]#x# is true.
+When [code]#x# is [code]#vec# or the [code]#+__swizzled_vec__+# type, returns
+the value 1 if any element in [code]#x# has its most significant bit set,
+otherwise returns the value 0.
 
 The return type is [code]#bool# if [code]#GenInt# is [code]#marray#.
 Otherwise, the return type is [code]#int#.
@@ -26515,9 +26535,9 @@ _Constraints:_ Available only if [code]#GenInt# is one of the following types:
 * [code]#marray<long long, N>#
 
 _Returns:_ When [code]#x# is a scalar, returns a Boolean telling whether the
-most significant bit of [code]#x# is set.  When [code]#x# is [code]#marray#,
-returns a Boolean telling whether the most significant bit of any element
-in [code]#x# is set.
+most significant bit of [code]#x# is set.
+When [code]#x# is [code]#marray#, returns a Boolean telling whether the most
+significant bit of any element in [code]#x# is set.
 
 '''
 
@@ -26545,9 +26565,10 @@ _Constraints:_ Available only if [code]#GenInt# is one of the following types:
 * [code]#+__swizzled_vec__+# that is convertible to [code]#vec<int64_t, N>#
 
 _Returns:_ When [code]#x# is [code]#marray#, returns a Boolean telling whether
-all elements of [code]#x# are true.  When [code]#x# is [code]#vec# or the
-[code]#+__swizzled_vec__+# type, returns the value 1 if all elements in
-[code]#x# have their most significant bit set, otherwise returns the value 0.
+all elements of [code]#x# are true.
+When [code]#x# is [code]#vec# or the [code]#+__swizzled_vec__+# type, returns
+the value 1 if all elements in [code]#x# have their most significant bit set,
+otherwise returns the value 0.
 
 The return type is [code]#bool# if [code]#GenInt# is [code]#marray#.
 Otherwise, the return type is [code]#int#.
@@ -26570,9 +26591,9 @@ _Constraints:_ Available only if [code]#GenInt# is one of the following types:
 * [code]#marray<long long, N>#
 
 _Returns:_ When [code]#x# is a scalar, returns a Boolean telling whether the
-most significant bit of [code]#x# is set.  When [code]#x# is [code]#marray#,
-returns a Boolean telling whether the most significant bit of all elements
-in [code]#x# are set.
+most significant bit of [code]#x# is set.
+When [code]#x# is [code]#marray#, returns a Boolean telling whether the most
+significant bit of all elements in [code]#x# are set.
 
 '''
 
@@ -26591,22 +26612,23 @@ _Constraints:_ Available only if all of the following conditions are met:
    defined above; or
 ** [code]#+__swizzled_vec__+# that is convertible to [code]#vec<T, N>#, where
    [code]#T# is one of the _vector element types_;
-* If [code]#GenType1# is not [code]#vec# or the [code]#+__swizzled_vec__+#
-  type, then [code]#GenType2# and [code]#GenType3# must be the same as
+* If [code]#GenType1# is not [code]#vec# or the [code]#+__swizzled_vec__+# type,
+  then [code]#GenType2# and [code]#GenType3# must be the same as
   [code]#GenType1#; and
 * If [code]#GenType1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then [code]#GenType2# and [code]#GenType3# must also be [code]#vec# or the
-  [code]#+__swizzled_vec__+# type, and all three must have the same element
-  type and the same number of elements.
+  [code]#+__swizzled_vec__+# type, and all three must have the same element type
+  and the same number of elements.
 
 _Returns:_ When the input parameters are scalars, returns a result where each
-bit of the result is the corresponding bit of [code]#a# if the corresponding
-bit of [code]#c# is 0.  Otherwise it is the corresponding bit of [code]#b#.
+bit of the result is the corresponding bit of [code]#a# if the corresponding bit
+of [code]#c# is 0.
+Otherwise it is the corresponding bit of [code]#b#.
 
 When the input parameters are not scalars, returns a result for each element
 where each bit of the result for element [code]#i# is the corresponding bit of
-[code]#a[i]# if the corresponding bit of [code]#c[i]# is 0.  Otherwise it is
-the corresponding bit of [code]#b[i]#.
+[code]#a[i]# if the corresponding bit of [code]#c[i]# is 0.
+Otherwise it is the corresponding bit of [code]#b[i]#.
 
 The return type is [code]#GenType1# unless [code]#GenType1# is the
 [code]#+__swizzled_vec__+# type, in which case the return type is the
@@ -26635,25 +26657,25 @@ _Returns:_ The value [code]#(c ? b : a)#.
 _Constraints:_ Available only if all of the following conditions are met:
 
 * [code]#NonScalar1# is one of the following types:
-** [code]#marray<T, N>#, where [code]#T# is one of the _generic scalar types_
-   as defined above;
-** [code]#vec<T, N>#, where [code]#T# is one of the _vector element types_
-   as defined above; or
+** [code]#marray<T, N>#, where [code]#T# is one of the _generic scalar types_ as
+   defined above;
+** [code]#vec<T, N>#, where [code]#T# is one of the _vector element types_ as
+   defined above; or
 ** [code]#+__swizzled_vec__+# that is convertible to [code]#vec<T, N>#, where
    [code]#T# is one of the _vector element types_;
 * If [code]#NonScalar1# is [code]#marray#, then:
 ** [code]#NonScalar2# must be the same as [code]#NonScalar1#; and
-** [code]#NonScalar3# must be [code]#marray# with element type [code]#bool#
-   and the same number of elements as [code]#NonScalar1#;
+** [code]#NonScalar3# must be [code]#marray# with element type [code]#bool# and
+   the same number of elements as [code]#NonScalar1#;
 * If [code]#NonScalar1# is [code]#vec# or the [code]#+__swizzled_vec__+# type,
   then:
-** [code]#NonScalar2# must also be [code]#vec# or the
-   [code]#+__swizzled_vec__+# type, and both must have the same element type
-   and the same number of elements; and
-** [code]#NonScalar3# must be [code]#vec# or the [code]#+__swizzled_vec__+#
-   type with the same number of elements as [code]#NonScalar1#.  The element
-   type of [code]#NonScalar3# must be a signed or unsigned integer with the
-   same number of bits as the element type of [code]#NonScalar1#.
+** [code]#NonScalar2# must also be [code]#vec# or the [code]#+__swizzled_vec__+#
+   type, and both must have the same element type and the same number of
+   elements; and
+** [code]#NonScalar3# must be [code]#vec# or the [code]#+__swizzled_vec__+# type
+   with the same number of elements as [code]#NonScalar1#.
+   The element type of [code]#NonScalar3# must be a signed or unsigned integer
+   with the same number of bits as the element type of [code]#NonScalar1#.
 
 _Returns:_ If [code]#NonScalar1# is [code]#marray#, return the value
 [code]#(c[i] ? b[i] : a[i])# for each element of [code]#a#, [code]#b#, and

--- a/adoc/config/khronos.css
+++ b/adoc/config/khronos.css
@@ -438,6 +438,16 @@ pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 
 .listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
 
+/* Format "[source,role=codebox]" blocks.  This format overrides "listingblock" above. */
+.codebox > .content {
+  position: relative;
+  display: inline-block;
+  border: 1px solid #ddd;
+}
+.codebox pre, .codebox pre[class] {
+  padding: 7px 7px 7px 7px;
+}
+
 table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
 
 table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }


### PR DESCRIPTION
This is a purely editorial change that changes the formatting of the
builtin function sections 4.17.4 "Math function" through 4.17.10
"Relational functions".  The new format does the following:

* Removes the giant table the encloses all of the functions in each
  section.  Instead, we just draw a horizontal line between the
  description of each function.

* Removes the table around each code synopsis.  This table existed only
  to draw a border around the synopsis in the HTML render.  Instead, I
  created a new [source] style called "codebox", and I added some CSS to
  draw a border around these source blocks.

The tables were causing problems in the PDF render because the PDF
rendering tools fail if any single table row is taller than a page.
By removing the tables, we avoid this limitation.

As an aside, I noticed that the [source,linenums] blocks *were*
rendered in HTML with a border.  It turns out this happens because
adding "linenums" causes the block to be rendered as a table in HTML.
(The line numbers are in one column, and each source line is in a
second column.)  This causes the block to get a border just by accident
because the default CSS format for tables draws a border around the
outside of the table.