### PR TITLE
Add API synopsis titles and cross references

### DIFF
--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -144,7 +144,8 @@ ADOCOPTS     = --doctype book $(ADOCMISCOPTS) $(ATTRIBOPTS) \
 
 ADOCHTMLEXTS = --require $(CURDIR)/config/katex_replace.rb \
   --require $(CURDIR)/config/loadable_html.rb \
-  --require $(CURDIR)/config/synopsis.rb
+  --require $(CURDIR)/config/synopsis.rb \
+  --require $(CURDIR)/config/api_xrefs.rb
 
 # ADOCHTMLOPTS relies on the relative runtime path from the output HTML
 # file to the katex scripts being set with KATEXDIR. This is overridden

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -22928,7 +22928,7 @@ _Effects:_ Computes the value [code]#r# such that [code]#r = x - k*y#, where
 If there are two integers closest to [code]#x/y#, [code]#k# shall be the even
 one.
 If [code]#r# is zero, it is given the same sign as [code]#x#.
-This is the same value that is returned by the [code]#remainder# function.
+This is the same value that is returned by the [api]#remainder# function.
 The [code]#remquo# function also calculates the lower seven bits of the integral
 quotient [code]#x/y# and gives that value the same sign as [code]#x/y#.
 It stores this signed value to the object pointed to by [code]#quo#.
@@ -22967,7 +22967,7 @@ nearest the exact value of [code]#x[i]/y[i]#.
 If there are two integers closest to [code]#x[i]/y[i]#, [code]#k# shall be the
 even one.
 If [code]#r# is zero, it is given the same sign as [code]#x[i]#.
-This is the same value that is returned by the [code]#remainder# function.
+This is the same value that is returned by the [api]#remainder# function.
 The [code]#remquo# function also calculates the lower seven bits of the integral
 quotient [code]#x[i]/y[i]# and gives that value the same sign as
 [code]#x[i]/y[i]#.
@@ -25841,10 +25841,10 @@ This section describes the relational functions that are available in the
 These functions perform various relational comparisons on [code]#vec#,
 [code]#marray#, and scalar types.
 
