### PR TITLE
Specify copy assignment operator for vec swizzles

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18678,13 +18678,9 @@ __writeable_swizzle__(const __writeable_swizzle__&) = delete
 
 __const_swizzle__() = delete
 __const_swizzle__(const __const_swizzle__&) = delete
-
-__const_swizzle__& operator=(const __const_swizzle__&) = delete
 ----
 |====
 The default constructor and copy constructor are deleted.
-
-The copy assignment operator for [code]#+__const_swizzle__+# is deleted.
 
 ===== Destructors for the swizzled vector class templates
 
@@ -18857,6 +18853,46 @@ Functions (2) is available only in [code]#+__const_swizzle__+#.
 
 _Returns:_ A reference to the element of the underlying [code]#vec# object that
 corresponds to the position [code]#index# of the swizzle operation.
+
+'''
+
+[frame=all,grid=none,separator="@"]
+|====
+a@
+[source]
+----
+const __writeable_swizzle__&
+operator=(const __writeable_swizzle__& rhs) const
+----
+|====
+_Availability:_ Available only in [code]#+__writeable_swizzle__+#.
+
+_Constraints:_ Available only when the [code]#+__writeable_swizzle__+# view does
+not contain any repeated elements.
+
+_Effects:_ Assigns elements from the right hand side
+[code]#+__writeable_swizzle__+# view to elements of the left hand side
+[code]#+__writeable_swizzle__+# view.
+The value corresponding to the first element of the [code]#rhs# swizzle
+operation is assigned to the element of the underlying [code]#vec# object that
+corresponds to the first element of the left hand side swizzle operation, etc.
+
+_Returns:_ A reference to the left hand side [code]#+__writeable_swizzle__+#
+view.
+
+'''
+
+[frame=all,grid=none,separator="@"]
+|====
+a@
+[source]
+----
+const __const_swizzle__&
+operator=(const __const_swizzle__& rhs) const = delete;
+----
+|====
+The copy assignment operator is deleted for the [code]#+__const_swizzle__+#
+class.
 
 '''
 


### PR DESCRIPTION
Even though we specify an assignment operator for
`__writeable_swizzle__` like this:

```
template</*unspecified*/>
const __writeable_swizzle__&
operator=(const __writeable_swizzle__</*unspecified*/>& rhs) const
```

The compiler will not select this operator when the left-hand-side has the same type as the right-hand-side.  (Even though the template constraints would allow such a selection.)  Instead, the compiler will generate the default copy assignment operator and call that.

Since the default copy assignment operator would not be correct (performing a shallow copy), the `__writeable_swizzle__` class must provide a user defined copy assignment operator.

The copy assignment operator for `__const_swizzle__` was already deleted in the "constructors" section.  It seemed better to move this to the "member functions" part of the specification, next to the specification for the copy assignment operator for `__writeable_swizzle__`.