### PR TITLE
Deprecate fallback/secondary queue.

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1518,6 +1518,8 @@ queue.
 The situations where a SYCL runtime may be able to achieve this asynchronous
 fall-back is implementation-defined.
 
+This feature is deprecated in SYCL NEXT.
+
 === Scheduling of kernels and data movement
 
 A <<command-group-function-object>> takes a reference to a command group

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -406,6 +406,7 @@ supported by both the primary queue's device and the secondary queue's device.
 If an application fails to do this, the implementation must throw a synchronous
 exception with the [code]#errc::kernel_not_supported# error code from the
 <<kernel-invocation-command>> (e.g. [code]#parallel_for()#).
+The secondary queue feature is deprecated in SYCL NEXT.
 
 It is legal for a SYCL application to define several kernels in the same
 translation unit even if they use different optional features, as shown in the
@@ -605,7 +606,8 @@ Specifying this attribute on a kernel has two effects.  First, it causes the
 [code]#errc::kernel_not_supported# error code if the kernel is submitted to a
 device that does not have one of the listed aspects.  (This includes the device
 associated with the secondary queue if the kernel is submitted from a
-<<command-group>> that has a secondary queue.)  Second, it causes the compiler
+<<command-group>> that has a secondary queue, which is deprecated in SYCL NEXT.)
+Second, it causes the compiler
 to issue a diagnostic if the kernel (or any of the functions it calls) uses an
 optional feature that is associated with an aspect that is not listed in the
 attribute.

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -406,7 +406,6 @@ supported by both the primary queue's device and the secondary queue's device.
 If an application fails to do this, the implementation must throw a synchronous
 exception with the [code]#errc::kernel_not_supported# error code from the
 <<kernel-invocation-command>> (e.g. [code]#parallel_for()#).
-The secondary queue feature is deprecated in SYCL NEXT.
 
 It is legal for a SYCL application to define several kernels in the same
 translation unit even if they use different optional features, as shown in the
@@ -606,8 +605,7 @@ Specifying this attribute on a kernel has two effects.  First, it causes the
 [code]#errc::kernel_not_supported# error code if the kernel is submitted to a
 device that does not have one of the listed aspects.  (This includes the device
 associated with the secondary queue if the kernel is submitted from a
-<<command-group>> that has a secondary queue, which is deprecated in SYCL NEXT.)
-Second, it causes the compiler
+<<command-group>> that has a secondary queue.)  Second, it causes the compiler
 to issue a diagnostic if the kernel (or any of the functions it calls) uses an
 optional feature that is associated with an aspect that is not listed in the
 attribute.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4631,8 +4631,7 @@ the implementation to throw an [code]#exception# with the [code]#errc::invalid#
 error code from the [code]#accessor# constructor (if the accessor is not a
 placeholder) or from [code]#handler::require()# (if the accessor is a
 placeholder).  If the accessor is bound to a <<command-group>> with a secondary
-queue (deprecated in SYCL NEXT), the sub-buffer's alignment must be
-compatible with both the primary
+queue, the sub-buffer's alignment must be compatible with both the primary
 queue's device and the secondary queue's device, otherwise this exception is
 thrown.
 
@@ -13690,8 +13689,7 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified - this feature is deprecated
-in SYCL NEXT).
+associated with the secondary queue (if specified).
 
 a@
 [source]
@@ -13713,8 +13711,7 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified - this feature is deprecated
-in SYCL NEXT).
+associated with the secondary queue (if specified).
 
 a@
 [source]
@@ -13741,8 +13738,7 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified - this feature is deprecated
-in SYCL NEXT).
+associated with the secondary queue (if specified).
 
 |====
 
@@ -14370,10 +14366,10 @@ If the <<command-group>> attempts to invoke a kernel that is not contained by a
 compatible device image in [code]#execBundle#, the <<kernel-invocation-command>>
 throws a synchronous [code]#exception# with the
 [code]#errc::kernel_not_supported# error code.