-The comparisons performed by [code]#isequal#, [code]#isgreater#,
-[code]#isgreaterequal#, [code]#isless#, [code]#islessequal#, and
-[code]#islessgreater# are false when one or both operands are NaN.
-The comparison performed by [code]#isnotequal# is true when one or both operands
+The comparisons performed by [api]#isequal#, [api]#isgreater#,
+[api]#isgreaterequal#, [api]#isless#, [api]#islessequal#, and
+[api]#islessgreater# are false when one or both operands are NaN.
+The comparison performed by [api]#isnotequal# is true when one or both operands
 are NaN.
 
 The function descriptions in this section use two terms that refer to a specific

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20876,6 +20876,7 @@ to represent the following address spaces:
 
 '''
 
+.[apidef]#acos#
 [source,role=synopsis,id=api:acos]
 ----
 float acos(float x)                (1)
@@ -20906,6 +20907,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#acosh#
 [source,role=synopsis,id=api:acosh]
 ----
 float acosh(float x)                (1)
@@ -20937,6 +20939,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#acospi#
 [source,role=synopsis,id=api:acospi]
 ----
 float acospi(float x)                (1)
@@ -20967,6 +20970,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#asin#
 [source,role=synopsis,id=api:asin]
 ----
 float asin(float x)                (1)
@@ -20997,6 +21001,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#asinh#
 [source,role=synopsis,id=api:asinh]
 ----
 float asinh(float x)                (1)
@@ -21028,6 +21033,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#asinpi#
 [source,role=synopsis,id=api:asinpi]
 ----
 float asinpi(float x)                (1)
@@ -21058,6 +21064,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#atan#
 [source,role=synopsis,id=api:atan]
 ----
 float atan(float y_over_x)                (1)
@@ -21088,6 +21095,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#atan2#
 [source,role=synopsis,id=api:atan2]
 ----
 float atan2(float y, float x)                       (1)
@@ -21125,6 +21133,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#atanh#
 [source,role=synopsis,id=api:atanh]
 ----
 float atanh(float x)                (1)
@@ -21156,6 +21165,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#atanpi#
 [source,role=synopsis,id=api:atanpi]
 ----
 float atanpi(float x)                (1)
@@ -21186,6 +21196,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#atan2pi#
 [source,role=synopsis,id=api:atan2pi]
 ----
 float atan2pi(float y, float x)                      (1)
@@ -21223,6 +21234,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#cbrt#
 [source,role=synopsis,id=api:cbrt]
 ----
 float cbrt(float x)                (1)
@@ -21253,6 +21265,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#ceil#
 [source,role=synopsis,id=api:ceil]
 ----
 float ceil(float x)                (1)
@@ -21285,6 +21298,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#copysign#
 [source,role=synopsis,id=api:copysign]
 ----
 float copysign(float x, float y)                      (1)
@@ -21323,6 +21337,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#cos#
 [source,role=synopsis,id=api:cos]
 ----
 float cos(float x)                (1)
@@ -21353,6 +21368,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#cosh#
 [source,role=synopsis,id=api:cosh]
 ----
 float cosh(float x)                (1)
@@ -21383,6 +21399,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#cospi#
 [source,role=synopsis,id=api:cospi]
 ----
 float cospi(float x)                (1)
@@ -21413,6 +21430,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#erfc#
 [source,role=synopsis,id=api:erfc]
 ----
 float erfc(float x)                (1)
@@ -21444,6 +21462,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#erf#
 [source,role=synopsis,id=api:erf]
 ----
 float erf(float x)                (1)
@@ -21475,6 +21494,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#exp#
 [source,role=synopsis,id=api:exp]
 ----
 float exp(float x)                (1)
@@ -21506,6 +21526,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#exp2#
 [source,role=synopsis,id=api:exp2]
 ----
 float exp2(float x)                (1)
@@ -21537,6 +21558,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#exp10#
 [source,role=synopsis,id=api:exp10]
 ----
 float exp10(float x)                (1)
@@ -21568,6 +21590,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#expm1#
 [source,role=synopsis,id=api:expm1]
 ----
 float expm1(float x)                (1)
@@ -21598,6 +21621,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fabs#
 [source,role=synopsis,id=api:fabs]
 ----
 float fabs(float x)                (1)
@@ -21628,6 +21652,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fdim#
 [source,role=synopsis,id=api:fdim]
 ----
 float fdim(float x, float y)                        (1)
@@ -21665,6 +21690,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#floor#
 [source,role=synopsis,id=api:floor]
 ----
 float floor(float x)                (1)
@@ -21697,6 +21723,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fma#
 [source,role=synopsis,id=api:fma]
 ----
 float fma(float a, float b, float c)                                     (1)
@@ -21743,6 +21770,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fmax#
 [source,role=synopsis,id=api:fmax]
 ----
 float fmax(float x, float y)                                (1)
@@ -21804,6 +21832,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fmin#
 [source,role=synopsis,id=api:fmin]
 ----
 float fmin(float x, float y)                                (1)
@@ -21865,6 +21894,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fmod#
 [source,role=synopsis,id=api:fmod]
 ----
 float fmod(float x, float y)                        (1)
@@ -21902,6 +21932,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fract#
 [source,role=synopsis,id=api:fract]
 ----
 template<typename Ptr>                        (1)
@@ -21961,6 +21992,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#frexp#
 [source,role=synopsis,id=api:frexp]
 ----
 template<typename Ptr>                        (1)
@@ -22031,6 +22063,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#hypot#
 [source,role=synopsis,id=api:hypot]
 ----
 float hypot(float x, float y)                       (1)
@@ -22069,6 +22102,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#ilogb#
 [source,role=synopsis,id=api:ilogb]
 ----
 int ilogb(float x)                  (1)
@@ -22106,6 +22140,7 @@ as [code]#NonScalar#.
 
 '''
 
+.[apidef]#ldexp#
 [source,role=synopsis,id=api:ldexp]
 ----
 float ldexp(float x, int k)                         (1)
@@ -22162,6 +22197,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#lgamma#
 [source,role=synopsis,id=api:lgamma]
 ----
 float lgamma(float x)                (1)
@@ -22194,6 +22230,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#lgamma_r#
 [source,role=synopsis,id=api:lgamma_r]
 ----
 template<typename Ptr>                        (1)
