### PR TITLE
Clarify "vec" DataT

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17727,8 +17727,8 @@ a@
 ----
 byte
 ----
-   a@ An unsigned 8-bit integer. This is deprecated in SYCL 2020 since {cpp17}
-      [code]#std::byte# can be used instead.
+   a@ An alias to [code]#std::uint8_t#.  This is deprecated in SYCL 2020 since
+      {cpp17} [code]#std::byte# can be used instead.
 
 a@
 [source]
@@ -17758,10 +17758,12 @@ from a swizzled set of component elements.
 
 The [code]#vec# class is templated on its number of elements and its element
 type.
-The number of elements parameter, _NumElements_, can be one of: 1, 2, 3, 4, 8 or 16.
+The number of elements parameter, [code]#NumElements#, must be one of: 1, 2, 3,
+4, 8 or 16.
 Any other value shall produce a compilation failure.
-The element type parameter, _DataT_, must be one of the basic scalar types
-supported in device code.
+The element type parameter, [code]#DataT#, must be the cv-unqualified version of
+one of the following: one of the built-in scalar data types listed in
+<<subsec:scalartypes>>, [code]#half#, or [code]#sycl::byte#.
 
 The SYCL [code]#vec# class template provides interoperability with the
 underlying vector type defined by [code]#vector_t# which is available only when


### PR DESCRIPTION
This is change 6 of 9 that fix problems with the specification of the `vec` class.  An implementation that follows the existing specification would not accept common code patterns and would not pass the CTS.  None of the existing implementations actually follow the existing specification.

This change clarifies the set of legal data types for a `vec` element and also clarifies what `sycl::byte` is.

These changes correspond to slides 23 - 25 and 28 of the presentation that was discussed in the WG meetings.