### PR TITLE
Prepare sycl_khr_default_context for publication

### DIFF
--- a/adoc/Makefile
+++ b/adoc/Makefile
@@ -170,7 +170,7 @@ HEADER_DIR = $(CURDIR)/headers
 # Top-level spec source file
 SPECSRC = syclbase.adoc
 # Static files making up sections of the API spec.
-SPECFILES = $(wildcard *.adoc) $(wildcard chapters/*.adoc)
+SPECFILES = $(wildcard *.adoc) $(wildcard chapters/*.adoc) $(wildcard extensions/*.adoc)
 
 # Shorthand for where different types of generated files go.
 # All can be relocated by overriding GENERATED in the make invocation.

--- a/adoc/extensions/index.adoc
+++ b/adoc/extensions/index.adoc
@@ -1,0 +1,13 @@
+[appendix]
+[[chapter:extensions]]
+= Optional extensions
+
+Each of the optional extensions in this appendix has been approved by the SYCL
+working group.
+These extensions may be promoted to core features in future versions of the SYCL
+specification, but their design is subject to change.
+
+// leveloffset=2 allows extensions to be written as standalone documents
+// include::sycl_khr_extension_name.adoc[leveloffset=2]
+
+include::sycl_khr_default_context.adoc[leveloffset=2]

--- a/adoc/extensions/sycl_khr_default_context.adoc
+++ b/adoc/extensions/sycl_khr_default_context.adoc
@@ -1,0 +1,57 @@
+[[sec:khr-default-context]]
+= sycl_khr_default_context
+
+When a [code]#queue# object is constructed without passing an explicit
+[code]#context# object, the queue uses the platform's default context.
+This extension adds a new query function to retrieve this default context from a
+[code]#platform# object.
+
+[[sec:khr-default-context-dependencies]]
+== Dependencies
+
+This extension has no dependencies on other extensions.
+
+[[sec:khr-default-context-feature-test]]
+== Feature test macro
+
+An implementation supporting this extension must predefine the macro
+[code]#SYCL_KHR_DEFAULT_CONTEXT# to one of the values defined in the table
+below.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial version of this extension.
+|===
+
+[[sec:khr-default-context-platform]]
+== Extensions to the platform class
+
+This extension adds the following new member functions to the [code]#platform#
+class.
+
+[source,role=synopsis,id=api:khr-default-context-platform]
+----
+namespace sycl {
+class platform {
+  context khr_get_default_context() const;
+  // ...
+};
+}
+----
+
+[[sec:khr-default-context-platform-member-funcs]]
+=== Member functions
+
+.[apidef]#platform::khr_get_default_context#
+[source,role=synopsis,id=api:platform-khr-get-default-context]
+----
+context khr_get_default_context() const
+----
+
+_Returns:_ A copy of the default context object for this platform.
+The default context contains all of the <<root-device, root devices>> that are
+associated with this platform.

--- a/adoc/scripts/verify_reflow_conformance.sh
+++ b/adoc/scripts/verify_reflow_conformance.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 error=0
-for file in adoc/chapters/*.adoc;
+for file in adoc/chapters/*.adoc adoc/extensions/*.adoc;
 do
   echo "$file"
-  ./adoc/scripts/reflow.py -out tmp_ci/ -- "$file"
-  diff "$file" "${file/adoc\/chapters/tmp_ci}"
+  dir=`dirname $file`
+  dir=`basename $dir`
+  ./adoc/scripts/reflow.py -out "tmp_ci/$dir" -- "$file"
+  diff "$file" "${file/adoc/tmp_ci}"
   error=$((error+$?))
 done
 

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -159,5 +159,7 @@ include::chapters/what_changed.adoc[]
 
 include::chapters/references.adoc[]
 
+include::extensions/index.adoc[]
+
 include::chapters/glossary.adoc[]
 //endif::[]


### PR DESCRIPTION
The sycl_khr_default_context KHR extension has been ratified. Prepare to publish it as an appendix in the next SYCL 2020 update.