### PR TITLE
Clarify backend and introduce "backend::none"

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -3,36 +3,25 @@
 [[architecture]]
 = SYCL architecture
 
-This chapter describes the structure of a SYCL application, and how the SYCL
-generic programming model lays out on top of a number of <<backend>>s.
+This chapter describes the structure of a SYCL application and its programming
+model.
 
 
 == Overview
 
 SYCL is an open industry standard for programming a heterogeneous system.
 The design of SYCL allows standard {cpp} source code to be written such that it
-can run on either an heterogeneous device or on the <<host>>.
+can run on either an heterogeneous device such as a GPU or on a general purpose
+CPU.
 
-The terminology used for SYCL inherits historically from OpenCL with some
-SYCL-specific additions.
-However SYCL is a generic {cpp} programming model that can be laid out on top of
-other heterogeneous APIs apart from OpenCL.
-SYCL implementations can provide <<backend>>s for various heterogeneous APIs,
-implementing the SYCL general specification on top of them.
-We refer to this heterogeneous API as the <<backend-api>>.
-The SYCL general specification defines the behavior that all SYCL
-implementations must expose to SYCL users for a SYCL application to behave as
-expected.
+Some terminology from SYCL derives from OpenCL.
+However, OpenCL is not a prerequisite for implementing SYCL.
+A SYCL implementation may layer on top of a heterogeneous programming API such
+as OpenCL, but this is not necessary.
+It is also possible to implement SYCL directly on hardware.
 
-A function object that can execute on a <<device>> exposed by a <<backend-api>>
-is called a <<sycl-kernel-function>>.
-
-To ensure maximum interoperability with different <<backend-api>>s, software
-developers can access the <<backend-api>> alongside the SYCL general API
-whenever they include the <<backend>> interoperability headers.
-However, interoperability is a <<backend>>-specific feature.
-An application that uses interoperability does not conform to the SYCL general
-application model, since it is not portable across backends.
+A function object that can execute on a <<device>> is called a
+<<sycl-kernel-function>>.
 
 // Note below I leave the reference to OpenCL intentionally
 
@@ -194,8 +183,8 @@ An implementation may also expose empty <<platform, platforms>> that do not
 contain any <<device,devices>>.
 
 A SYCL <<context>> is constructed, either directly by the user or implicitly
-when creating a <<queue>>, to hold all the runtime information required by the
-SYCL runtime and the <<backend>> to operate on a device, or group of devices.
+when creating a <<queue>>, to hold all the runtime information required to
+operate on a device, or group of devices.
 When a group of devices can be grouped together on the same context, they have
 some visibility of each other's memory objects.
 The SYCL runtime can assume that memory is visible across all devices in the
@@ -204,26 +193,23 @@ Not all devices exposed from the same <<platform>> can be grouped together in
 the same <<context>>.
 
 A SYCL application executes on the host as a standard {cpp} program.
-<<device,Devices>> are exposed through different <<backend, SYCL backends>> to
-the SYCL application.
+The <<sycl-runtime>> exposes <<device,devices>> to the application.
 The SYCL application submits <<command-group-function-object,command group
-function objects>> to <<queue,queues>>.
-Each <<queue>> enables execution on a given device.
+function objects>> to <<queue,queues>>, and each <<queue>> enables execution on
+a given device.
 
 The <<sycl-runtime>> then extracts operations from the
 <<command-group-function-object>>, e.g. an explicit copy operation or a
 <<sycl-kernel-function>>.
-When the operation is a <<sycl-kernel-function>>, the <<sycl-runtime>> uses a
-<<backend>>-specific mechanism to extract the device binary from the SYCL
+When the operation is a <<sycl-kernel-function>>, the <<sycl-runtime>> uses an
+implementation-specific mechanism to extract the device binary from the SYCL
 application and pass it to the heterogeneous API for execution on the
 <<device>>.
 
 A SYCL <<device>> is divided into one or more compute units (CUs) which are each
 divided into one or more processing elements (PEs).
 Computations on a device occur within the processing elements.
