### PR TITLE
Add shorthand aliases for address spaces

### DIFF
--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -9,6 +9,10 @@
   * The overload with a fallback/secondary queue parameter of the
     [code]#submit()# member function of [code]#sycl::queue# was deprecated.
 
+  * Added shorthand aliases for address spaces to reduce verbosity, enabling
+    (for example) [code]#sycl::access::address_space::global_space# to be
+    replaced with [code]#sycl::global_space#.
+
 == What has changed from SYCL 1.2.1 to SYCL 2020
 
 The SYCL runtime moved from namespace [code]#cl::sycl# provided by

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -20,6 +20,12 @@ enum class decorated : /* unspecified */ {
 
 } // namespace access
 
+// Shorthand aliases for address spaces
+constexpr inline access::address_space global_space = access::address_space::global_space;
+constexpr inline access::address_space local_space = access::address_space::local_space;
+constexpr inline access::address_space private_space = access::address_space::private_space;
+constexpr inline access::address_space generic_space = access::address_space::generic_space;
+
 template <typename T> struct remove_decoration {
   using type = /* ... */;
 };


### PR DESCRIPTION
Working with address spaces (e.g., when using address space casts) was previously very verbose. Defining shorthands allows long values like `sycl::access::address_space::global_space` to be replaced by much shorter values like `sycl::global_space`.