### PR TITLE
Fix vec constructors

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17808,16 +17808,38 @@ a@
 ----
 explicit constexpr vec(const DataT& arg)
 ----
-   a@ Construct a vector of element type [code]#DataT# and
-      [code]#NumElements# dimensions by setting each value to [code]#arg# by
-      assignment.
+a@ _Constraints:_ [code]#NumElements# is greater than 1.
+
+Constructs a [code]#vec# object by assigning each element to [code]#arg#.
+
+a@
+[source]
+----
+constexpr vec(const DataT& arg)
+----
+a@ _Constraints:_ [code]#NumElements# is equal to 1.
+
+Constructs a 1-element [code]#vec# object by assigning the element to
+[code]#arg#.
 
 a@
 [source]
 ----
 template <typename... ArgTN> constexpr vec(const ArgTN&... args)
 ----
-   a@ Construct a SYCL [code]#vec# instance from any combination of scalar and SYCL [code]#vec# parameters of the same element type, providing the total number of elements for all parameters sum to [code]#NumElements# of this [code]#vec# specialization.
+a@ _Constraints:_
+
+* The total number of elements from all parameters is greater than 1 and sums to
+[code]#NumElements#, and
+
+* Each type [code]#ArgTN# is one of the following:
+** A type that is implicitly convertible to [code]#DataT#, or
+** A [code]#vec# type whose element type is [code]#DataT#, or
+** A [code]#+__writeable_swizzle__+# type whose element type is [code]#DataT#, or
+** A [code]#+__const_swizzle__+# type whose element type is [code]#DataT#.
+
+Constructs a [code]#vec# object from a combination of scalar and vector
+parameters.
 
 a@
 [source]

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -43,7 +43,11 @@ template <typename DataT, int NumElements> class vec {
 
   vec();
 
+  // Available only when: NumElements > 1
   explicit constexpr vec(const DataT& arg);
+
+  // Available only when: NumElements == 1
+  constexpr vec(const DataT& arg);
 
   template <typename... ArgTN> constexpr vec(const ArgTN&... args);
 


### PR DESCRIPTION
This is change 1 of 9 that fix problems with the specification of the `vec` class.  An implementation that follows the existing specification would not accept common code patterns and would not pass the CTS.  None of the existing implementations actually follow the existing specification.

This change updates the constructors:

* Allow the variadic constructor parameters to be types implicitly convertible to `DataT`.
* Allow the variadic constructor parameters to be the swizzle types.
* Allow implicit conversions from scalar type `T` to 1-element `vec` where `T` is implicitly convertible to `DataT`.

These changes correspond to slides 3 - 7 of the presentation that was discussed in the WG meetings