### PR TITLE
Remove info::platform::profile from the header

### DIFF
--- a/adoc/headers/platformInfo.h
+++ b/adoc/headers/platformInfo.h
@@ -5,7 +5,6 @@ namespace sycl {
 namespace info {
 namespace platform {
 
-struct profile;
 struct version;
 struct name;
 struct vendor;


### PR DESCRIPTION
It is never described in the spec.
Alternatively, we could bring the description in the spec back and mark it deprecated.