### PR TITLE
Change KHR name to lower case

### DIFF
--- a/adoc/extensions/sycl_khr_default_context.adoc
+++ b/adoc/extensions/sycl_khr_default_context.adoc
@@ -1,5 +1,5 @@
 [[sec:khr-default-context]]
-= SYCL_KHR_DEFAULT_CONTEXT
+= sycl_khr_default_context
 
 When a [code]#queue# object is constructed without passing an explicit
 [code]#context# object, the queue uses the platform's default context.


### PR DESCRIPTION
@Pennycook and I both think that the name of KHR extensions should be in lower case.  This affects only the documentation when referring to the name of the extension.  The feature-test macro remains in upper case, consistent with other SYCL macro names.