### PR TITLE
Add HTML links for "synopsis" code blocks

### DIFF
--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -143,7 +143,8 @@ ADOCOPTS     = --doctype book $(ADOCMISCOPTS) $(ATTRIBOPTS) \
   $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
 
 ADOCHTMLEXTS = --require $(CURDIR)/config/katex_replace.rb \
-  --require $(CURDIR)/config/loadable_html.rb
+  --require $(CURDIR)/config/loadable_html.rb \
+  --require $(CURDIR)/config/synopsis.rb
 
 # ADOCHTMLOPTS relies on the relative runtime path from the output HTML
 # file to the katex scripts being set with KATEXDIR. This is overridden

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20876,7 +20876,7 @@ to represent the following address spaces:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:acos]
 ----
 float acos(float x)                (1)
 double acos(double x)              (2)
@@ -20906,7 +20906,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:acosh]
 ----
 float acosh(float x)                (1)
 double acosh(double x)              (2)
@@ -20937,7 +20937,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:acospi]
 ----
 float acospi(float x)                (1)
 double acospi(double x)              (2)
@@ -20967,7 +20967,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:asin]
 ----
 float asin(float x)                (1)
 double asin(double x)              (2)
@@ -20997,7 +20997,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:asinh]
 ----
 float asinh(float x)                (1)
 double asinh(double x)              (2)
@@ -21028,7 +21028,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:asinpi]
 ----
 float asinpi(float x)                (1)
 double asinpi(double x)              (2)
@@ -21058,7 +21058,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:atan]
 ----
 float atan(float y_over_x)                (1)
 double atan(double y_over_x)              (2)
@@ -21088,7 +21088,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:atan2]
 ----
 float atan2(float y, float x)                       (1)
 double atan2(double y, double x)                    (2)
@@ -21125,7 +21125,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:atanh]
 ----
 float atanh(float x)                (1)
 double atanh(double x)              (2)
@@ -21156,7 +21156,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:atanpi]
 ----
 float atanpi(float x)                (1)
 double atanpi(double x)              (2)
@@ -21186,7 +21186,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:atan2pi]
 ----
 float atan2pi(float y, float x)                      (1)
 double atan2pi(double y, double x)                   (2)
@@ -21223,7 +21223,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:cbrt]
 ----
 float cbrt(float x)                (1)
 double cbrt(double x)              (2)
@@ -21253,7 +21253,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:ceil]
 ----
 float ceil(float x)                (1)
 double ceil(double x)              (2)
@@ -21285,7 +21285,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:copysign]
 ----
 float copysign(float x, float y)                      (1)
 double copysign(double x, double y)                   (2)
@@ -21323,7 +21323,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:cos]
 ----
 float cos(float x)                (1)
 double cos(double x)              (2)
@@ -21353,7 +21353,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:cosh]
 ----
 float cosh(float x)                (1)
 double cosh(double x)              (2)
@@ -21383,7 +21383,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:cospi]
 ----
 float cospi(float x)                (1)
 double cospi(double x)              (2)
@@ -21413,7 +21413,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:erfc]
 ----
 float erfc(float x)                (1)
 double erfc(double x)              (2)
@@ -21444,7 +21444,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:erf]
 ----
 float erf(float x)                (1)
 double erf(double x)              (2)
@@ -21475,7 +21475,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:exp]
 ----
 float exp(float x)                (1)
 double exp(double x)              (2)
@@ -21506,7 +21506,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:exp2]
 ----
 float exp2(float x)                (1)
 double exp2(double x)              (2)
@@ -21537,7 +21537,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:exp10]
 ----
 float exp10(float x)                (1)
 double exp10(double x)              (2)
@@ -21568,7 +21568,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:expm1]
 ----
 float expm1(float x)                (1)
 double expm1(double x)              (2)
@@ -21598,7 +21598,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fabs]
 ----
 float fabs(float x)                (1)
 double fabs(double x)              (2)
@@ -21628,7 +21628,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fdim]
 ----
 float fdim(float x, float y)                        (1)
 double fdim(double x, double y)                     (2)
@@ -21665,7 +21665,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:floor]
 ----
 float floor(float x)                (1)
 double floor(double x)              (2)
@@ -21697,7 +21697,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fma]
 ----
 float fma(float a, float b, float c)                                     (1)
 double fma(double a, double b, double c)                                 (2)
@@ -21743,7 +21743,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fmax]
 ----
 float fmax(float x, float y)                                (1)
 double fmax(double x, double y)                             (2)
@@ -21804,7 +21804,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fmin]
 ----
 float fmin(float x, float y)                                (1)
 double fmin(double x, double y)                             (2)
@@ -21865,7 +21865,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fmod]
 ----
 float fmod(float x, float y)                        (1)
 double fmod(double x, double y)                     (2)
@@ -21902,7 +21902,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fract]
 ----
 template<typename Ptr>                        (1)
 float fract(float x, Ptr iptr)
@@ -21961,7 +21961,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:frexp]
 ----
 template<typename Ptr>                        (1)
 float frexp(float x, Ptr exp)
@@ -22031,7 +22031,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:hypot]
 ----
 float hypot(float x, float y)                       (1)
 double hypot(double x, double y)                    (2)
@@ -22069,7 +22069,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:ilogb]
 ----
 int ilogb(float x)                  (1)
 int ilogb(double x)                 (2)
@@ -22106,7 +22106,7 @@ as [code]#NonScalar#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:ldexp]
 ----
 float ldexp(float x, int k)                         (1)
 double ldexp(double x, int k)                       (2)
