### PR TITLE
Correct commit id when building from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build spec targets
         run: |
           cd adoc
-          make OUTDIR=/tmp/out QUIET= html pdf
+          make OUTDIR=/tmp/out QUIET= COMMIT_SHA=$GITHUB_SHA html pdf
       - name: Verify reflow conformance
         run: |
           ./adoc/scripts/verify_reflow_conformance.sh

--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -93,22 +93,14 @@ NOTEOPTS     = --attribute showtodos
 # Spell out ISO 8601 format as not all date commands support --rfc-3339
 SPECDATE     = $(shell echo `date -u "+%Y-%m-%d %TZ"`)
 
-# Generate Asciidoc attributes for spec remark
-# Could use `git log -1 --format="%cd"` to get branch commit date
-# This used to be a dependency in the spec html/pdf targets,
-# but that's likely to lead to merge conflicts. Just regenerate
-# when pushing a new spec for review to the sandbox.
-# The dependency on HEAD is per the suggestion in
-# http://neugierig.org/software/blog/2014/11/binary-revisions.html
-# Get back something clearer from the old LaTeX-based specification by
-# name the exact annotated tag. If not, list a path to the closest tag.
-SPECREMARK = from git $(shell \
-  echo `git describe --exact-match 2> /dev/null \
-        || ( git describe 2> /dev/null; echo "on branch:" ; \
-             git symbolic-ref --short HEAD 2> /dev/null \
-             || echo Git branch not available )`) \
-        commit: $(shell echo `git log -1 --format="%H" 2> /dev/null \
-                              || echo Git commit not available`)
+# Deterine the commit ID that is printed at the top of the spec.
+# In some CI systems, the build may happen outside of a git repo, so
+# "git log" may not be available.  These CI systems set the commit id via
+# "make COMMIT_SHA=...", so the build process doesn't need the "git log"
+# command.
+SPECREMARK = commit $(COMMIT_SHA)
+COMMIT_SHA = $(shell echo `git log -1 --format="%H" 2> /dev/null \
+               || echo "(not available)"`)
 
 # Some of the attributes used in building all spec documents:
 #   chapters - absolute path to chapter sources


### PR DESCRIPTION
The revision line at the top of the spec is supposed to include the git commit ID that the spec was built from.  This works fine when building manually, but there has been a longstanding bug preventing this form working when the spec is built in GitHub CI.

I think the problem is that the GitHub action doesn't check out any of the git history, so the "git describe" and "git log" commands don't work.  Rather than use git commands to get the commit ID, we can just get the ID from the GitHib $GITHUB_SHA variable.

I also simplified the information in the revision line, so it just contains the commit ID and not the branch information.  I think this is the only critical information because we can always map the ID back to a branch later if we want.