### PR TITLE
Fix Asciidoc error in vec table

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17589,7 +17589,7 @@ a@
 ----
 vec<RET, NumElements> operatorOP(const DataT& lhs, const vec& rhs)
 ----
-Construct a new instance of the SYCL [code]#vec# class template with
+   a@ Construct a new instance of the SYCL [code]#vec# class template with
 the same template parameters as the [code]#rhs# SYCL [code]#vec#
 with each element of the new SYCL [code]#vec# instance the result of
 an element-wise [code]#OP# logical operation between the [code]#lhs# scalar and each element of the [code]#rhs# SYCL [code]#vec#.


### PR DESCRIPTION
It appears that this error was introduced a while ago in #480, but it was only flagged recently as an error in the build.  The docker image we use to build the spec was updated earlier today, and the new image flags this as an error.  It appears that older docker images did not flag an error, but the build output was corrupt.  Luckily, we did not publish any of the corrupted builds.