### PR TITLE
Clarify default context behavior

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -969,8 +969,12 @@ The [code]#platform# class also provides constructors, but constructing a new
 [code]#platform# instance merely creates a new object that is a copy of one of
 the objects returned by [api]#platform::get_platforms#.
 
-Each platform has a single context object which is used as its default context.
-That context object contains all of the devices in the platform.
+Each platform has a default context which contains all of the devices in the
+platform and has no associated asynchronous error handler.
+Applications can retrieve a copy of this default `context` object, for example,
+by constructing a `queue`.
+These copies follow the common reference semantics, as though they are all copies
+of a single internal `context` object that is held by each platform.
 
 The [code]#platform# class provides the common reference semantics as defined in
 <<sec:reference-semantics>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -969,12 +969,14 @@ The [code]#platform# class also provides constructors, but constructing a new
 [code]#platform# instance merely creates a new object that is a copy of one of
 the objects returned by [api]#platform::get_platforms#.
 
-Each platform has a default context which contains all of the devices in the
-platform and has no associated asynchronous error handler.
+Each platform has an associated default context which contains all of the
+devices in the platform.
+This default context does not have an asynchronous error handler.
 Applications can retrieve a copy of this default `context` object, for example,
 by constructing a `queue`.
 These copies follow the common reference semantics, as though they are all
-copies of a single internal `context` object that is held by each platform.
+copies of an internal per-platform `context` object representing the platform's
+default context.
 
 The [code]#platform# class provides the common reference semantics as defined in
 <<sec:reference-semantics>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -973,8 +973,8 @@ Each platform has a default context which contains all of the devices in the
 platform and has no associated asynchronous error handler.
 Applications can retrieve a copy of this default `context` object, for example,
 by constructing a `queue`.
-These copies follow the common reference semantics, as though they are all copies
-of a single internal `context` object that is held by each platform.
+These copies follow the common reference semantics, as though they are all
+copies of a single internal `context` object that is held by each platform.
 
 The [code]#platform# class provides the common reference semantics as defined in
 <<sec:reference-semantics>>.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -970,7 +970,7 @@ The [code]#platform# class also provides constructors, but constructing a new
 the objects returned by [api]#platform::get_platforms#.
 
 Each platform has an associated default context which contains all of the
-devices in the platform.
+<<root-device,root devices>> in the platform.
 This default context does not have an asynchronous error handler.
 Applications can retrieve a copy of this default `context` object, for example,
 by constructing a `queue`.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -969,6 +969,9 @@ The [code]#platform# class also provides constructors, but constructing a new
 [code]#platform# instance merely creates a new object that is a copy of one of
 the objects returned by [api]#platform::get_platforms#.
 
+Each platform has a single context object which is used as its default context.
+That context object contains all of the devices in the platform.
+
 The [code]#platform# class provides the common reference semantics as defined in
 <<sec:reference-semantics>>.
 
@@ -2936,16 +2939,6 @@ passing <<async-error,asynchronous errors>> at specific times to an
 The application can wait for all <<command-group,command groups>> submitted to a
 queue calling [api]#queue::wait# or [api]#queue::wait_and_throw#.
 
-All [code]#queue# objects have an associated device, platform, and context which
-are determined by the constructor.
-The description of each constructor below tells how the device is chosen, and
-the platform is always the platform that contains this device.
-The description of each constructor also tells how the context is chosen.
-When the constructor does not take a context object as a parameter, the queue
-uses the platform's default context.
-Each platform has a single context object which is used as its default context,
-and that context object contains all of the devices in the platform.
-
 A queue may be destroyed even when there are uncompleted <<command, commands>>
 that have been submitted to the queue.
 Doing so does not block.
@@ -2985,7 +2978,9 @@ explicit queue(const property_list& propList = {})
 
 _Effects:_ Constructs a [code]#queue# object using the device selected by
 [code]#default_selector_v#.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 
 '''
 
@@ -2998,7 +2993,9 @@ explicit queue(const async_handler& asyncHandler,
 
 _Effects:_ Constructs a [code]#queue# object using the device selected by
 [code]#default_selector_v#.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''
@@ -3018,7 +3015,9 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 
 '''
 