@@ -22162,7 +22162,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:lgamma]
 ----
 float lgamma(float x)                (1)
 double lgamma(double x)              (2)
@@ -22194,7 +22194,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:lgamma_r]
 ----
 template<typename Ptr>                        (1)
 float lgamma_r(float x, Ptr signp)
@@ -22257,7 +22257,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:log]
 ----
 float log(float x)                (1)
 double log(double x)              (2)
@@ -22287,7 +22287,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:log2]
 ----
 float log2(float x)                (1)
 double log2(double x)              (2)
@@ -22317,7 +22317,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:log10]
 ----
 float log10(float x)                (1)
 double log10(double x)              (2)
@@ -22347,7 +22347,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:log1p]
 ----
 float log1p(float x)                (1)
 double log1p(double x)              (2)
@@ -22377,7 +22377,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:logb]
 ----
 float logb(float x)                (1)
 double logb(double x)              (2)
@@ -22410,7 +22410,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mad]
 ----
 float mad(float a, float b, float c)                                     (1)
 double mad(double a, double b, double c)                                 (2)
@@ -22456,7 +22456,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:maxmag]
 ----
 float maxmag(float x, float y)                      (1)
 double maxmag(double x, double y)                   (2)
@@ -22495,7 +22495,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:minmag]
 ----
 float minmag(float x, float y)                      (1)
 double minmag(double x, double y)                   (2)
@@ -22534,7 +22534,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:modf]
 ----
 template<typename Ptr>                        (1)
 float modf(float x, Ptr iptr)
@@ -22596,7 +22596,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:nan]
 ----
 float nan(uint32_t nancode)             (1)
 double nan(uint64_t nancode)            (2)
@@ -22646,7 +22646,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:nextafter]
 ----
 float nextafter(float x, float y)                      (1)
 double nextafter(double x, double y)                   (2)
@@ -22686,7 +22686,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:pow]
 ----
 float pow(float x, float y)                         (1)
 double pow(double x, double y)                      (2)
@@ -22723,7 +22723,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:pown]
 ----
 float pown(float x, int y)                          (1)
 double pown(double x, int y)                        (2)
@@ -22760,7 +22760,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:powr]
 ----
 float powr(float x, float y)                        (1)
 double powr(double x, double y)                     (2)
@@ -22802,7 +22802,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:remainder]
 ----
 float remainder(float x, float y)                      (1)
 double remainder(double x, double y)                   (2)
@@ -22847,7 +22847,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:remquo]
 ----
 template<typename Ptr>                                            (1)
 float remquo(float x, float y, Ptr quo)
@@ -22928,7 +22928,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:rint]
 ----
 float rint(float x)                (1)
 double rint(double x)              (2)
@@ -22963,7 +22963,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:rootn]
 ----
 float rootn(float x, int y)                         (1)
 double rootn(double x, int y)                       (2)
@@ -23000,7 +23000,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:round]
 ----
 float round(float x)                (1)
 double round(double x)              (2)
@@ -23033,7 +23033,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:rsqrt]
 ----
 float rsqrt(float x)                (1)
 double rsqrt(double x)              (2)
@@ -23064,7 +23064,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sin]
 ----
 float sin(float x)                (1)
 double sin(double x)              (2)
@@ -23094,7 +23094,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sincos]
 ----
 template<typename Ptr>                           (1)
 float sincos(float x, Ptr cosval)
@@ -23152,7 +23152,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sinh]
 ----
 float sinh(float x)                (1)
 double sinh(double x)              (2)
@@ -23182,7 +23182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sinpi]
 ----
 float sinpi(float x)                (1)
 double sinpi(double x)              (2)
@@ -23212,7 +23212,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sqrt]
 ----
 float sqrt(float x)                (1)
 double sqrt(double x)              (2)
@@ -23242,7 +23242,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:tan]
 ----
 float tan(float x)                (1)
 double tan(double x)              (2)
@@ -23272,7 +23272,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:tanh]
 ----
 float tanh(float x)                (1)
 double tanh(double x)              (2)
@@ -23303,7 +23303,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:tanpi]
 ----
 float tanpi(float x)                (1)
 double tanpi(double x)              (2)
@@ -23333,7 +23333,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:tgamma]
 ----
 float tgamma(float x)                (1)
 double tgamma(double x)              (2)
@@ -23363,7 +23363,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:trunc]
 ----
 float trunc(float x)                (1)
 double trunc(double x)              (2)
@@ -23409,7 +23409,7 @@ but they may sacrifice accuracy or limit the set of legal input values.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-cos]
 ----
 float cos(float x)                (1)
 
@@ -23437,7 +23437,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-divide]
 ----
 float divide(float x, float y)                      (1)
 
@@ -23466,7 +23466,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-exp]
 ----
 float exp(float x)                (1)
 
@@ -23495,7 +23495,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-exp2]
 ----
 float exp2(float x)                (1)
 
@@ -23524,7 +23524,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-exp10]
 ----
 float exp10(float x)                (1)
 
@@ -23553,7 +23553,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-log]
 ----
 float log(float x)                (1)
 
@@ -23581,7 +23581,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-log2]
 ----
 float log2(float x)                (1)
 
@@ -23609,7 +23609,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-log10]
 ----
 float log10(float x)                (1)
 
@@ -23637,7 +23637,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-powr]
 ----
 float powr(float x, float y)                        (1)
 
@@ -23671,7 +23671,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-recip]
 ----
 float recip(float x)                (1)
 
@@ -23699,7 +23699,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-rsqrt]
 ----
 float rsqrt(float x)                (1)
 
