### PR TITLE
Add workflow to automatically open CTS issue on spec changes

### DIFF
--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -1,0 +1,30 @@
+name: Open CTS issue for spec changes
+on: pull_request
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    # Skip if this is a purely editorial PR
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'editorial') }}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.SYCL_ISSUE_BOT_APP_ID }}
+          private-key: ${{ secrets.SYCL_ISSUE_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: "SYCL-CTS"
+      - name: Create Issue
+        uses: dacbd/create-issue-action@v2.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          owner: ${{ github.repository_owner }}
+          repo: SYCL-CTS
+          title: |
+            [Spec change] ${{ github.event.pull_request.title }}
+          # Assign person who opened PR
+          assignees: ${{ github.triggering_actor }}
+          body: |
+            Please review whether ${{ github.event.pull_request.html_url }} by @${{ github.triggering_actor }} requires any changes to the CTS.
+
+            **If changes are required**: Open a new PR addressing the changes and link it to this issue.
+            **If no changes are required**: Close this issue and proceed with the spec PR.


### PR DESCRIPTION
As discussed in a recent SYCL WG call, in order to avoid having the CTS and spec go out of sync, I'm proposing to introduce a CI workflow that automatically opens an issue in the SYCL-CTS repository whenever a spec pull request opened, unless it has the `editorial` label *upon creation*.

The issue has the title "[Spec change] <title of PR>", and looks like this: https://github.com/KhronosGroup/SYCL-CTS/issues/915

The message can simply be updated in the workflow file in this repository; it's relatively brief right now, let me know if you think it needs more information. I'm also assigning the author of the PR to the issue - not sure if that's something we want to do.

For future reference, here is how the whole thing is set up:

- In order to create a new issue in another repository we need an access token. The best way I've found to generate such a token is through a GitHub app with apropriate permissions.
  - The KhronosGroup organization is the owner of the [SYCL Issue Bot](https://github.com/apps/sycl-issue-bot) application, which @outofcontrol set up for me (thanks!).
  - The app only has access to the SYCL-Docs and SYCL-CTS repositories, and is only allowed to read/write issues.
- The app itself doesn't do anything at all. Instead, it is only used to generate a temporary token through the https://github.com/actions/create-github-app-token action as part of the workflow added in this PR.
  - To do so, the action requires the app's ID as well as a secret private key, both of which are provided as GitHub action variable/secret.
- Once the temporary token is generated, it can then be used by the [Create GitHub Issue Action](https://github.com/marketplace/actions/create-github-issue). Note that this is not an official GitHub action, and there are several other options available. I chose this one for its simplicity.