### PR TITLE
Clarify wording about local_access "value_type"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8299,7 +8299,7 @@ void swap(local_accessor& other);
 a@
 [source]
 ----
-local_ptr<DataT> get_pointer() const noexcept
+local_ptr<value_type> get_pointer() const noexcept
 ----
    a@ Returns a [code]#multi_ptr# to the start of this accessor's local memory
       region which corresponds to the calling work-group. The return value is

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -4,8 +4,7 @@
 namespace sycl {
 template <typename DataT, int Dimensions = 1> class local_accessor {
  public:
-  using value_type = // const DataT for read-only accessors, DataT otherwise
-      __value_type__;
+  using value_type = DataT;
   using reference = value_type&;
   using const_reference = const DataT&;
   template <access::decorated IsDecorated>
@@ -63,7 +62,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
   reference operator[](size_t index) const;
 
   /* Deprecated in SYCL 2020 */
-  local_ptr<DataT> get_pointer() const noexcept;
+  local_ptr<value_type> get_pointer() const noexcept;
 
   template <access::decorated IsDecorated>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept;


### PR DESCRIPTION
Because there is no access mode for `local_accessor`, the `value_type` is always the same as `DataT`.  (The only way to get a read-only `local_accessor` is to use a `DataT` that is `const`.)

Remove a comment in the synopsis that made it appear that `value_type` might be different from `DataT`.

Also change the return type of `local_accessor::get_pointer` from `DataT` to `value_type`.  Although these types are the same, it seems clearer to be consistent with `accessor::get_pointer`, where the return type is `value_type`.