### PR TITLE
CTS issue workflow: Only run on main branch

### DIFF
--- a/.github/workflows/open_cts_issue.yml
+++ b/.github/workflows/open_cts_issue.yml
@@ -10,6 +10,9 @@ on:
     types: opened
     paths:
       - 'adoc/**'
+    # We don't want to create issues for cherry-picks into older spec revisions
+    branches:
+      - main
 jobs:
   create-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes that are being cherry-picked into an older version of the spec don't need a separate CTS issue, as the CTS targets all versions from SYCL 2020 onward.