-How computation is mapped to PEs is <<backend>> and <<device>> specific.
-Two devices exposed via two different backends can map computations differently
-to the same device.
+How computation is mapped to PEs is specific to the implementation.
 
 When a SYCL application contains <<sycl-kernel-function>> objects, the SYCL
 implementation must provide an offline compilation mechanism that enables the
@@ -233,29 +219,37 @@ as SPIR-V, that will be finalized during execution or a final device ISA.
 
 A device may expose special purpose functionality as a _built-in_ function.
 The SYCL API exposes functions to query and dispatch said _built-in_ functions.
-Some <<backend, SYCL backends>> and <<device,devices>> may not support
-programmable kernels, and only support _built-in_ functions.
+Some <<device,devices>> may not support programmable kernels, and only support
+_built-in_ functions.
 // TODO: Conformance of these custom-devices?
 
 
 == The SYCL backend model
 
-SYCL is a generic programming model for the {cpp} language that can target
-multiple heterogeneous APIs, such as OpenCL.
+A SYCL implementation may expose devices by layering on top of a heterogeneous
+API such as OpenCL or it may expose devices in some other way.
+An implementation may even combine these methods, exposing devices through
+several different heterogeneous APIs or through other mechanisms.
+Regardless of how the devices are exposed, they must implement the semantics of
+the SYCL APIs defined in this document.
 
-SYCL implementations enable these target APIs by implementing <<backend, SYCL
-backends>>.
-For a SYCL implementation to be conformant on said <<backend>>, it must execute
-the SYCL generic programming model on the backend.
-All SYCL implementations must provide at least one backend.
+When a SYCL implementation layers on top of a heterogeneous API such as OpenCL,
+we refer to this as a <<backend>>.
+In this case, the implementation may choose to document how the backend APIs
+correlate to SYCL and provide interoperation APIs that allow a SYCL application
+to make calls to both the SYCL APIs and the backend APIs.
+However, applications that make use of this ability are no longer conformant to
+the core SYCL specification and may not be portable to other implementations of
+SYCL.
 
-The present document covers the SYCL generic interface available to all
-<<backend, SYCL backends>>.
-How the SYCL generic interface maps to a particular <<backend>> is defined
-either by a separate <<backend>> specification document, provided by the Khronos
-SYCL group, or by the SYCL implementation documentation.
-Whenever there is a <<backend>> specification document, this takes precedence
-over SYCL implementation documentation.
+In order to aid with this sort of backend interoperation, SYCL provides the
+[code]#backend# enumeration, and most SYCL objects provide a member function
+[code]#get_backend#.
+If a SYCL implementation wants to expose backend interoperation, it must define
+one or more enumerators in the [code]#backend# enumeration, and each of those
+enumerators must have a corresponding backend interoperation specification.
+These enumerators and specifications may be defined either by the Khronos SYCL
+group or by the vendor of the SYCL implementation.
 
 When a SYCL user builds their SYCL application, she decides which of the
 <<backend, SYCL backends>> will be used to build the SYCL application.
@@ -316,9 +310,9 @@ implementation that supports the required features for the application.
 
 The SYCL generic programming model exposes a number of <<platform,platforms>>,
 each of them either empty or exposing a number of <<device,devices>>.
-Each <<platform>> is bound to a certain <<backend>>.
-SYCL <<device,devices>> associated with said <<platform>> are associated with
-that <<backend>>.
+Each platform is bound to no more than one <<backend>>.
+If the platform is bound to a backend, the devices associated with that platform
+are associated with that backend.
 
 Although the APIs in the SYCL generic programming model are defined according to
 this specification and their version is indicated by the macro
@@ -1608,7 +1602,7 @@ queue constructor.
 Device topology may be cached by the <<sycl-runtime>>, but this is not required.
 
 Device discovery will return all <<device,devices>> from all
-<<platform,platforms>> exposed by all the supported <<backend, SYCL backends>>.
+<<platform,platforms>>.
 
 === Interfacing with the SYCL backend API
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -24,24 +24,24 @@ indicates a values for the enumerator.
 [[sec:backends]]
 == Backends
 