@@ -22257,6 +22294,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#log#
 [source,role=synopsis,id=api:log]
 ----
 float log(float x)                (1)
@@ -22287,6 +22325,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#log2#
 [source,role=synopsis,id=api:log2]
 ----
 float log2(float x)                (1)
@@ -22317,6 +22356,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#log10#
 [source,role=synopsis,id=api:log10]
 ----
 float log10(float x)                (1)
@@ -22347,6 +22387,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#log1p#
 [source,role=synopsis,id=api:log1p]
 ----
 float log1p(float x)                (1)
@@ -22377,6 +22418,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#logb#
 [source,role=synopsis,id=api:logb]
 ----
 float logb(float x)                (1)
@@ -22410,6 +22452,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mad#
 [source,role=synopsis,id=api:mad]
 ----
 float mad(float a, float b, float c)                                     (1)
@@ -22456,6 +22499,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#maxmag#
 [source,role=synopsis,id=api:maxmag]
 ----
 float maxmag(float x, float y)                      (1)
@@ -22495,6 +22539,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#minmag#
 [source,role=synopsis,id=api:minmag]
 ----
 float minmag(float x, float y)                      (1)
@@ -22534,6 +22579,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#modf#
 [source,role=synopsis,id=api:modf]
 ----
 template<typename Ptr>                        (1)
@@ -22596,6 +22642,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#nan#
 [source,role=synopsis,id=api:nan]
 ----
 float nan(uint32_t nancode)             (1)
@@ -22646,6 +22693,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#nextafter#
 [source,role=synopsis,id=api:nextafter]
 ----
 float nextafter(float x, float y)                      (1)
@@ -22686,6 +22734,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#pow#
 [source,role=synopsis,id=api:pow]
 ----
 float pow(float x, float y)                         (1)
@@ -22723,6 +22772,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#pown#
 [source,role=synopsis,id=api:pown]
 ----
 float pown(float x, int y)                          (1)
@@ -22760,6 +22810,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#powr#
 [source,role=synopsis,id=api:powr]
 ----
 float powr(float x, float y)                        (1)
@@ -22802,6 +22853,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#remainder#
 [source,role=synopsis,id=api:remainder]
 ----
 float remainder(float x, float y)                      (1)
@@ -22847,6 +22899,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#remquo#
 [source,role=synopsis,id=api:remquo]
 ----
 template<typename Ptr>                                            (1)
@@ -22928,6 +22981,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#rint#
 [source,role=synopsis,id=api:rint]
 ----
 float rint(float x)                (1)
@@ -22963,6 +23017,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#rootn#
 [source,role=synopsis,id=api:rootn]
 ----
 float rootn(float x, int y)                         (1)
@@ -23000,6 +23055,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#round#
 [source,role=synopsis,id=api:round]
 ----
 float round(float x)                (1)
@@ -23033,6 +23089,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#rsqrt#
 [source,role=synopsis,id=api:rsqrt]
 ----
 float rsqrt(float x)                (1)
@@ -23064,6 +23121,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sin#
 [source,role=synopsis,id=api:sin]
 ----
 float sin(float x)                (1)
@@ -23094,6 +23152,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sincos#
 [source,role=synopsis,id=api:sincos]
 ----
 template<typename Ptr>                           (1)
@@ -23152,6 +23211,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sinh#
 [source,role=synopsis,id=api:sinh]
 ----
 float sinh(float x)                (1)
@@ -23182,6 +23242,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sinpi#
 [source,role=synopsis,id=api:sinpi]
 ----
 float sinpi(float x)                (1)
@@ -23212,6 +23273,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sqrt#
 [source,role=synopsis,id=api:sqrt]
 ----
 float sqrt(float x)                (1)
@@ -23242,6 +23304,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#tan#
 [source,role=synopsis,id=api:tan]
 ----
 float tan(float x)                (1)
@@ -23272,6 +23335,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#tanh#
 [source,role=synopsis,id=api:tanh]
 ----
 float tanh(float x)                (1)
@@ -23303,6 +23367,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#tanpi#
 [source,role=synopsis,id=api:tanpi]
 ----
 float tanpi(float x)                (1)
@@ -23333,6 +23398,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#tgamma#
 [source,role=synopsis,id=api:tgamma]
 ----
 float tgamma(float x)                (1)
