### PR TITLE
Redefine SYCL_LANGUAGE_VERSION

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -357,7 +357,6 @@ implementations:
 |====
 @ SYCL version @ Macro defined as
 a@ SYCL 2020 a@ [code]#202012L#
-a@ SYCL {SYCL_VERSION} a@ [code]#{SYCL_LANGUAGE_VERSION}L#
 |====
 +
 Future versions of the SYCL specification will define this macro to an integer

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -349,13 +349,19 @@ The standard {cpp} preprocessing directives and macros are supported.
 The following preprocessor macros must be defined by all conformant
 implementations:
 
-  * [code]#SYCL_LANGUAGE_VERSION# substitutes an integer reflecting the version
-    number and revision of the SYCL language being supported by the
-    implementation.
-    The version of SYCL defined in this document will have
-    [code]#SYCL_LANGUAGE_VERSION# substitute the integer
-    [code]#{SYCL_LANGUAGE_VERSION}#, composed with the general SYCL version
-    followed by 2 digits representing the revision number;
+  * [code]#SYCL_LANGUAGE_VERSION# is defined to an integer literal that
+    indicates the version of the SYCL specification to which the implementation
+    conforms.
++
+[width="100%",options="header",separator="@",cols="50%,50%"]
+|====
+@ SYCL version @ Macro defined as
+a@ SYCL 2020 a@ [code]#202012L#
+a@ SYCL {SYCL_VERSION} a@ [code]#{SYCL_LANGUAGE_VERSION}L#
+|====
++
+Future versions of the SYCL specification will define this macro to an integer
+literal with greater value.
   * [code]#SYCL_DEVICE_COPYABLE# is defined to 1 if the implementation supports
     explicitly specified <<device-copyable>> types as described in
     <<sec::device.copyable>>.


### PR DESCRIPTION
Cherry pick #634 from main
(cherry picked from commit 7dea419d7a95077342dbe0d4f55d2eeb7ee06f4e)

With a few tweaks required to backport to the SYCL 2020 spec