-The <<backend, SYCL backends>> that can be supported by a SYCL implementation
-are identified using the [code]#enum class backend#.
+The [code]#backend# enumerator defines the <<backend, SYCL backends>> (if any)
+that an application may interoperate with.
 
 [source,,linenums]
 ----
 include::{header_dir}/backends.h[lines=4..-1]
 ----
 
-The [code]#enum class backend# is implementation-defined and must be populated
-with a unique identifier for each <<backend>> that the SYCL implementation can
-support.
-Note that the <<backend, SYCL backends>> listed in the [code]#enum class
-backend# are not guaranteed to be available in a given installation.
+The enumerator value [code]#backend::none# is used to identify a SYCL object
+that does not correspond to any backend.
+If the implementation provides interoperation with any backends, it must define
+one additional enumerator for each of these backends, and these enumerators must
+each have an associated backend interoperation specification.
 
-Each named <<backend>> enumerated in the [code]#enum class backend# must be
-associated with a <<backend>> specification.
-Many sections of this specification will refer to the associated <<backend>>
-specification.
+Even if an implementation defines a backend enumerator, this is not a guarantee
+that the backend is available when the application runs.
+A backend is only guaranteed to be available if some SYCL object returns the
+associated enumerator from its [code]#get_backend# member function.
 
 
 [[sec:backend-macros]]
@@ -745,9 +745,8 @@ and returning a value that is implicitly convertible to [code]#int#.
 
 At any point where the <<sycl-runtime>> needs to select a SYCL [code]#device#
 using a <<device-selector>>, the system queries all <<root-device, root
-devices>> from all <<backend, SYCL backends>> in the system, calls the
-<<device-selector>> on each device and selects the one which returns the highest
-score.
+devices>> from all platforms in the system, calls the <<device-selector>> on
+each device and selects the one which returns the highest score.
 If the highest value is strictly negative no device is selected.
 
 In places where only one device has to be picked and the high score is obtained
@@ -770,7 +769,7 @@ a@
 ----
 default_selector_v
 ----
-   a@ Select a SYCL [code]#device# from any supported <<backend>>
+   a@ Select a SYCL [code]#device# from one of the platforms
       based on an implementation-defined heuristic. Since all
       implementations must support at least one device, this selector
       must always return a device.
@@ -787,7 +786,7 @@ a@
 ----
 gpu_selector_v
 ----
-   a@ Select a SYCL [code]#device# from any supported <<backend>>
+   a@ Select a SYCL [code]#device# from one of the platforms
       for which the device type is
       [code]#info::device_type::gpu#. The SYCL class
       constructor using it must throw an [code]#exception#
@@ -799,7 +798,7 @@ a@
 ----
 accelerator_selector_v
 ----
-   a@ Select a SYCL [code]#device# from any supported <<backend>>
+   a@ Select a SYCL [code]#device# from one of the platforms
       for which the device type is
       [code]#info::device_type::accelerator#. The SYCL
       class constructor using it must throw an [code]#exception#
@@ -811,7 +810,7 @@ a@
 ----
 cpu_selector_v
 ----
-   a@ Select a SYCL [code]#device# from any supported <<backend>>
+   a@ Select a SYCL [code]#device# from one of the platforms
       for which the device type is
       [code]#info::device_type::cpu#. The SYCL class
       constructor using it must throw an [code]#exception#
@@ -832,7 +831,7 @@ template <aspect... AspectList> __unspecified_callable__ aspect_selector();
 ----
 a@ The free function [code]#aspect_selector# has several overloads,
 each of which returns a selector object that selects a
-SYCL [code]#device# from any supported <<backend>>
+SYCL [code]#device# from one of the platforms
 which contains all the requested aspects,
 i.e. for the specific device [code]#dev#
 and each aspect [code]#devAspect# from [code]#aspectList#
@@ -951,10 +950,11 @@ to resolve some ambiguity in constructors with default parameters.
 
 The SYCL [code]#platform# class encapsulates a single SYCL platform on which
 SYCL kernel functions may be executed.
-A SYCL platform must be associated with a single <<backend>>.
+A SYCL platform must be associated with no more than one <<backend>>.
 
