### PR TITLE
CTS issue workflow: Don't assign PR author to issue

### DIFF
--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -31,8 +31,6 @@ jobs:
           repo: SYCL-CTS
           title: |
             [Spec change] ${{ github.event.pull_request.title }}
-          # Assign person who opened PR
-          assignees: ${{ github.triggering_actor }}
           body: |
             Please review whether ${{ github.event.pull_request.html_url }} by @${{ github.triggering_actor }} requires any changes to the CTS.
 


### PR DESCRIPTION
The workflow may fail when trying to assign a person that is not a member of the @KhronosGroup organization to the CTS issue, as can be seen [in this run](https://github.com/KhronosGroup/SYCL-Docs/actions/runs/10559189740/attempts/1) for #608. Unfortunately there is no simple way of detecting this in advance, so I think we have to instead remove the assignment mechanism altogether.