### PR TITLE
Clarify "vec" ADL behavior

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18573,15 +18573,13 @@ behavior:
 
 * When an argument is the [code]#+__writeable_swizzle__+# type, the ADL search
   set must include only the class template definition for
-  [code]#+__writeable_swizzle__+#, the [code]#sycl# namespace, the class
-  definition for [code]#DataT# (if it is a class), and the namespace that
-  contains [code]#DataT#.
+  [code]#+__writeable_swizzle__+#, the class definition for [code]#DataT# (if it
+  is a class), and the namespace that contains [code]#DataT#.
 
 * When an argument is the [code]#+__const_swizzle__+# type, the ADL search set
   must include only the class template definition for
-  [code]#+__const_swizzle__+#, the [code]#sycl# namespace, the class definition
-  for [code]#DataT# (if it is a class), and the namespace that contains
-  [code]#DataT#.
+  [code]#+__const_swizzle__+#, the class definition for [code]#DataT# (if it is
+  a class), and the namespace that contains [code]#DataT#.
 
 When the string [code]#+__writeable_swizzle__+# or [code]#+__const_swizzle__+#
 is used inside the class definition in the synopses below, it refers to the

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18564,6 +18564,23 @@ The constant [code]#NumElements# represents the number of elements in the result
 of the swizzle operation, which could be different from the number of elements
 in the underlying [code]#vec#.
 
+Because the template parameters to the [code]#+__writeable_swizzle__+# and
+[code]#+__const_swizzle__+# classes affect the {cpp} argument dependent lookup
+(ADL) behavior, implementations do not have complete freedom when choosing these
+template parameters.
+Implementations must choose template parameters that result in the following ADL
+behavior:
+
+* When an argument is the [code]#+__writeable_swizzle__+# type, the ADL search
+  set must include only the class template definition for
+  [code]#+__writeable_swizzle__+#, the class definition for [code]#DataT# (if it
+  is a class), and the namespaces that contain these types.
+
+* When an argument is the [code]#+__const_swizzle__+# type, the ADL search set
+  must include only the class template definition for
+  [code]#+__const_swizzle__+#, the class definition for [code]#DataT# (if it is
+  a class), and the namespaces that contain these types.
+
 When the string [code]#+__writeable_swizzle__+# or [code]#+__const_swizzle__+#
 is used inside the class definition in the synopses below, it refers to the
 instantiation with the same set of template parameters as the enclosing class.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18573,13 +18573,15 @@ behavior:
 
 * When an argument is the [code]#+__writeable_swizzle__+# type, the ADL search
   set must include only the class template definition for
-  [code]#+__writeable_swizzle__+#, the class definition for [code]#DataT# (if it
-  is a class), and the namespaces that contain these types.
+  [code]#+__writeable_swizzle__+#, the [code]#sycl# namespace, the class
+  definition for [code]#DataT# (if it is a class), and the namespace that
+  contains [code]#DataT#.
 
 * When an argument is the [code]#+__const_swizzle__+# type, the ADL search set
   must include only the class template definition for
-  [code]#+__const_swizzle__+#, the class definition for [code]#DataT# (if it is
-  a class), and the namespaces that contain these types.
+  [code]#+__const_swizzle__+#, the [code]#sycl# namespace, the class definition
+  for [code]#DataT# (if it is a class), and the namespace that contains
+  [code]#DataT#.
 
 When the string [code]#+__writeable_swizzle__+# or [code]#+__const_swizzle__+#
 is used inside the class definition in the synopses below, it refers to the


### PR DESCRIPTION
This is change 4 of 9 that fix problems with the specification of the `vec` class.  An implementation that follows the existing specification would not accept common code patterns and would not pass the CTS.  None of the existing implementations actually follow the existing specification.

This change clarifies the ADL behavior of the `vec` class.  Without this clarification, implementations could make additional operators available on the ADL search set, which could lead to ambiguity errors when compiling applications.  For example, we know that adding `vec` to the ADL search set for the swizzled vector operators leads to ambiguity errors.

These changes correspond to slide 14 of the presentation that was discussed in the WG meetings.