### PR TITLE
Fix a typo in `multi_ptr::operator=` documentation

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10135,7 +10135,7 @@ operator=(const multi_ptr<value_type, AS, IsDecorated>&)
 ----
    a@ Available only when: [code]#(Space == access::address_space::generic_space && AS != access::address_space::constant_space)#.
 
-Assigns the value of the left hand side [code]#multi_ptr# into the [code]#generic_ptr#.
+Assigns the value of the right hand side [code]#multi_ptr# into the [code]#generic_ptr#.
 
 a@
 [source]
@@ -10148,7 +10148,7 @@ operator=(multi_ptr<value_type, AS, IsDecorated>&&)
    a@ Available only when:
       [code]#(Space == access::address_space::generic_space && AS != access::address_space::constant_space)#.
 
-Move the value of the left hand side [code]#multi_ptr# into the [code]#generic_ptr#.
+Move the value of the right hand side [code]#multi_ptr# into the [code]#generic_ptr#.
 
 a@
 [source]


### PR DESCRIPTION
Cherry pick #642 from sycl-2020
(cherry picked from commit 05469ac562242d171fc87c42d77dea23739573e2)