### PR TITLE
[RFC] Say something about asynchronous behavior on host

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -441,6 +441,16 @@ The SYCL implementation guarantees the correct initialization and destruction of
 any resource handled by the underlying <<backend-api>>, except for those the
 user has obtained manually via the SYCL interoperability API.
 
+==== Synchronous and asynchronous resource management
+
+A SYCL implementation may manage <<backend-api>> resources synchronously by
+calling into the <<backend-api>> in the same host thread that the SYCL
+application uses to call into SYCL.
+A SYCL implementation may also manage <<backend-api>> resources asynchronously,
+using a host thread owned by the SYCL implementation.
+It is implementation-defined whether a given interaction between the
+<<sycl-runtime>> and a <<backend-api>> occurs synchronously or asynchronously.
+
 [[sec:command-groups-exec-order]]
 ==== SYCL command groups and execution order
 


### PR DESCRIPTION
The idea that (most practical) SYCL implementations will do some things asynchronously on the host (either by using a worker thread spawned by the SYCL runtime, or by relying on a worker thread owned by a backend, or both) is central to SYCL. The idea is implicit throughout the whole spec, but there isn't a single place where it's authoritatively spelled out.

The first place where the word *asynchronous* appears is in `§3.9.9 Error handling`, and IMO this is logically too late in the spec. Error handling shouldn't be used to introduce the idea of asynchronicity; the reader should go into the error handling section already understanding that SYCL has asynchronicity.

I suspect that the idea of asynchronicity is so obvious to everyone who's worked on the SYCL spec that it's been taken for granted, but I don't think we should assume that it will be obvious to all readers.

I've taken a stab at adding a (hopefully uncontroversial) paragraph to `§3.7.1. SYCL application execution model` just to spell out that yes, some things might happen asynchronously. I think there's scope for folding the paragraph into the previous subsection, or expanding it, or moving it somewhere else entirely. There are a number of places in the spec (like `§3.9.9 Error handling`) that could be made clearer and more succinct if they were to link to this new paragraph. There could also be scope for tying in the wording on asynchronicity with some of the forward progress wording.

I'm curious to hear people's thoughts.