### PR TITLE
Revert "Merge pull request #698 from gmlueck/gmlueck/cherry-pick-693"

### DIFF
--- a/adoc/chapters/acknowledgements.adoc
+++ b/adoc/chapters/acknowledgements.adoc
@@ -1,4 +1,3 @@
-[acknowledgements]
 [[acknowledgements]]
 = Acknowledgements
 

--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -126,6 +126,8 @@ toc::[]
 
 :leveloffset: 1
 
+include::chapters/acknowledgements.adoc[]
+
 // \include{introduction}
 include::chapters/introduction.adoc[]
 
@@ -160,7 +162,4 @@ include::chapters/references.adoc[]
 include::extensions/index.adoc[]
 
 include::chapters/glossary.adoc[]
-
-include::chapters/acknowledgements.adoc[]
-
 //endif::[]


### PR DESCRIPTION
Revert moving the Acknowledgements chapter.  Although we want to move this chapter, we don't want to move it as a revision to SYCL 2020 because it causes all the other chapter numbers to change.  Therefore keep this change in the "main" branch, but remove it from "sycl-2020".

This reverts commit 665315e968b8e79562a752338c976bbd248cd313, reversing changes made to 1399526a058c12cdc72d84edbbecf503e299c8c6.