### PR TITLE
Only run CTS issue workflow when opening PRs; run on base branch

### DIFF
--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -8,6 +8,8 @@ on:
   # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information.
   pull_request_target:
     types: opened
+    paths:
+      - 'adoc/**'
 jobs:
   create-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -1,6 +1,12 @@
 name: Open CTS issue for spec changes
 on:
-  pull_request:
+  # We use the pull_request_target trigger to always run the workflow in the context of the base branch,
+  # since this allows us to access repository secrets even if the PR originates from a fork.
+  #
+  # Importantly, the workflow must not checkout any code from the PR branch, as this could allow an attacker
+  # to gain write access to the repository.
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information.
+  pull_request_target:
     types: opened
 jobs:
   create-issue:

--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -1,5 +1,7 @@
 name: Open CTS issue for spec changes
-on: pull_request
+on:
+  pull_request:
+    types: opened
 jobs:
   create-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Turns out](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request) the `pull_request` trigger by default also runs when PRs are updated or re-opened. Change to only run on the `opened` activity.

Additionally, I forgot that using the `pull_request` trigger doesn't allow the workflow to access repository secrets when the triggering PR originates from a fork. Thankfully there is a `pull_request_target` trigger to remedy this, which runs the workflow in the context of the base branch (i.e., changes to the workflow itself aren't executed). This is fine for our use case, as we don't need to access the PR's contents within the workflow.

~~(Side note: I marked this as `editorial` to not run the workflow - maybe we need another label for these kinds of infrastructure changes).~~ Edit: I've now limited the workflow to only run when changes are made inside the `adoc` directory.