### PR TITLE
Add pointer-to-object to list of `atomic_ref` types

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20033,8 +20033,9 @@ The template parameter [code]#T# must be one of the following types:
 * [code]#unsigned long#,
 * [code]#long long#,
 * [code]#unsigned long long#,
-* [code]#float#, or
-* [code]#double#.
+* [code]#float#,
+* [code]#double#, or
+* Any pointer-to-object type.
 
 In addition, the type [code]#T# must satisfy one of the following conditions:
 


### PR DESCRIPTION
The fact that this was missing from the list is a bug. `sycl::atomic_ref` has a specialization for pointer types, and several other parts of the specification talk about atomic operations on pointers.

Use of the term "pointer-to-object types" is aligned with `std::atomic_ref`.

Closes #684.