### PR TITLE
Move acknowledgements section

### DIFF
--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -1,3 +1,4 @@
+[acknowledgements]
 [[acknowledgements]]
 = Acknowledgements
 

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -127,8 +127,6 @@ toc::[]
 
 :leveloffset: 1
 
-include::chapters/acknowledgements.adoc[]
-
 // \include{introduction}
 include::chapters/introduction.adoc[]
 
@@ -163,4 +161,7 @@ include::chapters/references.adoc[]
 include::extensions/index.adoc[]
 
 include::chapters/glossary.adoc[]
+
+include::chapters/acknowledgements.adoc[]
+
 //endif::[]


### PR DESCRIPTION
@gmlueck and I discussed this offline, and agreed that moving the acknowledgements section to the end of the specification made sense. It's very long, and there are other Khronos specifications (e.g., OpenCL) with acknowledgements at the end.

I also made it into an unnumbered section to match the Glossary. Having Section 6 appear after all the appendices looked weird.