### PR TITLE
Update CI "actions/upload-artifact" version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./adoc/scripts/verify_reflow_conformance.sh
       - name: Archive generated files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spec-outputs
           path: |


### PR DESCRIPTION
Version 3 will be deprecated later this year.  Move to the latest version.