### PR TITLE
Clarify and deprecate "execution_capabilities"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2748,12 +2748,19 @@ struct execution_capabilities {
 } // namespace sycl::info::device
 ----
 
+Deprecated by SYCL {SYCL_VERSION}.
+
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
-_Returns:_ A [code]#std::vector# of the [api]#info::execution_capability# values
+_Returns:_ Only supported when the backend of this device is OpenCL (see
+<<chapter:opencl-backend>>).
+Returns a [code]#std::vector# of the [api]#info::execution_capability# values
 describing the supported execution capabilities.
-Note that this information is intended for OpenCL interoperability only as SYCL
-only supports [api]#info::execution_capability::exec_kernel#.
+Unless the device type is [api]#info::device_type::custom#, the returned vector
+will always include [api]#info::execution_capability::exec_kernel#.
+
+_Throws:_ An [code]#exception# with the [code]#errc::invalid# error code if the
+backend of this device is not OpenCL.
 
 '''
 
@@ -3658,6 +3665,11 @@ enum class global_mem_cache_type : /* unspecified */ {
 [[sec:device-enum-execution-capability]]
 ===== Execution capability
 
+Deprecated by SYCL {SYCL_VERSION}.
+
+The [code]#info::execution_capability# enumeration tells the type of kernels
+that can be submitted to a device from the OpenCL backend.
+
 [source,role=synopsis]
 ----
 namespace sycl::info {
@@ -3667,6 +3679,24 @@ enum class execution_capability : /* unspecified */ {
 };
 } // namespace sycl::info
 ----
+
+'''
+
+.[apidef]#info::execution_capability::exec_kernel#
+[role=synopsis,id=api:info-execution-capability-exec-kernel]
+--
+Device can execute SYCL kernels.
+--
+
+'''
+
+.[apidef]#info::execution_capability::exec_native_kernel#
+[role=synopsis,id=api:info-execution-capability-exec-native-kernel]
+--
+Device can execute native OpenCL kernels.
+--
+
+'''
 
 
 [[sec:interface.queue.class]]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2748,7 +2748,7 @@ struct execution_capabilities {
 } // namespace sycl::info::device
 ----
 
-Deprecated by SYCL {SYCL_VERSION}.
+Deprecated by SYCL 2020.
 
 _Remarks:_ Template parameter to [api]#device::get_info#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3665,7 +3665,7 @@ enum class global_mem_cache_type : /* unspecified */ {
 [[sec:device-enum-execution-capability]]
 ===== Execution capability
 
-Deprecated by SYCL {SYCL_VERSION}.
+Deprecated by SYCL 2020.
 
 The [code]#info::execution_capability# enumeration tells the type of kernels
 that can be submitted to a device from the OpenCL backend.

--- a/adoc/config/api_xrefs.adoc
+++ b/adoc/config/api_xrefs.adoc
@@ -15,7 +15,6 @@
   info::device_type::custom=sec:device-enum-device-type \
   info::device_type::all=sec:device-enum-device-type \
   info::execution_capability=sec:device-enum-execution-capability \
-  info::execution_capability::exec_kernel=sec:device-enum-execution-capability \
   info::fp_config=sec:device-enum-fp-config \
   info::global_mem_cache_type=sec:device-enum-global-mem-cache-type \
   info::local_mem_type=sec:device-enum-local-mem-type \


### PR DESCRIPTION
We had a customer bug report about the behavior of `info::device::execution_capabilities` for non-OpenCL devices.  It turns out that the spec isn't clear about this.  This PR clarifies that an exception should be thrown, which is consistent with our behavior for `info::device::profile` and `info::device::preferred_interop_user_sync`, which are also inherited from OpenCL.  Another option would be to return an empty vector, so we could debate that if people think that's better.

I also think we should deprecate this query, which is consistent with the other queries that are specific to the OpenCL backend.  This PR deprecates the query in SYCL-NEXT, though I would also be open to retroactively deprecating it in SYCL 2020 with the rationale that we deprecated the other OpenCL-specific queries and simply forgot this one.