### PR TITLE
Fix typo in multi_ptr class name

### DIFF
--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -387,7 +387,7 @@ Changes in [code]#multi_ptr# interface:
   * [code]#global_ptr#, [code]#local_ptr# and [code]#private_ptr# alias take the
     new extra parameter;
   * addition of the [code]#address_space_cast# free function to cast undecorated
-    pointer to [code]#multi_pointer#;
+    pointer to [code]#multi_ptr#;
   * addition of construction/conversion operator for the generic address space;
   * removal of the constructor and assignment operator taking an unannotated
     pointer;


### PR DESCRIPTION
multi_pointer -> multi_ptr