@@ -23363,6 +23429,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#trunc#
 [source,role=synopsis,id=api:trunc]
 ----
 float trunc(float x)                (1)
@@ -23409,6 +23476,7 @@ but they may sacrifice accuracy or limit the set of legal input values.
 
 '''
 
+.[apidef]#native::cos#
 [source,role=synopsis,id=api:native-cos]
 ----
 float cos(float x)                (1)
@@ -23437,6 +23505,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::divide#
 [source,role=synopsis,id=api:native-divide]
 ----
 float divide(float x, float y)                      (1)
@@ -23466,6 +23535,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::exp#
 [source,role=synopsis,id=api:native-exp]
 ----
 float exp(float x)                (1)
@@ -23495,6 +23565,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::exp2#
 [source,role=synopsis,id=api:native-exp2]
 ----
 float exp2(float x)                (1)
@@ -23524,6 +23595,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::exp10#
 [source,role=synopsis,id=api:native-exp10]
 ----
 float exp10(float x)                (1)
@@ -23553,6 +23625,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::log#
 [source,role=synopsis,id=api:native-log]
 ----
 float log(float x)                (1)
@@ -23581,6 +23654,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::log2#
 [source,role=synopsis,id=api:native-log2]
 ----
 float log2(float x)                (1)
@@ -23609,6 +23683,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::log10#
 [source,role=synopsis,id=api:native-log10]
 ----
 float log10(float x)                (1)
@@ -23637,6 +23712,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::powr#
 [source,role=synopsis,id=api:native-powr]
 ----
 float powr(float x, float y)                        (1)
@@ -23671,6 +23747,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::recip#
 [source,role=synopsis,id=api:native-recip]
 ----
 float recip(float x)                (1)
@@ -23699,6 +23776,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::rsqrt#
 [source,role=synopsis,id=api:native-rsqrt]
 ----
 float rsqrt(float x)                (1)
@@ -23728,6 +23806,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::sin#
 [source,role=synopsis,id=api:native-sin]
 ----
 float sin(float x)                (1)
@@ -23756,6 +23835,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::sqrt#
 [source,role=synopsis,id=api:native-sqrt]
 ----
 float sqrt(float x)                (1)
@@ -23784,6 +23864,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#native::tan#
 [source,role=synopsis,id=api:native-tan]
 ----
 float tan(float x)                (1)
@@ -23825,6 +23906,7 @@ counterparts in <<sec:math-functions>>, but they have lower accuracy.
 
 '''
 
+.[apidef]#half_precision::cos#
 [source,role=synopsis,id=api:half-cos]
 ----
 float cos(float x)                (1)
@@ -23858,6 +23940,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::divide#
 [source,role=synopsis,id=api:half-divide]
 ----
 float divide(float x, float y)                      (1)
@@ -23887,6 +23970,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::exp#
 [source,role=synopsis,id=api:half-exp]
 ----
 float exp(float x)                (1)
@@ -23916,6 +24000,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::exp2#
 [source,role=synopsis,id=api:half-exp2]
 ----
 float exp2(float x)                (1)
@@ -23945,6 +24030,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::exp10#
 [source,role=synopsis,id=api:half-exp10]
 ----
 float exp10(float x)                (1)
@@ -23974,6 +24060,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::log#
 [source,role=synopsis,id=api:half-log]
 ----
 float log(float x)                (1)
@@ -24002,6 +24089,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::log2#
 [source,role=synopsis,id=api:half-log2]
 ----
 float log2(float x)                (1)
@@ -24030,6 +24118,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::log10#
 [source,role=synopsis,id=api:half-log10]
 ----
 float log10(float x)                (1)
@@ -24058,6 +24147,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::powr#
 [source,role=synopsis,id=api:half-powr]
 ----
 float powr(float x, float y)                        (1)
@@ -24092,6 +24182,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::recip#
 [source,role=synopsis,id=api:half-recip]
 ----
 float recip(float x)                (1)
@@ -24120,6 +24211,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::rsqrt#
 [source,role=synopsis,id=api:half-rsqrt]
 ----
 float rsqrt(float x)                (1)
@@ -24149,6 +24241,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::sin#
 [source,role=synopsis,id=api:half-sin]
 ----
 float sin(float x)                (1)