-A SYCL [code]#platform# is also associated with any number of SYCL
-[code]#devices# associated with the same <<backend>>.
+A platform is also associated with any number of SYCL devices.
+If the platform is associated with a backend, each of these devices must be
+associated with that same backend.
 A platform may contain no devices.
 
 All member functions of the [code]#platform# class are synchronous and errors
@@ -1028,8 +1028,10 @@ a@
 ----
 backend get_backend() const noexcept
 ----
-   a@ Returns a [code]#backend# identifying the <<backend>> associated
-      with this [code]#platform#.
+   a@ Returns the backend (if any) that underlies this object.
+      When the backend is not [code]#backend::none#, backend interoperation is
+      available for this object as defined by the corresponding SYCL backend
+      specification.
 
 a@
 [source]
@@ -1099,7 +1101,7 @@ a@
 static std::vector<platform> get_platforms()
 ----
    a@ Returns a [code]#std::vector# containing all SYCL
-      [code]#platforms# from all <<backend, SYCL backends>> available in the system.
+      [code]#platforms# available in the system.
 
 |====
 
@@ -1170,8 +1172,8 @@ Returns the extensions supported by this [code]#platform#. Returns an empty list
 === Context class
 
 The <<context>> class represents a SYCL <<context>>.
-A <<context>> represents the runtime data structures and state required by a
-<<backend>> API to interact with a group of devices associated with a platform.
+A <<context>> represents the runtime data structures and state required to
+interact with a group of devices associated with a platform.
 
 The SYCL [code]#context# class provides the common reference semantics (see
 <<sec:reference-semantics>>).
@@ -1191,9 +1193,9 @@ All member functions of the <<context>> class are synchronous and errors are
 handled by throwing synchronous SYCL exceptions.
 
 All constructors of the SYCL <<context>> class will construct an instance
-associated with a particular <<backend>>, determined by the constructor
-parameters or, in the case of the default constructor, the SYCL [code]#device#
-produced by the [code]#default_selector_v#.
+associated with a particular platform, determined by the constructor parameters
+or, in the case of the default constructor, the SYCL [code]#device# produced by
+the [code]#default_selector_v#.
 
 A SYCL [code]#context# can optionally be constructed with an
 [code]#async_handler# parameter.
@@ -1257,8 +1259,10 @@ a@
 ----
 backend get_backend() const noexcept
 ----
-   a@ Returns a [code]#backend# identifying the <<backend>> associated
-      with this [code]#context#.
+   a@ Returns the backend (if any) that underlies this object.
+      When the backend is not [code]#backend::none#, backend interoperation is
+      available for this object as defined by the corresponding SYCL backend
+      specification.
 
 a@
 [source]
@@ -1448,8 +1452,8 @@ A SYCL [code]#device# can be partitioned into multiple SYCL devices, by calling
 the [code]#create_sub_devices()# member function template.
 The resulting SYCL [code]#devices# are considered sub devices, and it is valid
 to partition these sub devices further.
-The range of support for this feature is <<backend>> and device specific and can
-be queried for through [code]#get_info()#.
+The range of support for this feature can be queried for through
+[code]#device::get_info()#.
 
 The SYCL [code]#device# class provides the common reference semantics (see
 <<sec:reference-semantics>>).
@@ -1507,8 +1511,10 @@ a@
 ----
 backend get_backend() const noexcept
 ----
-   a@ Returns a [code]#backend# identifying the <<backend>> associated
-      with this [code]#device#.
+   a@ Returns the backend (if any) that underlies this object.
+      When the backend is not [code]#backend::none#, backend interoperation is
+      available for this object as defined by the corresponding SYCL backend
+      specification.
 
 a@
 [source]
@@ -1692,7 +1698,7 @@ static std::vector<device>
 get_devices(info::device_type deviceType = info::device_type::all)
 ----
    a@ Returns a [code]#std::vector# containing all the
-      <<root-device, root devices>> from all <<backend, SYCL backends>>
+      <<root-device, root devices>> from all platforms
       available in the system which have the device type encapsulated by
       [code]#deviceType#.
 
@@ -3109,8 +3115,10 @@ a@
 ----
 backend get_backend() const noexcept
 ----
