### PR TITLE
Relax backend for default-constructed event

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3794,9 +3794,7 @@ event()
       Waiting on this [code]#event# will return immediately and querying
       its status will return [code]#info::event_command_status::complete#.
 
-The event is constructed as though it was created from a default-constructed
-[code]#queue#.  Therefore, its backend is the same as the backend from the
-default device.
+The backend that is associated with this event is implementation defined.
 
 |====
 


### PR DESCRIPTION
Relax the requirements on the backend for a default-constructed `event` object.  Previously, we required the backend for such an event to be the same as the backend for the default device.  After some implementation experience, we decided that this is not practical.  Requiring interoperation with a particular backend constrains the implementation too much.  It also seems arbitrary to require the default-constructed event to have a particular backend.  To address these concerns, we now say that the backend that is associated with a default-constructed event is implementation defined.