@@ -24182,6 +24275,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::sqrt#
 [source,role=synopsis,id=api:half-sqrt]
 ----
 float sqrt(float x)                (1)
@@ -24210,6 +24304,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#half_precision::tan#
 [source,role=synopsis,id=api:half-tan]
 ----
 float tan(float x)                (1)
@@ -24294,6 +24389,7 @@ represent the following types:
 
 '''
 
+.[apidef]#abs#
 [source,role=synopsis,id=api:abs]
 ----
 template<typename GenInt>
@@ -24314,6 +24410,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#abs_diff#
 [source,role=synopsis,id=api:abs_diff]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24342,6 +24439,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#add_sat#
 [source,role=synopsis,id=api:add_sat]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24369,6 +24467,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#hadd#
 [source,role=synopsis,id=api:hadd]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24396,6 +24495,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#rhadd#
 [source,role=synopsis,id=api:rhadd]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24423,6 +24523,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#clamp#
 [source,role=synopsis,id=api:clamp-int]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>    (1)
@@ -24477,6 +24578,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#clz#
 [source,role=synopsis,id=api:clz]
 ----
 template<typename GenInt>
@@ -24497,6 +24599,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#ctz#
 [source,role=synopsis,id=api:ctz]
 ----
 template<typename GenInt>
@@ -24517,6 +24620,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mad_hi#
 [source,role=synopsis,id=api:mad_hi]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
@@ -24544,6 +24648,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mad_sat#
 [source,role=synopsis,id=api:mad_sat]
 ----
 template<typename GenInt1, typename GenInt2, typename GenInt3>
@@ -24572,6 +24677,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#max#
 [source,role=synopsis,id=api:max-int]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
@@ -24617,6 +24723,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#min#
 [source,role=synopsis,id=api:min-int]
 ----
 template<typename GenInt1, typename GenInt2>               (1)
@@ -24662,6 +24769,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mul_hi#
 [source,role=synopsis,id=api:mul_hi]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24692,6 +24800,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#rotate#
 [source,role=synopsis,id=api:rotate]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24726,6 +24835,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sub_sat#
 [source,role=synopsis,id=api:sub_sat]
 ----
 template<typename GenInt1, typename GenInt2>
@@ -24753,6 +24863,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample-uint16]
 ----
 template<typename UInt8Bit1, typename UInt8Bit2>
@@ -24781,6 +24892,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample,id=api:upsample-int16]
 ----
 template<typename Int8Bit, typename UInt8Bit>
@@ -24810,6 +24922,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample-uint32]
 ----
 template<typename UInt16Bit1, typename UInt16Bit2>
@@ -24838,6 +24951,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample-int32]
 ----
 template<typename Int16Bit, typename UInt16Bit>
@@ -24868,6 +24982,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample-uint64]
 ----
 template<typename UInt32Bit1, typename UInt32Bit2>
@@ -24896,6 +25011,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apititle]#upsample#
 [source,role=synopsis,id=api:upsample-int64]
 ----
 template<typename Int32Bit, typename UInt32Bit>
@@ -24926,6 +25042,7 @@ the same number of elements as the inputs.
 
 '''
 
+.[apidef]#popcount#
 [source,role=synopsis,id=api:popcount]
 ----
 template<typename GenInt>
@@ -24946,6 +25063,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mad24#
 [source,role=synopsis,id=api:mad24]
 ----
 template<typename Int32Bit1, typename Int32Bit2, typename Int32Bit3>
@@ -24988,6 +25106,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mul24#
 [source,role=synopsis,id=api:mul24]
 ----
 template<typename Int32Bit1, typename Int32Bit2>
