### PR TITLE
Undeprecate legacy multi_ptr

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9138,7 +9138,6 @@ For interoperability with the <<backend>>, users should rely on types exposed by
 the decorated version.
 If the value of [code]#access::decorated# is [code]#access::decorated::legacy#,
 the 1.2.1 interface is exposed.
-This interface is deprecated.
 
 The template traits [code]#remove_decoration# and type alias
 [code]#remove_decoration_t# retrieve the non-decorated pointer or reference from

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9846,10 +9846,6 @@ below.
 include::{header_dir}/pointer.h[lines=4..-1]
 ----
 
-Note that using [code]#global_ptr#, [code]#local_ptr#, [code]#constant_ptr# or
-[code]#private_ptr# without specifying the decoration is deprecated.
-The default argument is provided for compatibility with 1.2.1.
-
 
 [[subsec:samplers]]
 === Image samplers

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -381,7 +381,6 @@ Changes in [code]#multi_ptr# interface:
      Returned pointer and reference are not annotated by an address space;
   ** interface exposing decorated types.
      Returned pointer and reference are annotated by an address space;
-  ** legacy 1.2.1 interface (deprecated).
   * deprecation of the 1.2.1 interface;
   * deprecation of [code]#constant_ptr#;
   * [code]#global_ptr#, [code]#local_ptr# and [code]#private_ptr# alias take the

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -15,7 +15,7 @@ enum class address_space : /* unspecified */ {
 enum class decorated : /* unspecified */ {
   no,
   yes,
-  legacy // Deprecated in SYCL 2020
+  legacy
 };
 
 } // namespace access

--- a/adoc/headers/multipointerlegacy.h
+++ b/adoc/headers/multipointerlegacy.h
@@ -4,7 +4,6 @@
 namespace sycl {
 
 // Legacy interface, inherited from 1.2.1.
-// Deprecated.
 template <typename ElementType, access::address_space Space>
 class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
  public:
@@ -162,7 +161,6 @@ class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
 };
 
 // Legacy interface, inherited from 1.2.1.
-// Deprecated.
 // Specialization of multi_ptr for void and const void
 // VoidType can be either void or const void
 template <access::address_space Space>


### PR DESCRIPTION
The legacy decoration for multi_ptr has been made the default template argument of the decoration in multi_ptr to bridge the gap between SYCL 1.2.1 and SYCL 2020 multi_ptr interfaces. However, the legacy decoration and the specialization of multi_ptr with the decoration is deprecated with SYCL 2020. This is confusing to users as they may easily run into deprecation warnings simply due to not specifying the decoration. This commit proposes that we remove the deprecation of legacy in SYCL 2020.