### PR TITLE
Some editorial cleanup

### DIFF
--- a/adoc/config/attribs.adoc
+++ b/adoc/config/attribs.adoc
@@ -69,7 +69,3 @@ endif::backend-html5[]
 ifndef::backend-html5[]
 :wbro:
 endif::backend-html5[]
-
-// Placeholders for host synchronization block text
-:externsynctitle: Host Synchronization
-:externsyncprefix: Host access to

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -5,7 +5,7 @@
 // This should be set by the Makefile based on values in
 // ../sycl_version.txt, passed into the asciidoctor command line.
 :SYCL_LANGUAGE_VERSION: [red]#Unknown SYCL_LANGUAGE_VERSION!#
-:SYCL_NAMEA: [red]#Unknown SYCL_NAME!#
+:SYCL_NAME: [red]#Unknown SYCL_NAME!#
 :SYCL_VERSION: [red]#Unknown SYCL_VERSION!#
 :SYCL_REVISION: [red]#Unknown SYCL_REVISION!#
 
@@ -13,6 +13,21 @@
 // :regtitle: is explained in
 // http://discuss.asciidoctor.org/How-to-add-markup-to-author-information-in-document-title-td6488.html
 :regtitle: pass:q,r[^®^]
+
+// Disable the footer for the HTML render.  The footer for HTML is not well
+// documented in Asciidoc, but it appears to insert a line "Last updated <date>"
+// at the very bottom of the HTML where the <date> is the timestamp of the
+// "syclbase.adoc" file.  This date is confusing because it might be quite a bit
+// older than the last modification to the specification.  We already have the
+// specification date in the HTML header, which shows the timestamp when the
+// specification was built from Asciidoc sources.
+//
+// Note that we *do* want a footer in the PDF render, which contains completely
+// different content.  The PDF footer shows the page number and the current
+// chapter.
+ifdef::backend-html5[]
+:nofooter:
+endif::[]
 
 = {SYCL_NAME}{tmtitle} {SYCL_VERSION} Specification (revision {SYCL_REVISION})
 The Khronos{regtitle} {SYCL_NAME}{tmtitle} Working Group
@@ -110,7 +125,7 @@ toc::[]
 
 :leveloffset: 1
 
-include::chapters/acknowledgements.adoc[][]
+include::chapters/acknowledgements.adoc[]
 
 // \include{introduction}
 include::chapters/introduction.adoc[]


### PR DESCRIPTION
* Remove the footer from the HTML build, which contained a confusing date.

* Remove some unused Asciidoc attributes that I think we inherited from another project when we first copied our Asciidoc configuration files.

* Fix some minor bugs in the "syclbase.adoc" file.

I compared the HTML render, and the only change this introduces is due to the first bullet item above.  The HTML output no longer contains the line "Last updated" with a confusing date.