-If the <<command-group>> has a secondary queue (feature deprecated in SYCL
-NEXT), then the [code]#execBundle# must contain a kernel that is compatible with
-both the primary queue's device and the secondary queue's device, otherwise the
-<<kernel-invocation-command>> throws this exception.
+If the <<command-group>> has a secondary queue, then the [code]#execBundle# must
+contain a kernel that is compatible with both the primary queue's device and the
+secondary queue's device, otherwise the <<kernel-invocation-command>> throws
+this exception.
 
 Since the handler method for setting specialization constants is incompatible
 with the kernel bundle method, applications should not call this function if
@@ -14385,9 +14381,8 @@ _Throws:_
   * An [code]#exception# with the [code]#errc::invalid# error code if the
     <<context>> associated with the <<handler>> via its associated primary
     <<queue>> or the <<context>> associated with the secondary <<queue>> (if
-    provided - this feature is deprecated in SYCL NEXT) is different from the
-    <<context>> associated with the <<kernel-bundle>> specified by
-    [code]#execBundle#.
+    provided) is different from the <<context>> associated with the
+    <<kernel-bundle>> specified by [code]#execBundle#.
 
   * An [code]#exception# with the [code]#errc::invalid# error code if
     [code]#handler::set_specialization_constant()# has been called for this
@@ -14818,9 +14813,9 @@ code if [code]#Backend != get_backend()#.
 --
 _Returns:_ The <<native-backend-object>> associated with the <<queue>> that the
 <<host-task>> was submitted to.
-If the <<command-group>> was submitted with a secondary <<queue>> (feature
-deprecated in SYCL NEXT) and the fall-back was triggered, the <<queue>> that is
-associated with the [code]#interop_handle# must be the fall-back <<queue>>.
+If the <<command-group>> was submitted with a secondary <<queue>> and the
+fall-back was triggered, the <<queue>> that is associated with the
+[code]#interop_handle# must be the fall-back <<queue>>.
 The <<native-backend-object>> returned must be in a state where it is capable of
 being used in a way appropriate for the associated <<backend>>.
 It is undefined behavior to use the <<native-backend-object>> outside of the

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3230,7 +3230,8 @@ a@
 ----
 template <typename T> event submit(T cgf, queue& secondaryQueue)
 ----
-a@ Submit a <<command-group-function-object>> to the queue, in order to be scheduled
+a@ Deprecated in SYCL NEXT.
+Submit a <<command-group-function-object>> to the queue, in order to be scheduled
 for execution on the device. On a kernel error, this <<command-group-function-object>>
 is then scheduled for execution on the secondary queue. Returns an
 event, which corresponds to the queue the <<command-group-function-object>>
@@ -4630,7 +4631,8 @@ the implementation to throw an [code]#exception# with the [code]#errc::invalid#
 error code from the [code]#accessor# constructor (if the accessor is not a
 placeholder) or from [code]#handler::require()# (if the accessor is a
 placeholder).  If the accessor is bound to a <<command-group>> with a secondary
-queue, the sub-buffer's alignment must be compatible with both the primary
+queue (deprecated in SYCL NEXT), the sub-buffer's alignment must be
+compatible with both the primary
 queue's device and the secondary queue's device, otherwise this exception is
 thrown.
 
@@ -13382,6 +13384,7 @@ fall-back from primary to secondary queue are unspecified in the specification.
 Even if a command group is run on the secondary queue, the requirement that host
 code within the command group is executed exactly once remains, regardless of
 whether the fallback queue is used for execution.
+The fallback queue feature is deprecated in SYCL NEXT.
 
 The command group [code]#handler# class provides the interface for all of the
 member functions that are able to be executed inside the command group scope,
@@ -13687,7 +13690,8 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+associated with the secondary queue (if specified - this feature is deprecated
+in SYCL NEXT).
 
 a@
 [source]
@@ -13709,7 +13713,8 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+associated with the secondary queue (if specified - this feature is deprecated
+in SYCL NEXT).
 
 a@
 [source]
