### PR TITLE
Remove "listing" cross references

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -615,12 +615,11 @@ values in the [code]#sycl::aspect# enumeration type (including any extended
 values the implementation may provide).  If it does not, the program is ill
 formed and the compiler must issue a diagnostic.
 
-See <<listing:device-has>> for an example of this attribute.
+See below for an example of this attribute.
 
 |====
 
 .Example of the [code]#sycl::device_has()# attribute
-[[listing:device-has]]
 [source,,linenums]
 ----
 include::{code_dir}/deviceHas.cpp[lines=4..-1]

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -387,8 +387,8 @@ For the full description please refer to <<subsec:buffers>>.
     Variables defined in one work-item's private memory are not visible to
     another work-item.
     The [code]#sycl::private_memory# class provides access to the work-item's
-    private memory for the hierarchical API as it is described at
-    <<paragraph.private.memory>>.
+    private memory for the hierarchical API as it is described in
+    <<sec:parallel-for-hierarchical>>.
 
 [[queue]]queue::
     A SYCL command queue is an object that holds command groups to be executed

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13926,6 +13926,7 @@ include::{code_dir}/parallelForWithKernelHandler.cpp[lines=4..-1]
 ----
 
 
+[[sec:parallel-for-hierarchical]]
 ===== Parallel for hierarchical invoke
 
 The hierarchical parallel kernel execution interface provides the same
@@ -13964,8 +13965,6 @@ data.
 
 The [code]#private_memory# class has the following interface:
 
-[[paragraph.private.memory]]
-.Private memory class
 [source,,linenums]
 ----
 include::{header_dir}/priv.h[lines=4..-1]
@@ -20115,8 +20114,6 @@ group to execute an operation over a range of iterators and algorithms which are
 applied to data held directly by the work-items in a group.
 An example of the usage of these functions is given below:
 
-[[listing.group.algorithms]]
-.Using the group algorithms library to perform a work-group reduce
 [source,,linenums]
 ----
 include::{code_dir}/algorithms.cpp[lines=4..-1]

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -70,10 +70,8 @@ include::config/attribs.adoc[]
 
 // This causes cross references to chapters, sections, and tables to be
 // rendered as "Section A.B" (for example) rather than rendering the reference
-// as the text of the section title.  It also enables cross references to
-// [source] blocks as "Listing N", but only if the [source] block has a title.
+// as the text of the section title.
 :xrefstyle: short
-:listing-caption: Listing
 
 // Original SYCL title page has:
 //  image:logos/Khronos_Tagline_500px_June18.png (upper right)


### PR DESCRIPTION
In order to further improve synopsis `[source]` blocks, we want to add a title, but we don't want that title to have the "Listing" prefix. In order to do this, we need to delete the `listing-caption` attribute.

However, doing this breaks cross references to listing blocks.  There were only a few such cross references, so restructure the text in those cases to remove them.