### PR TITLE
Allow any manifestly constant-evaluated expression and conversion in device function

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -205,6 +205,16 @@ Amongst other things, this restriction makes it illegal for a
     implementation defines the [code]#SYCL_EXTERNAL# macro as described in
     <<subsec:syclexternal>>.
 
+Inside a <<discarded-statement>> or in the case of a
+<<manifestly-constant-evaluated>>, any code accepted by the C++ standard in this
+case is also accepted in a SYCL <<device-function>>.
+
+[NOTE]
+====
+The restriction waiver in <<discarded-statement>> or
+<<manifestly-constant-evaluated>> allows any kind of meta-programming in a
+<<device-function>>.
+====
 
 [[subsec:scalartypes]]
 == Built-in scalar data types
@@ -377,8 +387,17 @@ in <<sec:backends>> must be defined by all conformant implementations.
 
 A number of kernel features defined by this SYCL specification are optional;
 they may be supported on some devices but not on other devices.
+
+As stated in <<sec:language.restrictions.kernels>>, the restrictions for
+optional kernel features do not apply to discarded statements or to manifestly
+constant-evaluated expressions or conversions in device code.
+Device code may use optional features in <<discarded-statement>> or
+<<manifestly-constant-evaluated>> even if the device does not support the
+optional feature.
+
 As described in <<sec:device-aspects>>, an application can test whether a device
-supports these features by testing whether the device has an associated aspect.
+supports an optional feature by testing whether the device has an associated
+aspect.
 The following aspects are those that correspond to optional kernel features:
 
   * [code]#fp16#

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -188,6 +188,12 @@ For the full description please refer to <<subsec:buffers>>.
     One of the device with the highest non-negative value is selected.
     See <<sec:device-selector>> for more details.
 
+[[discarded-statement]]discarded statement::
+    ISO C++ +[stmt.if]+ describes a discarded statement as the branch statement
+    of an [code]#if constexpr# which is not instantiated because of the boolean
+    condition.
+    For more context, see <<sec:language.restrictions.kernels>>.
+
 [[event]]event::
     A SYCL object that represents the status of an operation that is being
     executed by the SYCL runtime.
@@ -339,6 +345,14 @@ For the full description please refer to <<subsec:buffers>>.
     Local memory is a memory region associated with a <<work-group>> and
     accessible only by <<work-item,work-items>> in that <<work-group>>.
 
+[[manifestly-constant-evaluated]]manifestly constant-evaluated expression or conversion::
+    ISO C++ +[expr.const]+ describes manifestly constant-evaluated expression or
+    conversion like constant expressions, condition of an +if constexpr+, an
+    immediate invocation, used in template parameters, in constant
+    initialization, etc.
+    This is evaluated at compile-time by the compiler.
+    For more context, see <<sec:language.restrictions.kernels>>.
+
 [[mem-fence]]mem-fence::
     A memory fence provides control over re-ordering of memory load and store
     operations when coupled with an atomic operation.
@@ -352,7 +366,6 @@ For the full description please refer to <<subsec:buffers>>.
 [[native-specialization-constant]]native-specialization constant::
     A <<specialization-constant>> in a device image whose value can be used by
     an online compiler as an immediate value during the compilation.
-
 
 [[nd-item]]nd-item::
     A unique identifier representing a single <<work-item>> and <<work-group>>

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -463,4 +463,8 @@ parameters did not clearly specify which accessor's size determines the amount
 of memory that is copied.
 The spec now clarifies that the [code]#src# accessor's size is used.
 
+Any code considered as a <<discarded-statement>> or as a
+<<manifestly-constant-evaluated>> by the C++ standard is now also accepted in
+SYCL device function.
+
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%% end what_changed %%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Cherry pick #388 from main
(cherry picked from commit 94eb55836038e27469e738345ce87762c4eb364e)