### PR TITLE
Use a specific SHA of the Docker image for running CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     # Use Khronos container with asciidoctor toolchain preinstalled
-    container: khronosgroup/docker-images:asciidoctor-spec
+    # The SHA refers to a specific version of the
+    # khronosgroup/docker-images:asciidoctor-spec image.
+    container: khronosgroup/docker-images@sha256:bd30a83285a2ea062598f053b5bd8ebc843e16c639c0e4cd88ab4bbb4e63ead3
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This prevents unexpected behavior when the underlying asciidoctor-spec image is updated on dockerhub.

@gmlueck I built the HTML / PDF outputs and compared against versions built using the older image. They look similar but there are minor visible differences due to the updated asciidoctor versions (mostly that they tweaked CSS and PDF layout options in very small ways). So you should verify the outputs to your satisfaction. There's some stuff about docker in the Makefile which I don't fully understand so have not touched that - as noted in email, my approach in the Vulkan runDocker script was to extract the image name from the CI .yml file to avoid error-prone duplication. Maybe that would be applicable here.

Note this only changes the Github Actions container. In the internal SYCL spec repo there's also a .gitlab-ci.yml for our gitlab that would have to be changed as well to get consistent behavior.

Also, note I have not yet updated the dockerhub 'asciidoctor-spec' image, just the 'asciidoctor-spec.20240630' image (which is just an alias) and am using the image SHA here, as discussed.