### PR TITLE
Add x, y, and z shorthands to id and range classes

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11980,6 +11980,30 @@ size_t operator[](int dimension) const
 a@
 [source]
 ----
+size_t x() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 1# of the [code]#range#
+      object.
+
+a@
+[source]
+----
+size_t y() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 2# of the [code]#range#
+      object, or 1 if [code]#Dimensions < 2#.
+
+a@
+[source]
+----
+size_t z() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 3# of the [code]#range#
+      object, or 1 if [code]#Dimensions < 3#.
+
+a@
+[source]
+----
 size_t size() const
 ----
    a@ Return the size of the range computed as dimension0*...*dimensionN.
@@ -12321,6 +12345,30 @@ size_t operator[](int dimension) const
 ----
    a@ Return the value of the requested dimension of the [code]#id#
       object.
+
+a@
+[source]
+----
+size_t x() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 1# of the [code]#id#
+      object.
+
+a@
+[source]
+----
+size_t y() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 2# of the [code]#id#
+      object, or 1 if [code]#Dimensions < 2#.
+
+a@
+[source]
+----
+size_t z() const noexcept;
+----
+   a@ Return the value of dimension [code]#Dimensions - 3# of the [code]#id#
+      object, or 1 if [code]#Dimensions < 3#.
 
 a@
 [source]

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -27,6 +27,10 @@ template <int Dimensions = 1> class id {
   size_t& operator[](int dimension);
   size_t operator[](int dimension) const;
 
+  size_t x() const noexcept;
+  size_t y() const noexcept;
+  size_t z() const noexcept;
+
   // only available if Dimensions == 1
   operator size_t() const;
 

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -24,6 +24,10 @@ template <int Dimensions = 1> class range {
   size_t& operator[](int dimension);
   size_t operator[](int dimension) const;
 
+  size_t x() const noexcept;
+  size_t y() const noexcept;
+  size_t z() const noexcept;
+
   size_t size() const;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=


### PR DESCRIPTION
The numbering of dimensions in SYCL is aligned with the numbering of dimensions in ISO C++, such that the highest-numbered dimension is the fastest-moving.

This numbering is inconvenient when working with generic functions compatible with one-, two-, or three-dimensional ranges, since developers must account somehow for differences in the numbering of the dimensions. One common solution is to define helper functions called `x()`, `y()` and `z()` to encapsulate this logic. This solution can also assist with the migration of code from other languages (e.g., OpenCL and CUDA), and may provide a simpler mental model for SYCL developers working with images or other forms of graphics interop.

This commit adds `x()`, `y()` and `z()` functions directly to the `id` and `range` classes, providing a consistent way for SYCL developers to use this indexing pattern, rather than relying on each SYCL code base to define and maintain compatible index abstractions.

---

I've proposed this as a SYCL-Next feature because, like #633, this is merely introducing a shorthand for something that is already supported by all SYCL implementations.  Going through the full KHR process for this feature would require either function names like `khr_x()` or clones of `range` and `id` in the `khr::` namespace, which both feel like bad solutions to the problem.

I'd also like to point out that use of these shorthands could be combined with the improved group interface being discussed in #638, allowing developers to write things like `item.id().x()` to access the fastest-moving component of an item's `id`.

Finally, since there may be some confusion and I want to be very clear: I am _not_ suggesting that we revisit the linearization equation for multi-dimensional SYCL quantities, and this is in no way a breaking change. `x()`, `y()` and `z()` are defined in terms of the existing dimension numbering and are thus fully backwards-compatible.