-a@ Returns a [code]#backend# identifying the <<backend>> associated
-with this [code]#queue#.
+a@ Returns the backend (if any) that underlies this object.
+When the backend is not [code]#backend::none#, backend interoperation is
+available for this object as defined by the corresponding SYCL backend
+specification.
 
 a@
 [source]
@@ -3794,9 +3802,8 @@ event()
       Waiting on this [code]#event# will return immediately and querying
       its status will return [code]#info::event_command_status::complete#.
 
-The event is constructed as though it was created from a default-constructed
-[code]#queue#.  Therefore, its backend is the same as the backend from the
-default device.
+The backend (if any) that is associated with this event is implementation
+defined.
 
 |====
 
@@ -3812,8 +3819,10 @@ a@
 ----
 backend get_backend() const noexcept
 ----
-   a@ Returns a [code]#backend# identifying the <<backend>> associated
-      with this [code]#event#.
+   a@ Returns the backend (if any) that underlies this object.
+      When the backend is not [code]#backend::none#, backend interoperation is
+      available for this object as defined by the corresponding SYCL backend
+      specification.
 
 a@
 [source]
@@ -14705,8 +14714,10 @@ include::{header_dir}/hostTask/classInteropHandle/constructors.h[lines=4..-1]
 include::{header_dir}/hostTask/classInteropHandle/getbackend.h[lines=4..-1]
 ----
 
-  . _Returns:_ Returns a [code]#backend# identifying the <<backend>> associated
-      with the <<queue>> associated with this [code]#interop_handle#.
+  . _Returns:_ The backend (if any) that underlies the queue that is associated
+      with this [code]#interop_handle#.
+      When the backend is not [code]#backend::none#, backend interoperation is
+      available as defined by the corresponding SYCL backend specification.
 
 [[subsec:interfaces.hosttask.interophandle.getnative]]
 ==== Template member functions [code]#get_native_*#
@@ -15692,7 +15703,10 @@ _Returns:_ [code]#true# only if the kernel bundle contains no device images.
 backend get_backend() const noexcept;
 ----
 
-_Returns:_ The backend that is associated with the kernel bundle.
+_Returns:_ The backend (if any) that underlies this object.
+When the backend is not [code]#backend::none#, backend interoperation is
+available for this object as defined by the corresponding SYCL backend
+specification.
 
 [source]
 ----
@@ -15935,7 +15949,10 @@ The following member functions provide various queries for a <<kernel>>.
 backend get_backend() const noexcept;
 ----
 
-_Returns:_ The backend associated with this kernel.
+_Returns:_ The backend (if any) that underlies this object.
+When the backend is not [code]#backend::none#, backend interoperation is
+available for this object as defined by the corresponding SYCL backend
+specification.
 
 [source]
 ----

--- a/adoc/headers/backends.h
+++ b/adoc/headers/backends.h
@@ -3,6 +3,7 @@
 
 namespace sycl {
 enum class backend : /* unspecified */ {
+  none,
   /* see below */
 };
 } // namespace sycl


### PR DESCRIPTION
Clarify exactly what we mean by "backend".  I think it has always been our intention that the `backend` enumeration and the `get_backend` member function tell an application what sort of interoperation is supported by a SYCL object.  For example, if a SYCL object returns `backend::opencl` from its `get_backend` function, that SYCL object supports interoperation as defined by the OpenCL backend interoperation specification.

This commit clarifies the spec to say that explicitly.

It also became clear that we need a `backend::none` enumerator to indicate that a SYCL object does not support any backend interoperation. For example, this would be useful if a vendor implements SYCL directly on hardware, without using a documented low-level offload API.  Many of the changes in this commit merely remove sentences that imply that every SYCL object necessarily has some backend.

This commit also makes a minor change to the default `event` constructor.  Previously, we required the backend for such an event to be the same as the backend for the default device.  After some implementation experience, we decided that this is not practical. Requiring interoperation with a particular backend constrains the implementation too much.  It also seems arbitrary to require the default-constructed event to have a particular backend.  To address these concerns, this commit loosens the requirement, allowing an implementation to choose which backend (if any) the default-constructed event has.

Closes #564