### PR TITLE
Un-capitalize some middle words in headings

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1389,7 +1389,7 @@ implementation-defined.
 
 
 [[sec:coordination]]
-=== Coordination and Synchronization
+=== Coordination and synchronization
 
 Coordination between the host and any devices can be expressed in the host SYCL
 application using calls into the SYCL runtime.
@@ -1403,7 +1403,7 @@ Such functions can be used to ensure that the host and any devices do not access
 data concurrently, and/or to reason about the ordering of operations across the
 host and any devices.
 
-==== Host-Device Coordination
+==== Host-device coordination
 
 The following operations can be used to coordinate host and device(s):
 
@@ -1456,7 +1456,7 @@ So it is up to the programmer to use a member function to wait for completion in
 some cases if this does not fit the goal.
 See <<sec:managing-object-lifetimes>> for more information on object life time.
 
-==== Work-item Coordination
+==== Work-item coordination
 
 A <<group-barrier>> provides a mechanism to coordinate all work-items in the
 same group.


### PR DESCRIPTION
Cherry pick #647 from main
(cherry picked from commit f520589397ed58c02a14a7ebbe73f351c002a2af)