### PR TITLE
Typos in programming_interface.adoc

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18,7 +18,7 @@ The underlying types for all enumerations defined in this specification are
 implementation-defined.
 In addition, all enumerators within an enumeration have some
 implementation-defined unique value unless the specification specifically
-indicates a values for the enumerator.
+indicates a value for the enumerator.
 
 
 [[sec:backends]]
@@ -48,7 +48,7 @@ specification.
 === Backend macros
 
 As the identifiers defined in [code]#enum class backend# are
-implementation-defined, and the associated backends not guaranteed to be
+implementation-defined, and the associated backends are not guaranteed to be
 available, a SYCL implementation must also define a preprocessor macro for each
 of these identifiers.
 If the <<backend>> is defined by the Khronos SYCL group, the name of the macro
@@ -249,7 +249,7 @@ interoperability, a specialization of [code]#get_native# must be defined, which
 takes an instance of [code]#T# and returns a <<sycl-application>>
 interoperability <<native-backend-object>> associated with [code]#syclObject#
 which can be used for <<sycl-application>> interoperability.
-The lifetime of the object returned are backend-defined and specified in the
+The lifetime of the object returned is backend-defined and specified in the
 backend specification.
 
 For each <<sycl-runtime>> class [code]#T# which supports kernel function
@@ -257,7 +257,7 @@ interoperability, a specialization of [code]#get_native# must be defined, which
 takes an instance of [code]#T# and returns the kernel function interoperability
 <<native-backend-object>> associated with [code]#syclObject# which can be used
 for kernel function interoperability.
-The availability and behavior of these template functions is defined by the
+The availability and behavior of these template functions are defined by the
 <<backend>> specification document.
 
 The [code]#get_native# function must throw an [code]#exception# with the
@@ -277,7 +277,7 @@ interoperability, a specialization of the appropriate template function
 [code]#make_{sycl_class}# where [code]#{sycl_class}# is the class name of
 [code]#T#, must be defined, which takes a <<sycl-application>> interoperability
 <<native-backend-object>> and constructs and returns an instance of [code]#T#.
-The availability and behavior of these template functions is defined by the
+The availability and behavior of these template functions are defined by the
 <<backend>> specification document.
 
 Overloads of the [code]#make_{sycl_class}# function which take a SYCL
@@ -3842,14 +3842,14 @@ void wait_and_throw()
    a@ Blocks until all commands associated with this event and any dependent
       events have completed.
 
-At least all uncomsumed <<async-error,asynchronous errors>> held by queues (or
+At least all unconsumed <<async-error,asynchronous errors>> held by queues (or
 their associated contexts) which were used to enqueue commands associated with
-this event and any dependent events, are passed to the approriate
+this event and any dependent events, are passed to the appropriate
 <<async-handler>> as described in <<subsubsec:async.handler.priorities>>.
 
 [NOTE]
 ====
-This behaviour is equivalent to calling [code]#queue::throw_asynchronous()# on
+This behavior is equivalent to calling [code]#queue::throw_asynchronous()# on
 the queue associated with this event and any dependent events.
 ====
 
@@ -6512,7 +6512,7 @@ the accessor's range results in undefined behavior.
 ====
 There is no change in behavior for ranged accessors with a range of zero.
 It still creates a requisite for the entire underlying buffer, and an attempt to
-access an element produces undefined behaviour.
+access an element produces undefined behavior.
 ====
 
 ==== Buffer accessor for commands


### PR DESCRIPTION
- uncomsumed -> unconsumed
- approriate -> appropriate
-  behaviour -> behavior (just for consistency. We just got more instances of `behavior` than `behaviour`. Don't want to start a US versus UK war...)
- Some singular/plural thingy (`is` <-> `are`, `value` -> `values`)