@@ -23728,7 +23728,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-sin]
 ----
 float sin(float x)                (1)
 
@@ -23756,7 +23756,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-sqrt]
 ----
 float sqrt(float x)                (1)
 
@@ -23784,7 +23784,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:native-tan]
 ----
 float tan(float x)                (1)
 
@@ -23825,7 +23825,7 @@ counterparts in <<sec:math-functions>>, but they have lower accuracy.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-cos]
 ----
 float cos(float x)                (1)
 
@@ -23858,7 +23858,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-divide]
 ----
 float divide(float x, float y)                      (1)
 
@@ -23887,7 +23887,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-exp]
 ----
 float exp(float x)                (1)
 
@@ -23916,7 +23916,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-exp2]
 ----
 float exp2(float x)                (1)
 
@@ -23945,7 +23945,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-exp10]
 ----
 float exp10(float x)                (1)
 
@@ -23974,7 +23974,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-log]
 ----
 float log(float x)                (1)
 
@@ -24002,7 +24002,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-log2]
 ----
 float log2(float x)                (1)
 
@@ -24030,7 +24030,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-log10]
 ----
 float log10(float x)                (1)
 
@@ -24058,7 +24058,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-powr]
 ----
 float powr(float x, float y)                        (1)
 
@@ -24092,7 +24092,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-recip]
 ----
 float recip(float x)                (1)
 
@@ -24120,7 +24120,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-rsqrt]
 ----
 float rsqrt(float x)                (1)
 
@@ -24149,7 +24149,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-sin]
 ----
 float sin(float x)                (1)
 
@@ -24182,7 +24182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-sqrt]
 ----
 float sqrt(float x)                (1)
 
@@ -24210,7 +24210,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:half-tan]
 ----
 float tan(float x)                (1)
 
@@ -24294,7 +24294,7 @@ represent the following types:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:abs]
 ----
 template<typename GenInt>
 /*return-type*/ abs(GenInt x)
@@ -24314,7 +24314,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:abs_diff]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ abs_diff(GenInt1 x, GenInt2 y)
@@ -24342,7 +24342,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:add_sat]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ add_sat(GenInt1 x, GenInt2 y)
@@ -24369,7 +24369,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:hadd]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ hadd(GenInt1 x, GenInt2 y)
@@ -24396,7 +24396,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:rhadd]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rhadd(GenInt1 x, GenInt2 y)
@@ -24423,7 +24423,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:clamp-int]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>    (1)
 /*return-type*/ clamp(GenInt1 x, GenInt2 minval, GenInt3 maxval)
@@ -24477,7 +24477,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:clz]
 ----
 template<typename GenInt>
 /*return-type*/ clz(GenInt x)
@@ -24497,7 +24497,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:ctz]
 ----
 template<typename GenInt>
 /*return-type*/ ctz(GenInt x)
@@ -24517,7 +24517,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mad_hi]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_hi(GenInt1 a, GenInt2 b, GenInt3 c)
@@ -24544,7 +24544,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mad_sat]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_sat(GenInt1 a, GenInt2 b, GenInt3 c)
@@ -24572,7 +24572,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:max-int]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ max(GenInt1 x, GenInt2 y)
@@ -24617,7 +24617,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:min-int]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ min(GenInt1 x, GenInt2 y)
@@ -24662,7 +24662,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mul_hi]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ mul_hi(GenInt1 x, GenInt2 y)
@@ -24692,7 +24692,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:rotate]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rotate(GenInt1 v, GenInt2 count)
@@ -24726,7 +24726,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sub_sat]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ sub_sat(GenInt1 x, GenInt2 y)
@@ -24753,7 +24753,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample-uint16]
 ----
 template<typename UInt8Bit1, typename UInt8Bit2>
 /*return-type*/ upsample(UInt8Bit1 hi, UInt8Bit2 lo)
@@ -24781,7 +24781,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample,id=api:upsample-int16]
 ----
 template<typename Int8Bit, typename UInt8Bit>
 /*return-type*/ upsample(Int8Bit hi, UInt8Bit lo)
@@ -24810,7 +24810,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample-uint32]
 ----
 template<typename UInt16Bit1, typename UInt16Bit2>
 /*return-type*/ upsample(UInt16Bit1 hi, UInt16Bit2 lo)
@@ -24838,7 +24838,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample-int32]
 ----
 template<typename Int16Bit, typename UInt16Bit>
 /*return-type*/ upsample(Int16Bit hi, UInt16Bit lo)
@@ -24868,7 +24868,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample-uint64]
 ----
 template<typename UInt32Bit1, typename UInt32Bit2>
 /*return-type*/ upsample(UInt32Bit1 hi, UInt32Bit2 lo)
@@ -24896,7 +24896,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:upsample-int64]
 ----
 template<typename Int32Bit, typename UInt32Bit>
 /*return-type*/ upsample(Int32Bit hi, UInt32Bit lo)
@@ -24926,7 +24926,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:popcount]
 ----
 template<typename GenInt>
 /*return-type*/ popcount(GenInt x)
@@ -24946,7 +24946,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mad24]
 ----
 template<typename Int32Bit1, typename Int32Bit2, typename Int32Bit3>
 /*return-type*/ mad24(Int32Bit1 x, Int32Bit2 y, Int32Bit3 z)
@@ -24988,7 +24988,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mul24]
 ----
 template<typename Int32Bit1, typename Int32Bit2>
 /*return-type*/ mul24(Int32Bit1 x, Int32Bit2 y)
