### PR TITLE
Fix error behavior for initialize_to_identity

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13892,9 +13892,10 @@ property::reduction::initialize_to_identity
       identity value passed to the reduction interface, or to the identity
       value determined by the [code]#known_identity# trait if no identity value
       was specified. If no identity value was specified and an identity value
-      cannot be determined by the [code]#known_identity# trait, the compiler
-      must raise a diagnostic. When this property is set, the original value of
-      the reduction variable is not included in the reduction.
+      cannot be determined by the [code]#known_identity# trait, the
+      implementation must throw an [code]#exception# with the
+      [code]#errc::invalid# error code. When this property is set, the original
+      value of the reduction variable is not included in the reduction.
 
 |====
 


### PR DESCRIPTION
Previously, the specification said that a compiler must issue a diagnostic if the `initialize_to_identity` property was used without a known identity value. This requirement cannot be satisfied, because the presence of the `initialize_to_identity` value in a `property_list` cannot be proven until run-time.

This change replaces the compile-time diagnostic with a run-time exception.