### PR TITLE
Unify `group` code snippet with other non-user-constructible classes

### DIFF
--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -10,6 +10,8 @@ template <int Dimensions = 1> class group {
   static constexpr int dimensions = Dimensions;
   static constexpr memory_scope fence_scope = memory_scope::work_group;
 
+  group() = delete;
+
   /* -- common interface members -- */
 
   id<Dimensions> get_group_id() const;


### PR DESCRIPTION
`group` is not user-constructible, but explicit information about its constructors was missing from the code snippet.