@@ -25053,7 +25053,7 @@ type_ to represent the following types:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:clamp-fp]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>    (1)
 /*return-type*/ clamp(GenFloat1 x, GenFloat2 minval, GenFloat3 maxval)
@@ -25108,7 +25108,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:degrees]
 ----
 template<typename GenFloat>
 /*return-type*/ degrees(GenFloat radians)
@@ -25129,7 +25129,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:max-fp]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ max(GenFloat1 x, GenFloat2 y)
@@ -25182,7 +25182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:min-fp]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ min(GenFloat1 x, GenFloat2 y)
@@ -25235,7 +25235,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:mix]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
 /*return-type*/ mix(GenFloat1 x, GenFloat2 y, GenFloat3 a)
@@ -25288,7 +25288,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:radians]
 ----
 template<typename GenFloat>
 /*return-type*/ radians(GenFloat degrees)
@@ -25309,7 +25309,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:step]
 ----
 template<typename GenFloat1, typename GenFloat2>               (1)
 /*return-type*/ step(GenFloat1 edge, GenFloat2 x)
@@ -25354,7 +25354,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:smoothstep]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>                  (1)
 /*return-type*/ smoothstep(GenFloat1 edge0, GenFloat2 edge1, GenFloat3 x)
@@ -25436,7 +25436,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:sign]
 ----
 template<typename GenFloat>
 /*return-type*/ sign(GenFloat x)
@@ -25494,7 +25494,7 @@ The term _float geometric type_ represents these types:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:cross]
 ----
 template<typename Geo3or4Float1, typename Geo3or4Float2>
 /*return-type*/ cross(Geo3or4Float1 p0, Geo3or4Float2 p1)
@@ -25537,7 +25537,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:dot]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ dot(GeoFloat1 p0, GeoFloat2 p1)
@@ -25560,7 +25560,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:distance]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ distance(GeoFloat1 p0, GeoFloat2 p1)
@@ -25584,7 +25584,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:length]
 ----
 template<typename GeoFloat>
 /*return-type*/ length(GeoFloat p)
@@ -25601,7 +25601,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:normalize]
 ----
 template<typename GeoFloat>
 /*return-type*/ normalize(GeoFloat p)
@@ -25618,7 +25618,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fast_distance]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ fast_distance(GeoFloat1 p0, GeoFloat2 p1)
@@ -25641,7 +25641,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fast_length]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_length(GeoFloat p)
@@ -25658,7 +25658,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:fast_normalize]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_normalize(GeoFloat p)
@@ -25746,7 +25746,7 @@ The term _vector element type_ represents these types:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isequal]
 ----
 bool isequal(float x, float y)                       (1)
 bool isequal(double x, double y)                     (2)
@@ -25804,7 +25804,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isnotequal]
 ----
 bool isnotequal(float x, float y)                       (1)
 bool isnotequal(double x, double y)                     (2)
@@ -25862,7 +25862,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isgreater]
 ----
 bool isgreater(float x, float y)                       (1)
 bool isgreater(double x, double y)                     (2)
@@ -25920,7 +25920,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isgreaterequal]
 ----
 bool isgreaterequal(float x, float y)                       (1)
 bool isgreaterequal(double x, double y)                     (2)
@@ -25978,7 +25978,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isless]
 ----
 bool isless(float x, float y)                       (1)
 bool isless(double x, double y)                     (2)
@@ -26036,7 +26036,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:islessequal]
 ----
 bool islessequal(float x, float y)                       (1)
 bool islessequal(double x, double y)                     (2)
@@ -26094,7 +26094,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:islessgreater]
 ----
 bool islessgreater(float x, float y)                       (1)
 bool islessgreater(double x, double y)                     (2)
@@ -26152,7 +26152,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isfinite]
 ----
 bool isfinite(float x)                 (1)
 bool isfinite(double x)                (2)
@@ -26205,7 +26205,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isinf]
 ----
 bool isinf(float x)                 (1)
 bool isinf(double x)                (2)
@@ -26259,7 +26259,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isnan]
 ----
 bool isnan(float x)                 (1)
 bool isnan(double x)                (2)
@@ -26312,7 +26312,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isnormal]
 ----
 bool isnormal(float x)                 (1)
 bool isnormal(double x)                (2)
@@ -26365,7 +26365,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isordered]
 ----
 bool isordered(float x, float y)                       (1)
 bool isordered(double x, double y)                     (2)
@@ -26428,7 +26428,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:isunordered]
 ----
 bool isunordered(float x, float y)                       (1)
 bool isunordered(double x, double y)                     (2)
@@ -26490,7 +26490,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:signbit]
 ----
 bool signbit(float x)                 (1)
 bool signbit(double x)                (2)
@@ -26543,7 +26543,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:any]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ any(GenInt x)
@@ -26599,7 +26599,7 @@ significant bit of any element in [code]#x# is set.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:all]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ all(GenInt x)
@@ -26655,7 +26655,7 @@ significant bit of all elements in [code]#x# are set.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:bitselect]
 ----
 template<typename GenType1, typename GenType2, typename GenType3>
 /*return-type*/ bitselect(GenType1 a, GenType2 b, GenType3 c)
@@ -26694,7 +26694,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=synopsis]
+[source,role=synopsis,id=api:select]
 ----
 template<typename Scalar>                                                (1)
 Scalar select(Scalar a, Scalar b, bool c)

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20876,7 +20876,7 @@ to represent the following address spaces:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float acos(float x)                (1)
 double acos(double x)              (2)
@@ -20906,7 +20906,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float acosh(float x)                (1)
 double acosh(double x)              (2)
