### PR TITLE
Reference Docker Hub image by SHA

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,8 +25,11 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Use Khronos container with asciidoctor toolchain preinstalled
-    container: khronosgroup/docker-images:asciidoctor-spec
+    # Use the Khronos container with the asciidoctor toolchain preinstalled.  We
+    # reference the image by its SHA rather than its tag because they sometimes
+    # overwrite a tag with a different image (which has a different SHA).  This
+    # corresponds to tag 20240627.
+    container: khronosgroup/docker-images:asciidoctor-spec@sha256:91a1b62399f9804e17110e89d85d62e90bc8d2ad7b94a329bee87784158368a9
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     # Use the Khronos container with the asciidoctor toolchain preinstalled.  We
-    # reference the image by both its SHA and its tag because they sometimes
-    # overwrite a tag with a different image (which has a different SHA).
-    container: khronosgroup/docker-images:asciidoctor-spec.20240630@sha256:bd30a83285a2ea062598f053b5bd8ebc843e16c639c0e4cd88ab4bbb4e63ead3
+    # reference the image its SHA rather than its tag because they sometimes
+    # overwrite a tag with a different image (which has a different SHA).  This
+    # SHA corresponds to tag "asciidoctor-spec.20240630".
+    container: khronosgroup/docker-images@sha256:bd30a83285a2ea062598f053b5bd8ebc843e16c639c0e4cd88ab4bbb4e63ead3
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,8 +28,8 @@ jobs:
     # Use the Khronos container with the asciidoctor toolchain preinstalled.  We
     # reference the image its SHA rather than its tag because they sometimes
     # overwrite a tag with a different image (which has a different SHA).  This
-    # SHA corresponds to tag "asciidoctor-spec.20240630".
-    container: khronosgroup/docker-images@sha256:bd30a83285a2ea062598f053b5bd8ebc843e16c639c0e4cd88ab4bbb4e63ead3
+    # SHA corresponds to tag "asciidoctor-spec.20240701".
+    container: khronosgroup/docker-images@sha256:1175e55feeaca36d8c53b3628372cd371078473a162a558c3e89ffafdde40676
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,10 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     # Use the Khronos container with the asciidoctor toolchain preinstalled.  We
-    # reference the image by its SHA rather than its tag because they sometimes
-    # overwrite a tag with a different image (which has a different SHA).  This
-    # corresponds to tag 20240627.
-    container: khronosgroup/docker-images:asciidoctor-spec@sha256:91a1b62399f9804e17110e89d85d62e90bc8d2ad7b94a329bee87784158368a9
+    # reference the image by both its SHA and its tag because they sometimes
+    # overwrite a tag with a different image (which has a different SHA).
+    container: khronosgroup/docker-images:asciidoctor-spec.20240630@sha256:bd30a83285a2ea062598f053b5bd8ebc843e16c639c0e4cd88ab4bbb4e63ead3
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Download the Docker Hub container image by its SHA, so that we know exactly which version of the Asciidoctor tools we use to build the spec. The version (SHA) should be updated periodically as new container images are published.