### PR TITLE
Add missing `multi_ptr` aliases for `access::address_space::generic`

### DIFF
--- a/adoc/config/rouge/lib/rouge/lexers/sycl.rb
+++ b/adoc/config/rouge/lib/rouge/lexers/sycl.rb
@@ -312,6 +312,7 @@ module Rouge
         context_bound
         cpu_selector
         decorated_constant_ptr
+        decorated_generic_ptr
         decorated_global_ptr
         decorated_local_ptr
         decorated_private_ptr

--- a/adoc/headers/pointer.h
+++ b/adoc/headers/pointer.h
@@ -30,6 +30,11 @@ template <typename ElementType,
 using private_ptr =
     multi_ptr<ElementType, access::address_space::private_space, IsDecorated>;
 
+template <typename ElementType,
+          access::decorated IsDecorated = access::decorated::legacy>
+using generic_ptr =
+    multi_ptr<ElementType, access::address_space::generic_space, IsDecorated>;
+
 // Template specialization aliases for different pointer address spaces.
 // The interface exposes non-decorated pointer while keeping the
 // address space information internally.
@@ -48,6 +53,11 @@ using raw_private_ptr =
     multi_ptr<ElementType, access::address_space::private_space,
               access::decorated::no>;
 
+template <typename ElementType>
+using raw_generic_ptr =
+    multi_ptr<ElementType, access::address_space::generic_space,
+              access::decorated::no>;
+
 // Template specialization aliases for different pointer address spaces.
 // The interface exposes decorated pointer.
 
@@ -64,6 +74,11 @@ using decorated_local_ptr =
 template <typename ElementType>
 using decorated_private_ptr =
     multi_ptr<ElementType, access::address_space::private_space,
+              access::decorated::yes>;
+
+template <typename ElementType>
+using decorated_generic_ptr =
+    multi_ptr<ElementType, access::address_space::generic_space,
               access::decorated::yes>;
 
 } // namespace sycl


### PR DESCRIPTION
Add `[decorated_|raw_]generic_ptr` aliases definitions.

These aliases were previously mentioned in the
text (https://github.com/KhronosGroup/SYCL-Docs/blob/d314fbc9aead30704dd1f4d35db4b55b93bce7b0/adoc/chapters/architecture.adoc?plain=1#L1021), but their definitions were missing where their homologous are defined.