@@ -20937,7 +20937,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float acospi(float x)                (1)
 double acospi(double x)              (2)
@@ -20967,7 +20967,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float asin(float x)                (1)
 double asin(double x)              (2)
@@ -20997,7 +20997,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float asinh(float x)                (1)
 double asinh(double x)              (2)
@@ -21028,7 +21028,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float asinpi(float x)                (1)
 double asinpi(double x)              (2)
@@ -21058,7 +21058,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float atan(float y_over_x)                (1)
 double atan(double y_over_x)              (2)
@@ -21088,7 +21088,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float atan2(float y, float x)                       (1)
 double atan2(double y, double x)                    (2)
@@ -21125,7 +21125,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float atanh(float x)                (1)
 double atanh(double x)              (2)
@@ -21156,7 +21156,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float atanpi(float x)                (1)
 double atanpi(double x)              (2)
@@ -21186,7 +21186,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float atan2pi(float y, float x)                      (1)
 double atan2pi(double y, double x)                   (2)
@@ -21223,7 +21223,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cbrt(float x)                (1)
 double cbrt(double x)              (2)
@@ -21253,7 +21253,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float ceil(float x)                (1)
 double ceil(double x)              (2)
@@ -21285,7 +21285,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float copysign(float x, float y)                      (1)
 double copysign(double x, double y)                   (2)
@@ -21323,7 +21323,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cos(float x)                (1)
 double cos(double x)              (2)
@@ -21353,7 +21353,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cosh(float x)                (1)
 double cosh(double x)              (2)
@@ -21383,7 +21383,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cospi(float x)                (1)
 double cospi(double x)              (2)
@@ -21413,7 +21413,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float erfc(float x)                (1)
 double erfc(double x)              (2)
@@ -21444,7 +21444,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float erf(float x)                (1)
 double erf(double x)              (2)
@@ -21475,7 +21475,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp(float x)                (1)
 double exp(double x)              (2)
@@ -21506,7 +21506,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp2(float x)                (1)
 double exp2(double x)              (2)
@@ -21537,7 +21537,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp10(float x)                (1)
 double exp10(double x)              (2)
@@ -21568,7 +21568,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float expm1(float x)                (1)
 double expm1(double x)              (2)
@@ -21598,7 +21598,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fabs(float x)                (1)
 double fabs(double x)              (2)
@@ -21628,7 +21628,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fdim(float x, float y)                        (1)
 double fdim(double x, double y)                     (2)
@@ -21665,7 +21665,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float floor(float x)                (1)
 double floor(double x)              (2)
@@ -21697,7 +21697,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fma(float a, float b, float c)                                     (1)
 double fma(double a, double b, double c)                                 (2)
@@ -21743,7 +21743,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fmax(float x, float y)                                (1)
 double fmax(double x, double y)                             (2)
@@ -21804,7 +21804,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fmin(float x, float y)                                (1)
 double fmin(double x, double y)                             (2)
@@ -21865,7 +21865,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float fmod(float x, float y)                        (1)
 double fmod(double x, double y)                     (2)
@@ -21902,7 +21902,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                        (1)
 float fract(float x, Ptr iptr)
@@ -21961,7 +21961,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                        (1)
 float frexp(float x, Ptr exp)
@@ -22031,7 +22031,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float hypot(float x, float y)                       (1)
 double hypot(double x, double y)                    (2)
@@ -22069,7 +22069,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 int ilogb(float x)                  (1)
 int ilogb(double x)                 (2)
@@ -22106,7 +22106,7 @@ as [code]#NonScalar#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float ldexp(float x, int k)                         (1)
 double ldexp(double x, int k)                       (2)
@@ -22162,7 +22162,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float lgamma(float x)                (1)
 double lgamma(double x)              (2)
@@ -22194,7 +22194,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                        (1)
 float lgamma_r(float x, Ptr signp)
@@ -22257,7 +22257,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log(float x)                (1)
 double log(double x)              (2)
@@ -22287,7 +22287,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log2(float x)                (1)
 double log2(double x)              (2)
@@ -22317,7 +22317,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log10(float x)                (1)
 double log10(double x)              (2)
@@ -22347,7 +22347,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log1p(float x)                (1)
 double log1p(double x)              (2)
@@ -22377,7 +22377,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float logb(float x)                (1)
 double logb(double x)              (2)
@@ -22410,7 +22410,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float mad(float a, float b, float c)                                     (1)
 double mad(double a, double b, double c)                                 (2)
@@ -22456,7 +22456,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float maxmag(float x, float y)                      (1)
 double maxmag(double x, double y)                   (2)
@@ -22495,7 +22495,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float minmag(float x, float y)                      (1)
 double minmag(double x, double y)                   (2)
@@ -22534,7 +22534,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                        (1)
 float modf(float x, Ptr iptr)
@@ -22596,7 +22596,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float nan(uint32_t nancode)             (1)
 double nan(uint64_t nancode)            (2)
@@ -22646,7 +22646,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float nextafter(float x, float y)                      (1)
 double nextafter(double x, double y)                   (2)
@@ -22686,7 +22686,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float pow(float x, float y)                         (1)
 double pow(double x, double y)                      (2)
@@ -22723,7 +22723,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float pown(float x, int y)                          (1)
 double pown(double x, int y)                        (2)
@@ -22760,7 +22760,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float powr(float x, float y)                        (1)
 double powr(double x, double y)                     (2)
@@ -22802,7 +22802,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float remainder(float x, float y)                      (1)
 double remainder(double x, double y)                   (2)
