### PR TITLE
Add vec explicit conversion

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17872,6 +17872,21 @@ to allow standard conversion sequence for implicit conversion.
 a@
 [source]
 ----
+template<typename T>
+explicit operator T() const
+----
+a@ _Constraints:_
+
+* [code]#NumElements# is equal to 1, and
+* [code]#DataT# can be explicitly converted to [code]#T# via
+  [code]#static_cast<T>#, and
+* [code]#T# is not [code]#DataT#.
+
+Returns the value of the vector's element converted to [code]#T#.
+
+a@
+[source]
+----
 static constexpr size_t size() noexcept
 ----
    a@ Returns the number of elements of this SYCL [code]#vec#.
@@ -18661,6 +18676,10 @@ operator vector_t() const
 #endif
 
 operator DataT() const
+
+template<typename T>
+explicit operator T() const
+
 static constexpr size_t byte_size() noexcept
 static constexpr size_t size() noexcept
 

--- a/adoc/headers/vec.h
+++ b/adoc/headers/vec.h
@@ -58,6 +58,10 @@ template <typename DataT, int NumElements> class vec {
   // Available only when: NumElements == 1
   operator DataT() const;
 
+  // Available only when: NumElements == 1 and T is explicitly convertible to DataT
+  template<typename T>
+  explicit operator T() const;
+
   static constexpr size_t byte_size() noexcept;
 
   static constexpr size_t size() noexcept;


### PR DESCRIPTION
This is change 2 of 9 that fix problems with the specification of the `vec` class.  An implementation that follows the existing specification would not accept common code patterns and would not pass the CTS.  None of the existing implementations actually follow the existing specification.

This change adds an explicit conversion when the `vec` has one element, allowing a conversion to `T` whenever `DataT` can be explicitly converted to `T`.

This enables code like the following, where the element type `DataT` is itself a class:

```
sycl::vec<sycl::half, 1> h1;
int i = static_cast<int>(h1);
if (h1) {}
```

These changes correspond to slides 8 - 9 of the presentation that was discussed in the WG meetings.