### PR TITLE
[KHR] Add sycl_khr_max_num_work_groups extension

### DIFF
--- a/adoc/extensions/index.adoc
+++ b/adoc/extensions/index.adoc
@@ -11,3 +11,4 @@ specification, but their design is subject to change.
 // include::sycl_khr_extension_name.adoc[leveloffset=2]
 
 include::sycl_khr_default_context.adoc[leveloffset=2]
+include::sycl_khr_max_num_work_groups.adoc[leveloffset=2]

--- a/adoc/extensions/sycl_khr_max_num_work_groups.adoc
+++ b/adoc/extensions/sycl_khr_max_num_work_groups.adoc
@@ -1,0 +1,92 @@
+[[sec:khr-max-num-work-groups]]
+= sycl_khr_max_num_work_groups
+
+This extension allows developers to query iteration bounds in each dimension for a ND-range or basic range kernel.
+The implementation ensures the execution of the ND-range kernel if its global size is less than of equal to `max_num_work_groups_nd_range<N>` in each dimension. This condition applies to basic range kernels with `max_num_work_groups_range<N>`.
+
+
+[[sec:khr-max-num-work-groups-dependencies]]
+== Dependencies
+
+This extension does not depend on other extensions.
+
+[[sec:khr-max-num-work-groups-feature-test]]
+== Feature test macro
+An implementation supporting this extension must predefine the `SYCL_KHR_MAX_WORK_GROUP_QUERY` macro to one of the values defined in the table below.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial version of this extension.
+|===
+
+== New device descriptors
+
+[options="header"]
+[cols="1,1,2", options="header"]
+|===
+| Device descriptors                                     | Return type | Description
+
+| `khr::info::device::max_num_work_groups_nd_range<N>`
+| `id<N>`
+| Returns the maximum number of work-groups that can be submitted in each dimension of the `globalSize` of an `nd_range<N>`. The minimum value is `(1, 1, 1)` if the device is not `info::device_type::custom`.
+
+
+| `khr::info::device::max_num_work_groups_range<N>`
+| `id<N>`
+| Returns the maximum number of work-groups that can be submitted in each dimension of a `range<N>` for a basic kernel. The minimum value is `(1, 1, 1)` if the device is not `info::device_type::custom`.
+|===
+
+=== Note
+- N can take the value 1, 2 or 3
+// - nd_range allow barrier, and other scemantic who may impact the maximun size of allocation, hence we split the querry between the range and nd_range?
+
+[[sec:khr-max-num-work-groups-example]]
+== Example
+
+The example below demonstrates the use of this extension for an `nd_range` loop, the same code can be applied to a basic range by using the `max_num_work_group_range` device descriptor.
+
+[source,cpp]
+----
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+int
+main(int argc, char *argv[]) {
+    size_t dim1 = std::stoi(argv[1]);
+    size_t dim2 = std::stoi(argv[2]);
+    size_t dim3 = std::stoi(argv[3]);
+    sycl::range<3> globalSize(dim1, dim2, dim3);
+    sycl::range<3> localSize(1, 1, 1);
+
+    sycl::queue queue;
+    sycl::device device = queue.get_device();
+    std::cout << "Running on " << device.get_info<sycl::info::device::name>()
+              << "\n";
+
+    sycl::id<3> nd_limit =
+        gpu.get_info<sycl::khr::info::device::max_num_work_group_nd_range<3>>();
+    std::cout << "Max number groups for ND-Range: x_max: " << nd_limit[2]
+              << " y_max: " << nd_limit[1] << " z_max: " << nd_limit[0]
+              << std::endl;
+
+    // Should aways be satisfied at kernel submission
+    // user's responsibility to check
+    assert(globalSize[2] <= nd_limit[2]
+        && globalSize[1] <= nd_limit[1]
+        && globalSize[0] <= nd_limit[0]);
+
+    // If the assertion if satisfied, the implementation guarantees
+    // the execution of the kernel
+    queue.parallel_for(
+        sycl::nd_range{globalSize, localSize},
+        [=](sycl::id<3> idx) { /*Kernel*/ }).wait();
+
+    return 0;
+}
+
+----


### PR DESCRIPTION
This PR proposes to add to the specification a device descriptor on the maximum number of work-groups that can be submitted to a `range` or `nd_range` parallel for: `max_num_work_groups_nd_range<N>` and `max_num_work_groups_range<N>` for N=1, 2 or 3. The device query returns a tuple `id<N>` with boundaries in each dimension.

## Justification

- In the current revision of the spec, there is no limitation on the maximum iteration size submitted to a parallel for, supposedly meaning that any number should be valid. But when actually running with large sizes, backend-related issues emerge.

- Users rely on these values to check kernel boundaries and often have to hard-code these values, for example Kokkos developers with the SYCL backend (see [this PR](https://github.com/kokkos/kokkos/pull/7724)) or this implementation of [blocking/streaming kernels](https://github.com/Maison-de-la-Simulation/parallel-advection/blob/bkm-paper/src/core/advectors.h#L67-L75).

- The query is already available for all GPU backends:
  - [CUDA](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html#group__CUDA__DEVICE_1g9c3e1414f0ad901d3278a4d6645fc266) `CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_[X,Y,Z]`
  - [hip](https://rocm.docs.amd.com/projects/HIP/en/docs-6.0.0/doxygen/html/group___device.html#ga7080a145a4239a7276e0dc22062026c1) `hipDeviceAttributeMaxGridDim[X,Y,Z]`
  - [L0](https://spec.oneapi.io/level-zero/1.9.3/core/api.html#ze__api_8h_1ae0e7f575e41e2576ffa0269d886e55f4) `ze_device_properties_t::maxGroupCount[X,Y,Z]`

- DPC++ already implements something similar as [an extension](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_max_work_group_query.md)


## Notes
- There is a distinction for `nd_range` or `range` for multiple reasons:
  - The semantics of range and nd_range differ which might impact the maximum size of the iteration space
  - Implementers can choose to map higher-level optimization methods for basic range kernels, or directly map on the lower level limitations

- For N=3, the mapping is straightforward, as it directly queries the backend functions with `X, Y, Z`. The mapping for N=1 and N=2 is unclear, implementers could choose the minimum of `X,Y,Z` or compute a product of other dimensions, for example.

- Although this PR is largely inspired by DPC++ extension, they initially proposed `max_global_work_groups` which is not actually queryable with CUDA/HIP which is why it is not proposed here.
  - As a user, the main concern is ensuring that the kernel’s iteration range does not exceed the maximum values for each dimension. The rest should be implementation-defined (e.g., whether the mapping is direct or if blocking/streaming is used).