@@ -22847,7 +22847,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                                            (1)
 float remquo(float x, float y, Ptr quo)
@@ -22928,7 +22928,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float rint(float x)                (1)
 double rint(double x)              (2)
@@ -22963,7 +22963,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float rootn(float x, int y)                         (1)
 double rootn(double x, int y)                       (2)
@@ -23000,7 +23000,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float round(float x)                (1)
 double round(double x)              (2)
@@ -23033,7 +23033,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float rsqrt(float x)                (1)
 double rsqrt(double x)              (2)
@@ -23064,7 +23064,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sin(float x)                (1)
 double sin(double x)              (2)
@@ -23094,7 +23094,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Ptr>                           (1)
 float sincos(float x, Ptr cosval)
@@ -23152,7 +23152,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sinh(float x)                (1)
 double sinh(double x)              (2)
@@ -23182,7 +23182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sinpi(float x)                (1)
 double sinpi(double x)              (2)
@@ -23212,7 +23212,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sqrt(float x)                (1)
 double sqrt(double x)              (2)
@@ -23242,7 +23242,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tan(float x)                (1)
 double tan(double x)              (2)
@@ -23272,7 +23272,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tanh(float x)                (1)
 double tanh(double x)              (2)
@@ -23303,7 +23303,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tanpi(float x)                (1)
 double tanpi(double x)              (2)
@@ -23333,7 +23333,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tgamma(float x)                (1)
 double tgamma(double x)              (2)
@@ -23363,7 +23363,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float trunc(float x)                (1)
 double trunc(double x)              (2)
@@ -23409,7 +23409,7 @@ but they may sacrifice accuracy or limit the set of legal input values.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cos(float x)                (1)
 
@@ -23437,7 +23437,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float divide(float x, float y)                      (1)
 
@@ -23466,7 +23466,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp(float x)                (1)
 
@@ -23495,7 +23495,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp2(float x)                (1)
 
@@ -23524,7 +23524,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp10(float x)                (1)
 
@@ -23553,7 +23553,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log(float x)                (1)
 
@@ -23581,7 +23581,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log2(float x)                (1)
 
@@ -23609,7 +23609,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log10(float x)                (1)
 
@@ -23637,7 +23637,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float powr(float x, float y)                        (1)
 
@@ -23671,7 +23671,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float recip(float x)                (1)
 
@@ -23699,7 +23699,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float rsqrt(float x)                (1)
 
@@ -23728,7 +23728,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sin(float x)                (1)
 
@@ -23756,7 +23756,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sqrt(float x)                (1)
 
@@ -23784,7 +23784,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tan(float x)                (1)
 
@@ -23825,7 +23825,7 @@ counterparts in <<sec:math-functions>>, but they have lower accuracy.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float cos(float x)                (1)
 
@@ -23858,7 +23858,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float divide(float x, float y)                      (1)
 
@@ -23887,7 +23887,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp(float x)                (1)
 
@@ -23916,7 +23916,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp2(float x)                (1)
 
@@ -23945,7 +23945,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float exp10(float x)                (1)
 
@@ -23974,7 +23974,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log(float x)                (1)
 
@@ -24002,7 +24002,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log2(float x)                (1)
 
@@ -24030,7 +24030,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float log10(float x)                (1)
 
@@ -24058,7 +24058,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float powr(float x, float y)                        (1)
 
@@ -24092,7 +24092,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float recip(float x)                (1)
 
@@ -24120,7 +24120,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float rsqrt(float x)                (1)
 
@@ -24149,7 +24149,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sin(float x)                (1)
 
@@ -24182,7 +24182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float sqrt(float x)                (1)
 
@@ -24210,7 +24210,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 float tan(float x)                (1)
 
@@ -24294,7 +24294,7 @@ represent the following types:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>
 /*return-type*/ abs(GenInt x)
@@ -24314,7 +24314,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ abs_diff(GenInt1 x, GenInt2 y)
@@ -24342,7 +24342,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ add_sat(GenInt1 x, GenInt2 y)
@@ -24369,7 +24369,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ hadd(GenInt1 x, GenInt2 y)
@@ -24396,7 +24396,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rhadd(GenInt1 x, GenInt2 y)
@@ -24423,7 +24423,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>    (1)
 /*return-type*/ clamp(GenInt1 x, GenInt2 minval, GenInt3 maxval)
@@ -24477,7 +24477,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>
 /*return-type*/ clz(GenInt x)
@@ -24497,7 +24497,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>
 /*return-type*/ ctz(GenInt x)
@@ -24517,7 +24517,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_hi(GenInt1 a, GenInt2 b, GenInt3 c)
@@ -24544,7 +24544,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
 /*return-type*/ mad_sat(GenInt1 a, GenInt2 b, GenInt3 c)
@@ -24572,7 +24572,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ max(GenInt1 x, GenInt2 y)
@@ -24617,7 +24617,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
 /*return-type*/ min(GenInt1 x, GenInt2 y)
@@ -24662,7 +24662,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ mul_hi(GenInt1 x, GenInt2 y)
@@ -24692,7 +24692,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ rotate(GenInt1 v, GenInt2 count)
@@ -24726,7 +24726,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt1, typename GenInt2>
 /*return-type*/ sub_sat(GenInt1 x, GenInt2 y)
@@ -24753,7 +24753,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename UInt8Bit1, typename UInt8Bit2>
 /*return-type*/ upsample(UInt8Bit1 hi, UInt8Bit2 lo)