@@ -25053,6 +25172,7 @@ type_ to represent the following types:
 
 '''
 
+.[apititle]#clamp#
 [source,role=synopsis,id=api:clamp-fp]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>    (1)
@@ -25108,6 +25228,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#degrees#
 [source,role=synopsis,id=api:degrees]
 ----
 template<typename GenFloat>
@@ -25129,6 +25250,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#max#
 [source,role=synopsis,id=api:max-fp]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
@@ -25182,6 +25304,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apititle]#min#
 [source,role=synopsis,id=api:min-fp]
 ----
 template<typename GenFloat1, typename GenFloat2>           (1)
@@ -25235,6 +25358,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#mix#
 [source,role=synopsis,id=api:mix]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>       (1)
@@ -25288,6 +25412,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#radians#
 [source,role=synopsis,id=api:radians]
 ----
 template<typename GenFloat>
@@ -25309,6 +25434,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#step#
 [source,role=synopsis,id=api:step]
 ----
 template<typename GenFloat1, typename GenFloat2>               (1)
@@ -25354,6 +25480,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#smoothstep#
 [source,role=synopsis,id=api:smoothstep]
 ----
 template<typename GenFloat1, typename GenFloat2, typename GenFloat3>                  (1)
@@ -25436,6 +25563,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#sign#
 [source,role=synopsis,id=api:sign]
 ----
 template<typename GenFloat>
@@ -25494,6 +25622,7 @@ The term _float geometric type_ represents these types:
 
 '''
 
+.[apidef]#cross#
 [source,role=synopsis,id=api:cross]
 ----
 template<typename Geo3or4Float1, typename Geo3or4Float2>
@@ -25537,6 +25666,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#dot#
 [source,role=synopsis,id=api:dot]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
@@ -25560,6 +25690,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
+.[apidef]#distance#
 [source,role=synopsis,id=api:distance]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
@@ -25584,6 +25715,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
+.[apidef]#length#
 [source,role=synopsis,id=api:length]
 ----
 template<typename GeoFloat>
@@ -25601,6 +25733,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
+.[apidef]#normalize#
 [source,role=synopsis,id=api:normalize]
 ----
 template<typename GeoFloat>
@@ -25618,6 +25751,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#fast_distance#
 [source,role=synopsis,id=api:fast_distance]
 ----
 template<typename GeoFloat1, typename GeoFloat2>
@@ -25641,6 +25775,7 @@ Otherwise, the return type is [code]#GeoFloat1::value_type#.
 
 '''
 
+.[apidef]#fast_length#
 [source,role=synopsis,id=api:fast_length]
 ----
 template<typename GeoFloat>
@@ -25658,6 +25793,7 @@ Otherwise, the return type is [code]#GeoFloat::value_type#.
 
 '''
 
+.[apidef]#fast_normalize#
 [source,role=synopsis,id=api:fast_normalize]
 ----
 template<typename GeoFloat>
@@ -25746,6 +25882,7 @@ The term _vector element type_ represents these types:
 
 '''
 
+.[apidef]#isequal#
 [source,role=synopsis,id=api:isequal]
 ----
 bool isequal(float x, float y)                       (1)
@@ -25804,6 +25941,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isnotequal#
 [source,role=synopsis,id=api:isnotequal]
 ----
 bool isnotequal(float x, float y)                       (1)
@@ -25862,6 +26000,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isgreater#
 [source,role=synopsis,id=api:isgreater]
 ----
 bool isgreater(float x, float y)                       (1)
@@ -25920,6 +26059,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isgreaterequal#
 [source,role=synopsis,id=api:isgreaterequal]
 ----
 bool isgreaterequal(float x, float y)                       (1)
@@ -25978,6 +26118,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isless#
 [source,role=synopsis,id=api:isless]
 ----
 bool isless(float x, float y)                       (1)
@@ -26036,6 +26177,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#islessequal#
 [source,role=synopsis,id=api:islessequal]
 ----
 bool islessequal(float x, float y)                       (1)
@@ -26094,6 +26236,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#islessgreater#
 [source,role=synopsis,id=api:islessgreater]
 ----
 bool islessgreater(float x, float y)                       (1)
@@ -26152,6 +26295,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isfinite#
 [source,role=synopsis,id=api:isfinite]
 ----
 bool isfinite(float x)                 (1)
@@ -26205,6 +26349,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#isinf#
 [source,role=synopsis,id=api:isinf]
 ----
 bool isinf(float x)                 (1)
@@ -26259,6 +26404,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#isnan#
 [source,role=synopsis,id=api:isnan]
 ----
 bool isnan(float x)                 (1)
@@ -26312,6 +26458,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#isnormal#
 [source,role=synopsis,id=api:isnormal]
 ----
 bool isnormal(float x)                 (1)
@@ -26365,6 +26512,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#isordered#
 [source,role=synopsis,id=api:isordered]
 ----
 bool isordered(float x, float y)                       (1)
@@ -26428,6 +26576,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#isunordered#
 [source,role=synopsis,id=api:isunordered]
 ----
 bool isunordered(float x, float y)                       (1)
@@ -26490,6 +26639,7 @@ The return type depends on [code]#NonScalar1#:
 
 '''
 
