### PR TITLE
Add new non-normative note format

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -161,7 +161,8 @@ Programming languages — {cpp}>>, referred to in this specification as the next
 Unless stated otherwise, text within this SYCL specification is normative and
 defines the required behavior of a SYCL implementation.
 Non-normative / informational notes are included within this specification using
-a "`note`" callout, of the form:
+either of two formats.
+One format for non-normative notes is the "`note`" callout of this form:
 
 [NOTE]
 ====
@@ -169,6 +170,11 @@ Information within a note callout, such as this text, is for informational
 purposes and does not impose requirements on or specify behavior of a SYCL
 implementation.
 ====
+
+The other format for a non-normative note is like this:
+
+{note}This is also a non-normative note.
+{endnote}
 
 Source code examples within the specification are provided to aid with
 understanding, and are non-normative.

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -64,6 +64,17 @@ include::config/attribs.adoc[]
 :cpp20: pass:[C++20]
 // Fortunately, the cpp macro for C++ is defined by default in AsciiDoctor
 
+// Use these to format a non-normative note.  The Asciidoc source:
+//
+//  {note}Caveat emptor.
+//  {endnote}
+//
+// is formatted like:
+//
+//  [Note: Caveat emptor. -- end note]
+:note: pass:q[[_Note:_ ]
+:endnote: pass:q,a[_&#8212;{nbsp}end{nbsp}note_]]
+
 // SYCL Algebraic definitions
 :SYCLeval: Satisfied
 :SYCLperform: Perform


### PR DESCRIPTION
Add a new format for non-normative notes.  This is the same format that the C++ specification uses, and we plan to migrate to this new format as we generally improve the formatting of the SYCL spec.