@@ -24781,7 +24781,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Int8Bit, typename UInt8Bit>
 /*return-type*/ upsample(Int8Bit hi, UInt8Bit lo)
@@ -24810,7 +24810,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename UInt16Bit1, typename UInt16Bit2>
 /*return-type*/ upsample(UInt16Bit1 hi, UInt16Bit2 lo)
@@ -24838,7 +24838,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Int16Bit, typename UInt16Bit>
 /*return-type*/ upsample(Int16Bit hi, UInt16Bit lo)
@@ -24868,7 +24868,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename UInt32Bit1, typename UInt32Bit2>
 /*return-type*/ upsample(UInt32Bit1 hi, UInt32Bit2 lo)
@@ -24896,7 +24896,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Int32Bit, typename UInt32Bit>
 /*return-type*/ upsample(Int32Bit hi, UInt32Bit lo)
@@ -24926,7 +24926,7 @@ the same number of elements as the inputs.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>
 /*return-type*/ popcount(GenInt x)
@@ -24946,7 +24946,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Int32Bit1, typename Int32Bit2, typename Int32Bit3>
 /*return-type*/ mad24(Int32Bit1 x, Int32Bit2 y, Int32Bit3 z)
@@ -24988,7 +24988,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Int32Bit1, typename Int32Bit2>
 /*return-type*/ mul24(Int32Bit1 x, Int32Bit2 y)
@@ -25053,7 +25053,7 @@ type_ to represent the following types:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>    (1)
 /*return-type*/ clamp(GenFloat1 x, GenFloat2 minval, GenFloat3 maxval)
@@ -25108,7 +25108,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat>
 /*return-type*/ degrees(GenFloat radians)
@@ -25129,7 +25129,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ max(GenFloat1 x, GenFloat2 y)
@@ -25182,7 +25182,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
 /*return-type*/ min(GenFloat1 x, GenFloat2 y)
@@ -25235,7 +25235,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
 /*return-type*/ mix(GenFloat1 x, GenFloat2 y, GenFloat3 a)
@@ -25288,7 +25288,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat>
 /*return-type*/ radians(GenFloat degrees)
@@ -25309,7 +25309,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2>               (1)
 /*return-type*/ step(GenFloat1 edge, GenFloat2 x)
@@ -25354,7 +25354,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>                  (1)
 /*return-type*/ smoothstep(GenFloat1 edge0, GenFloat2 edge1, GenFloat3 x)
@@ -25390,7 +25390,7 @@ This is useful in cases where you would want a threshold function with a smooth
 transition.
 This is equivalent to:
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 GenFloat1 t;
 t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
@@ -25400,7 +25400,7 @@ return t * t * (3 - 2 * t);
 When the inputs are not scalars, returns the following value for each element of
 [code]#edge0#, [code]#edge1#, and [code]#x#:
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 GenFloat1::value_type t;
 t = clamp((x[i] - edge0[i]) / (edge1[i] - edge0[i]), 0, 1);
@@ -25423,7 +25423,7 @@ No element of [code]#x# may be NaN.
 
 _Returns:_ The following value for each element of [code]#x#:
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 NonScalar::value_type t;
 t = clamp((x[i] - edge0) / (edge1 - edge0), 0, 1);
@@ -25436,7 +25436,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenFloat>
 /*return-type*/ sign(GenFloat x)
@@ -25494,7 +25494,7 @@ The term _float geometric type_ represents these types:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Geo3or4Float1, typename Geo3or4Float2>
 /*return-type*/ cross(Geo3or4Float1 p0, Geo3or4Float2 p1)
@@ -25537,7 +25537,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ dot(GeoFloat1 p0, GeoFloat2 p1)
@@ -25560,7 +25560,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ distance(GeoFloat1 p0, GeoFloat2 p1)
@@ -25584,7 +25584,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat>
 /*return-type*/ length(GeoFloat p)
@@ -25601,7 +25601,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat>
 /*return-type*/ normalize(GeoFloat p)
@@ -25618,7 +25618,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
 /*return-type*/ fast_distance(GeoFloat1 p0, GeoFloat2 p1)
@@ -25641,7 +25641,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_length(GeoFloat p)
@@ -25658,7 +25658,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GeoFloat>
 /*return-type*/ fast_normalize(GeoFloat p)
@@ -25673,7 +25673,7 @@ computed as [code]#+p * half_precision::rsqrt(pow(p[0],2) + pow(p[1],2) +
 
 The result shall be within 8192 ulps error from the infinitely precise result of
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 if (all(p == 0.0f))
   result = p;
@@ -25746,7 +25746,7 @@ The term _vector element type_ represents these types:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isequal(float x, float y)                       (1)
 bool isequal(double x, double y)                     (2)
@@ -25804,7 +25804,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isnotequal(float x, float y)                       (1)
 bool isnotequal(double x, double y)                     (2)
@@ -25862,7 +25862,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isgreater(float x, float y)                       (1)
 bool isgreater(double x, double y)                     (2)
@@ -25920,7 +25920,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isgreaterequal(float x, float y)                       (1)
 bool isgreaterequal(double x, double y)                     (2)
@@ -25978,7 +25978,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isless(float x, float y)                       (1)
 bool isless(double x, double y)                     (2)
@@ -26036,7 +26036,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool islessequal(float x, float y)                       (1)
 bool islessequal(double x, double y)                     (2)
@@ -26094,7 +26094,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool islessgreater(float x, float y)                       (1)
 bool islessgreater(double x, double y)                     (2)
@@ -26152,7 +26152,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isfinite(float x)                 (1)
 bool isfinite(double x)                (2)