@@ -3038,7 +3037,9 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''
@@ -3051,7 +3052,9 @@ explicit queue(const device& syclDevice, const property_list& propList = {})
 
 _Effects:_ Constructs a [code]#queue# object using the device
 [code]#syclDevice#.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 
 '''
 
@@ -3064,7 +3067,9 @@ explicit queue(const device& syclDevice, const async_handler& asyncHandler,
 
 _Effects:_ Constructs a [code]#queue# object using the device
 [code]#syclDevice#.
-The queue has the default context of the platform that contains this device.
+The queue's platform is the platform that contains this device.
+The queue's context is this platform's default context as described in
+<<sec:platform-class>>.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''
@@ -3084,7 +3089,8 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
-The queue has the context [code]#syclContext#.
+The queue's platform is the platform that contains this device.
+The queue's context is [code]#syclContext#.
 
 _Throws:_ An [code]#exception# with the [code]#errc::invalid# error code if
 [code]#syclContext# does not contain the device selected by
@@ -3108,8 +3114,9 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
-The queue has the context [code]#syclContext# and the asynchronous error handler
-[code]#asyncHandler#.
+The queue's platform is the platform that contains this device.
+The queue's context is [code]#syclContext#.
+The queue has the asynchronous error handler [code]#asyncHandler#.
 
 _Throws:_ An [code]#exception# with the [code]#errc::invalid# error code if
 [code]#syclContext# does not contain the device selected by
@@ -3124,8 +3131,10 @@ explicit queue(const context& syclContext, const device& syclDevice,
                const property_list& propList = {})
 ----
 
-_Effects:_ Constructs a [code]#queue# object using the device [code]#syclDevice#
-and the context [code]#syclContext#.
+_Effects:_ Constructs a [code]#queue# object using the device
+[code]#syclDevice#.
+The queue's platform is the platform that contains this device.
+The queue's context is [code]#syclContext#.
 
 _Throws:_ An [code]#exception# with the [code]#errc::invalid# error code unless
 [code]#syclDevice# is contained by [code]#syclContext# or is a
@@ -3141,8 +3150,10 @@ explicit queue(const context& syclContext, const device& syclDevice,
                const property_list& propList = {})
 ----
 
-_Effects:_ Constructs a [code]#queue# object using the device [code]#syclDevice#
-and the context [code]#syclContext#.
+_Effects:_ Constructs a [code]#queue# object using the device
+[code]#syclDevice#.
+The queue's platform is the platform that contains this device.
+The queue's context is [code]#syclContext#.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 _Throws:_ An [code]#exception# with the [code]#errc::invalid# error code unless

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2936,9 +2936,15 @@ passing <<async-error,asynchronous errors>> at specific times to an
 The application can wait for all <<command-group,command groups>> submitted to a
 queue calling [api]#queue::wait# or [api]#queue::wait_and_throw#.
 
-All constructors of the [code]#queue# class implicitly construct a
-[code]#platform#, [code]#device#, and [code]#context# in order to facilitate the
-construction of the queue.
+All [code]#queue# objects have an associated device, platform, and context which
+are determined by the constructor.
+The description of each constructor below tells how the device is chosen, and
+the platform is always the platform that contains this device.
+The description of each constructor also tells how the context is chosen.
+When the constructor does not take a context object as a parameter, the queue
+uses the platform's default context.
+Each platform has a single context object which is used as its default context,
+and that context object contains all of the devices in the platform.
 
 A queue may be destroyed even when there are uncompleted <<command, commands>>
 that have been submitted to the queue.
@@ -2979,6 +2985,7 @@ explicit queue(const property_list& propList = {})
 
 _Effects:_ Constructs a [code]#queue# object using the device selected by
 [code]#default_selector_v#.
+The queue has the default context of the platform that contains this device.
 
 '''
 
@@ -2991,6 +2998,7 @@ explicit queue(const async_handler& asyncHandler,
 
 _Effects:_ Constructs a [code]#queue# object using the device selected by
 [code]#default_selector_v#.
+The queue has the default context of the platform that contains this device.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''
@@ -3010,6 +3018,7 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
+The queue has the default context of the platform that contains this device.
 
 '''
 
@@ -3029,6 +3038,7 @@ satisfies the requirements of a <<device-selector>> as defined in
 _Effects:_ The [code]#deviceSelector# is called for every <<root-device>> as
 described in <<sec:device-selector>>, and a [code]#queue# object is constructed
 using the device it selects.
+The queue has the default context of the platform that contains this device.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''
@@ -3041,6 +3051,7 @@ explicit queue(const device& syclDevice, const property_list& propList = {})
 
 _Effects:_ Constructs a [code]#queue# object using the device
 [code]#syclDevice#.
+The queue has the default context of the platform that contains this device.
 
 '''
 
@@ -3053,6 +3064,7 @@ explicit queue(const device& syclDevice, const async_handler& asyncHandler,
 
 _Effects:_ Constructs a [code]#queue# object using the device
 [code]#syclDevice#.
+The queue has the default context of the platform that contains this device.
 The queue has the asynchronous error handler [code]#asyncHandler#.
 
 '''


### PR DESCRIPTION
Clarify that the `queue` constructors that do not take a `context` parameter use the platform's default context.

The WG decided to make this as a clarification to the SYCL 2020 specification because:

* DPC++ has always behaved this way, and AdaptiveCpp mostly behaves this way now.

* It would be difficult to enable this as an extension because it doesn't add any new API.  Therefore, an application could end up relying on the "default context" behavior without the author of the application even being aware that the application is using extended behavior.