@@ -13736,7 +13741,8 @@ implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
 code if the [code]#kernelObject# is not compatible with either the device
 associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+associated with the secondary queue (if specified - this feature is deprecated
+in SYCL NEXT).
 
 |====
 
@@ -14364,10 +14370,10 @@ If the <<command-group>> attempts to invoke a kernel that is not contained by a
 compatible device image in [code]#execBundle#, the <<kernel-invocation-command>>
 throws a synchronous [code]#exception# with the
 [code]#errc::kernel_not_supported# error code.
-If the <<command-group>> has a secondary queue, then the [code]#execBundle# must
-contain a kernel that is compatible with both the primary queue's device and the
-secondary queue's device, otherwise the <<kernel-invocation-command>> throws
-this exception.
+If the <<command-group>> has a secondary queue (feature deprecated in SYCL
+NEXT), then the [code]#execBundle# must contain a kernel that is compatible with
+both the primary queue's device and the secondary queue's device, otherwise the
+<<kernel-invocation-command>> throws this exception.
 
 Since the handler method for setting specialization constants is incompatible
 with the kernel bundle method, applications should not call this function if
@@ -14379,8 +14385,9 @@ _Throws:_
   * An [code]#exception# with the [code]#errc::invalid# error code if the
     <<context>> associated with the <<handler>> via its associated primary
     <<queue>> or the <<context>> associated with the secondary <<queue>> (if
-    provided) is different from the <<context>> associated with the
-    <<kernel-bundle>> specified by [code]#execBundle#.
+    provided - this feature is deprecated in SYCL NEXT) is different from the
+    <<context>> associated with the <<kernel-bundle>> specified by
+    [code]#execBundle#.
 
   * An [code]#exception# with the [code]#errc::invalid# error code if
     [code]#handler::set_specialization_constant()# has been called for this
@@ -14811,9 +14818,9 @@ code if [code]#Backend != get_backend()#.
 --
 _Returns:_ The <<native-backend-object>> associated with the <<queue>> that the
 <<host-task>> was submitted to.
-If the <<command-group>> was submitted with a secondary <<queue>> and the
-fall-back was triggered, the <<queue>> that is associated with the
-[code]#interop_handle# must be the fall-back <<queue>>.
+If the <<command-group>> was submitted with a secondary <<queue>> (feature
+deprecated in SYCL NEXT) and the fall-back was triggered, the <<queue>> that is
+associated with the [code]#interop_handle# must be the fall-back <<queue>>.
 The <<native-backend-object>> returned must be in a state where it is capable of
 being used in a way appropriate for the associated <<backend>>.
 It is undefined behavior to use the <<native-backend-object>> outside of the
@@ -16576,6 +16583,8 @@ context will be used and if the context was also constructed without an
 <<async-handler>>, then the default handler will be used.
 The <<command-group-function-object>> event returned by that function will be
 relevant to the queue where the kernel has been enqueued.
+
+The secondary queue feature is deprecated in SYCL NEXT.
 
 Below is an example of catching a SYCL [code]#exception# and printing out the
 error message.

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -4,7 +4,11 @@
 [[cha:what-changed-from]]
 = What has changed from previous versions
 
-[[sec:what-changed-between]]
+== What has changed from SYCL 2020 to SYCL NEXT
+
+  * The overload with a fallback/secondary queue parameter of the
+    [code]#submit()# member function of [code]#sycl::queue# was deprecated.
+
 == What has changed from SYCL 1.2.1 to SYCL 2020
 
 The SYCL runtime moved from namespace [code]#cl::sycl# provided by

--- a/adoc/headers/queue.h
+++ b/adoc/headers/queue.h
@@ -60,6 +60,7 @@ class queue {
 
   template <typename T> event submit(T cgf);
 
+  // Deprecated in SYCL NEXT.
   template <typename T> event submit(T cgf, const queue& secondaryQueue);
 
   void wait();


### PR DESCRIPTION
At the F2F in Brussels there was general agreement to deprecate the fallback/secondary queue feature. SYCL SC will likely be removing it.

This corresponds to internal MR 754