@@ -26205,7 +26205,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isinf(float x)                 (1)
 bool isinf(double x)                (2)
@@ -26259,7 +26259,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isnan(float x)                 (1)
 bool isnan(double x)                (2)
@@ -26312,7 +26312,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isnormal(float x)                 (1)
 bool isnormal(double x)                (2)
@@ -26365,7 +26365,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isordered(float x, float y)                       (1)
 bool isordered(double x, double y)                     (2)
@@ -26428,7 +26428,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool isunordered(float x, float y)                       (1)
 bool isunordered(double x, double y)                     (2)
@@ -26490,7 +26490,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 bool signbit(float x)                 (1)
 bool signbit(double x)                (2)
@@ -26543,7 +26543,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ any(GenInt x)
@@ -26599,7 +26599,7 @@ significant bit of any element in [code]#x# is set.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenInt>      (1)
 /*return-type*/ all(GenInt x)
@@ -26655,7 +26655,7 @@ significant bit of all elements in [code]#x# are set.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename GenType1, typename GenType2, typename GenType3>
 /*return-type*/ bitselect(GenType1 a, GenType2 b, GenType3 c)
@@ -26694,7 +26694,7 @@ corresponding [code]#vec#.
 
 '''
 
-[source,role=codebox]
+[source,role=synopsis]
 ----
 template<typename Scalar>                                                (1)
 Scalar select(Scalar a, Scalar b, bool c)

--- a/adoc/config/khronos.css
+++ b/adoc/config/khronos.css
@@ -438,14 +438,41 @@ pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 
 .listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
 
-/* Format "[source,role=codebox]" blocks.  This format overrides "listingblock" above. */
-.codebox > .content {
+/* Format "[source,role=synopsis]" blocks.  This format overrides "listingblock" above. */
+.synopsis > .content {
   position: relative;
   display: inline-block;
   border: 1px solid #ddd;
 }
-.codebox pre, .codebox pre[class] {
+.synopsis pre, .synopsis pre[class] {
   padding: 7px 7px 7px 7px;
+}
+
+/* Any "[source,role=synopsis]" blocks with an "id" have an anchor tag inside the
+   block's <div>.  (See the "synopsis" Ruby extension script.)  Style this as a
+   pound sign in the left column that is visible when hovering over the listing
+   block.  This is similar to the way section headers are styled, but with a
+   pound sign instead of a section sign.
+*/
+.synopsis > a {
+  position: absolute;
+  z-index: 1001;
+  width: 1.5ex;
+  margin-left: -1.5ex;
+  display: block;
+  text-decoration: none !important;
+  visibility: hidden;
+  text-align: center;
+  font-weight: normal;
+}
+.synopsis > a:before {
+  content: "#";
+  font-size: 0.85em;
+  display: block;
+  padding-top: 0.1em;
+}
+.synopsis:hover > a {
+  visibility: visible;
 }
 
 table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }

--- a/adoc/config/synopsis.rb
+++ b/adoc/config/synopsis.rb
@@ -1,0 +1,9 @@
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+RUBY_ENGINE == 'opal' ? (require 'synopsis/extension') : (require_relative 'synopsis/extension')
+
+Asciidoctor::Extensions.register do
+    postprocessor AddSynopsisAnchors
+end

--- a/adoc/config/synopsis/extension.rb
+++ b/adoc/config/synopsis/extension.rb
@@ -1,0 +1,47 @@
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+# Add HTML anchors for "[source,role=synopsis,id=X]" blocks, changing the HTML
+# from this:
+#
+# <div id="X" class="listingblock synopsis">
+#
+# to this:
+#
+# <div id="X" class="listingblock synopsis">
+# <a href="#X"></a>
+#
+# Note that this happens only if the block has an "id" attribute.
+#
+# This extension also relies on some custom CSS styling to turn the anchor into
+# into a section marker that you can click on to get the URL of the synopsis
+# block.  See the CSS entries for the class name "synopsis".
+#
+# TODO: It would be nice to create a custom Asciidoc block instead of using the
+# "role=" syntax.  This would allow the Asciidoc source to look like:
+#
+# [synopsis,id=X]
+#
+# However, doing this disables the source code highlighting feature.  I think
+# this is because the rouge highlighter looks only at [source] blocks, and I
+# cannot find a way to tell it to look at a custom block named [synopsis].
+
+class AddSynopsisAnchors < Extensions::Postprocessor
+
+  SynopsisDiv = /<div id="([^"]*)" class="[^"]*\bsynopsis\b[^"]*"[^>]*>/m
+  Replacement = '\0
+<a href="#\1"></a>'
+
+  def process document, output
+
+    if document.basebackend? 'html'
+      output.gsub! SynopsisDiv, Replacement
+    end
+    output
+
+  end
+end


### PR DESCRIPTION
Extend and improve the "codebox" Asciidoc role:

* Rename "codebox" to "synopsis".  My intent is to use this role
  mostly to define the synopsis of an API.

* Create an Asciidoctor extension that enables HTML links for source
  listings that use the "synopsis" role and also define an id like:

  ```
  [source,role=synopsis,id=XXX]
  ```

  In the HTML render, when you hover the mouse over a code synopsis, a
  pound sign ("#") appears.  Clicking on this gives you a link directly
  to that code synopsis.  This makes it easy to get a direct link to
  any API that is defined with the "synopsis" role.  Note that this
  behavior is similar to the way section headers work in the HTML
  render, where you can click on a "section sign" symbol to get a URL
  directly to a section.

Change the synopses of the math builtin function sections to use this
new style.