### PR TITLE
Add constraint to vec <<, >> operators

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18326,15 +18326,17 @@ a@
 ----
 vec operatorOP(const DataT& lhs, const vec& rhs)
 ----
-   a@ Construct a new instance of the SYCL [code]#vec# class template with
-      the same template parameters as the [code]#rhs# SYCL [code]#vec#
-      with each element of the new SYCL [code]#vec# instance the result of
-      an element-wise [code]#OP# bitshift operation between the [code]#lhs# scalar and each element of the [code]#rhs# SYCL [code]#vec#.
-      If [code]#OP# is [code]#>>#, [code]#DataT# is a signed type
-      and this SYCL [code]#vec# has a negative value any vacated bits viewed
-      as an unsigned integer must be assigned the value [code]#1#, otherwise
-      any vacated bits viewed as an unsigned integer must be assigned the value
-      [code]#0#.
+   a@ Available only when: [code]#DataT != float && DataT != double && DataT != half#.
+
+Construct a new instance of the SYCL [code]#vec# class template with
+the same template parameters as the [code]#rhs# SYCL [code]#vec#
+with each element of the new SYCL [code]#vec# instance the result of
+an element-wise [code]#OP# bitshift operation between the [code]#lhs# scalar and each element of the [code]#rhs# SYCL [code]#vec#.
+If [code]#OP# is [code]#>>#, [code]#DataT# is a signed type
+and this SYCL [code]#vec# has a negative value any vacated bits viewed
+as an unsigned integer must be assigned the value [code]#1#, otherwise
+any vacated bits viewed as an unsigned integer must be assigned the value
+[code]#0#.
 
 Where [code]#OP# is: [code]#<<#, [code]#>>#.
 


### PR DESCRIPTION
I assume it was simply an oversight that we forgot to add this constraint to these operators.  This synopsis already listed the constraint in its comment, so this change just brings the description into alignment with the synopsis.

C++ does not allow `<<` or `>>` operators where the left-hand-side is a floating point value.  In addition, DPC++ already diagnoses an error if you attempt to use `vec::operator<<` where the left-hand-side is a floating point value.