+.[apidef]#signbit#
 [source,role=synopsis,id=api:signbit]
 ----
 bool signbit(float x)                 (1)
@@ -26543,6 +26693,7 @@ The return type depends on [code]#NonScalar#:
 
 '''
 
+.[apidef]#any#
 [source,role=synopsis,id=api:any]
 ----
 template<typename GenInt>      (1)
@@ -26599,6 +26750,7 @@ significant bit of any element in [code]#x# is set.
 
 '''
 
+.[apidef]#all#
 [source,role=synopsis,id=api:all]
 ----
 template<typename GenInt>      (1)
@@ -26655,6 +26807,7 @@ significant bit of all elements in [code]#x# are set.
 
 '''
 
+.[apidef]#bitselect#
 [source,role=synopsis,id=api:bitselect]
 ----
 template<typename GenType1, typename GenType2, typename GenType3>
@@ -26694,6 +26847,7 @@ corresponding [code]#vec#.
 
 '''
 
+.[apidef]#select#
 [source,role=synopsis,id=api:select]
 ----
 template<typename Scalar>                                                (1)

--- a/adoc/config/api_xrefs.rb
+++ b/adoc/config/api_xrefs.rb
@@ -1,0 +1,9 @@
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+RUBY_ENGINE == 'opal' ? (require 'api_xrefs/extension') : (require_relative 'api_xrefs/extension')
+
+Asciidoctor::Extensions.register do
+    postprocessor AddApiXrefs
+end

--- a/adoc/config/api_xrefs/extension.rb
+++ b/adoc/config/api_xrefs/extension.rb
@@ -1,0 +1,124 @@
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+# Make automatic cross references for API names in the HTML render.
+#
+# This extension assumes that APIs are defined in Asciidoc as listing blocks
+# with a particular structure:
+#
+# * The listing block must define an "id" attribute;
+# * The listing block must have a title; and
+# * The title must have one occurrence of the "[apidef]" role, where the text
+#   in that role is the name of the API.
+#
+# Here is an example that defines the API "foobar":
+#
+#   .[apidef]#foobar#
+#   [source,id=api:foobar]
+#   ----
+#   int foobar(void* p)
+#   ----
+#
+# This extension also looks for occurrences of the "[api]" role.  The text in
+# this role must exactly match the text in one of the "[apidef]" roles.  This
+# extension wraps the text in the "[api]" role with a cross reference link
+# to the listing block with the corresponding "[apidef]".  For example, consider
+# Asciidoc like this:
+#
+#   Use the [api]#foobar# function to initialize the system.
+#
+# This extension wraps the text "foobar" with an HTML anchor that links to the
+# listing block whose id is "api::foobar".
+#
+# Note that an "API" can be anything.  This extension only cares that the text
+# in the "[apidef]" role matches the text in the "[api]" role.
+#
+# Typically, projects using this extension also provide some custom CSS styling
+# for the "apidef" and "api" HTML classes.
+
+class AddApiXrefs < Extensions::Postprocessor
+  include Asciidoctor::Logging
+
+  ApiSpan = /<span class="api">([\w:]*)<\/span>/
+  ApiDefSpan = /<span class="apidef">([\w:]*)<\/span>/
+  ApiIdDiv = /<div id="([\w:-]*)"/
+
+  def process document, output
+
+    if document.basebackend? 'html'
+      # Scan through all the HTML lines looking for the "[apidef]" definitions.
+      # A typical definition looks like this:
+      #
+      # <div id="ID" class="listingblock">
+      # <a href="#ID"></a>
+      # <div class="title"><span class="apidef">NAME</span></div>
+      #
+      # where the <a> element above may or may not be present, depending on
+      # whether the listing block also uses the "synopsis" extension.
+      #
+      lines = output.lines
+      num_lines = lines.length-1
+      api_to_id = {}
+      match_id_last = nil
+      match_id_last2 = nil
+      for i in 0..num_lines
+        line = lines[i]
+        match_def = ApiDefSpan.match(line)
+        match_id = ApiIdDiv.match(line)
+
+        # If this line matches the "apidef", see if the previous line (or the
+        # line previous to that) matches the "id=".
+        api = nil
+        api_id = nil
+        if match_def and match_id_last
+          api = match_def[1]
+          api_id = match_id_last[1]
+        elsif match_def and match_id_last2
+          api = match_def[1]
+          api_id = match_id_last2[1]
+        end
+
+        if api and api_id
+          if api_to_id.key?(api)
+            old_id = api_to_id[api]
+            logger.error "[api]##{api}# multiply defined (id=#{old_id} and id=#{api_id})"
+          else
+            api_to_id[api] = api_id
+          end
+        end
+
+        match_id_last2 = match_id_last
+        match_id_last = match_id
+      end
+
+      # Now that we have a hash mapping each API name to its id, do another
+      # scan through the HTML, looking for each occurrence of
+      #
+      #   <span class="api">NAME</span>.
+      i = 0
+      new_output = ''
+      output.to_enum(:scan,ApiSpan).map{Regexp.last_match}.each do |m|
+        api = m[1]
+        # Make sure there was a definition for this API.  Diagnose an error if
+        # not.
+        if not api_to_id.key?(api)
+          logger.error "[api]##{api}#: Not defined"
+        else
+          # Wrap <span> in an anchor that links to the definition.
+          first, last = m.offset(0)
+          new_output << output[i..first-1]
+          new_output << '<a href="#' << api_to_id[api] << '">' << m[0] << '</a>'
+          i = last
+        end
+      end
+      new_output << output[i..-1]
+      output = new_output
+    end
+    output
+
+  end
+end

