### PR TITLE
Alphabetize m before n in glossary

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -339,6 +339,11 @@ For the full description please refer to <<subsec:buffers>>.
     Local memory is a memory region associated with a <<work-group>> and
     accessible only by <<work-item,work-items>> in that <<work-group>>.
 
+[[mem-fence]]mem-fence::
+    A memory fence provides control over re-ordering of memory load and store
+    operations when coupled with an atomic operation.
+    See the definition of the [code]#sycl::atomic_fence# function.
+
 [[native-backend-object]]native backend object::
     An opaque object defined by a specific backend that represents a high-level
     SYCL object on said backend.
@@ -369,11 +374,6 @@ For the full description please refer to <<subsec:buffers>>.
     be zero.
     In the SYCL interface an <<nd-range>> is represented by the [code]#nd_range#
     class (see <<subsubsec:nd-range-class>>).
-
-[[mem-fence]]mem-fence::
-    A memory fence provides control over re-ordering of memory load and store
-    operations when coupled with an atomic operation.
-    See the definition of the [code]#sycl::atomic_fence# function.
 
 [[object]]object::
     A state which a <<kernel-bundle>> can be in, representing


### PR DESCRIPTION
Move `mem-fence` definition to before `native-backend-object`.