--- a/adoc/config/khronos.css
+++ b/adoc/config/khronos.css
@@ -475,6 +475,9 @@ pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
   visibility: visible;
 }
 
+.apidef { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: bold; color: black; }
+.apititle { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: bold; color: black; }
+
 table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
 
 table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }

--- a/adoc/config/khronos.css
+++ b/adoc/config/khronos.css
@@ -477,6 +477,7 @@ pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 
 .apidef { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: bold; color: black; }
 .apititle { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: bold; color: black; }
+.api { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #ff0000; }
 
 table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
 

--- a/adoc/config/themes/pdf-theme.yml
+++ b/adoc/config/themes/pdf-theme.yml
@@ -88,6 +88,21 @@ role:
     font_size: 1em
     font_family: M+ 1mn
     font_color: FF0000
+  # The Asciidoctor [apidef] and [apititle] roles are styled in bold because
+  # they are headings to a description of an API.  The [apidef] role is styled
+  # as a fixed-width font because it's the name of a code identifier (e.g.
+  # function name or class name).  The [apititle] role is styled the same for
+  # consistency.
+  apidef:
+    font_size: 1em
+    font_style: bold
+    font_family: M+ 1mn
+    font_color: 000000
+  apititle:
+    font_size: 1em
+    font_style: bold
+    font_family: M+ 1mn
+    font_color: 000000
 # From khronos.css code CSS style:
 # code, .code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
 #   font_color: $base_font_color

--- a/adoc/config/themes/pdf-theme.yml
+++ b/adoc/config/themes/pdf-theme.yml
@@ -103,6 +103,11 @@ role:
     font_style: bold
     font_family: M+ 1mn
     font_color: 000000
+  # The [api] role is styled the same as [code].
+  api:
+    font_size: 1em
+    font_family: M+ 1mn
+    font_color: FF0000
 # From khronos.css code CSS style:
 # code, .code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
 #   font_color: $base_font_color


### PR DESCRIPTION
Add a title to each `[source]` block that is a synopsis.  The title uses
`[apidef]` if the title is a unique name for a SYCL identifier,
otherwise it uses `[apititle]`.

Also add an extension which creates automatic cross references to the
`[apidef]` synopses.  In order to make a cross reference, use the
Asciidoc role `[api]`.  This is styled like `[code]` but also creates a
cross reference.  For example, `[api]#foo#` creates a cross reference to
the synopsis whose title is `[apidef]#foo#`.

Replace some uses of `[code]` with `[api]` in the sections defining the
math builtins.