### PR TITLE
Replace "lambda function" with "lambda expression"

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -93,7 +93,7 @@ and lifetimes of the various objects used within SYCL, as explained in
 
 A <<sycl-kernel-function>> is the scoped block of code that will be compiled
 using a device compiler.
-This code may be defined by the body of a lambda function or by the
+This code may be defined by the body of a lambda expression or by the
 [code]#operator()# function of a function object.
 Each instance of the <<sycl-kernel-function>> will be executed as a single,
 though not necessarily entirely independent, flow of execution and has to adhere
@@ -370,7 +370,7 @@ The resources managed by SYCL are:
     In SYCL, a device is accessible through a [code]#sycl::device# object.
   . <<kernel,Kernels>>: the SYCL functions that run on SYCL devices are defined
     as {cpp} function objects (a named function object type or a lambda
-    function).
+    expression).
     A kernel can be introspected through a [code]#sycl::kernel# object.
 +
 --
@@ -1164,7 +1164,7 @@ Host code and device code is written in the same {cpp} source file, enabling
 instantiation of templated kernels from host code and also enabling kernel
 source code to be shared between host and device.
 The device kernels are encapsulated {cpp} callable types (a function object with
-[code]#operator()# or a lambda function), which have been designated to be
+[code]#operator()# or a lambda expression), which have been designated to be
 compiled as SYCL kernels.
 
 SYCL programs target heterogeneous systems.
@@ -1750,8 +1750,8 @@ Implementations conformant to the reduced feature set
 (<<sec:feature-sets.reduced>>) can do this by using the {cpp} type of the
 <<sycl-kernel-function>>.
 This type is specified via the <<kernel-name>> template parameter if the
-<<sycl-kernel-function>> is a lambda function, or it is obtained from the class
-type if the <<sycl-kernel-function>> is an object.
+<<sycl-kernel-function>> is a lambda expression, or it is obtained from the
+class type if the <<sycl-kernel-function>> is an object.
 Implementations conformant to the full feature set (<<sec:feature-sets.full>>)
 do not require a <<kernel-name>> at the invocation site, so they must implement
 some other way to make the association.

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -507,11 +507,11 @@ in this section has implementation-defined effect.
 === Kernel attributes
 
 The attributes listed in <<table.kernel.attributes>> have a different position
-depending on whether the kernel is defined as a lambda function or as a named
+depending on whether the kernel is defined as a lambda expression or as a named
 function object.
 If the kernel is a named function object, the attribute is applied to the
 declarator-id in the function declaration.
-However, if the kernel is a lambda function, the attribute is applied to the
+However, if the kernel is a lambda expression, the attribute is applied to the
 lambda declarator.
 
 [NOTE]

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -99,7 +99,7 @@ For the full description please refer to <<subsec:buffers>>.
     A type which is callable with [code]#operator()# that takes a reference to a
     <<handler>>, that defines a <<command-group>> which can be submitted by a
     <<queue>>.
-    The function object can be a named type, lambda function or
+    The function object can be a named type, lambda expression or
     [code]#std::function#.
 
 [[handler]]command group handler::
@@ -526,7 +526,7 @@ For the full description please refer to <<subsec:buffers>>.
     <<handler>>.
     A <<sycl-kernel-function>> defines an entry point to a <<kernel>>.
     The function object can be a named <<device-copyable>> type or lambda
-    function.
+    expression.
 
 [[sycl-runtime]]SYCL runtime::
     A SYCL runtime is an implementation of the SYCL API specification.

--- a/adoc/chapters/introduction.adoc
+++ b/adoc/chapters/introduction.adoc
@@ -9,7 +9,7 @@ heterogeneous computing in {cpp}.
 
 SYCL enables developers to write standard {cpp} code that executes on a wide
 range of devices, using modern techniques such as inheritance, templates, and
-lambda functions.
+lambda expressions.
 All computational kernels to be executed on a device can be written inside {cpp}
 source files as normal {cpp} code, alongside any code intended to be run on a
 system's host processor.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14409,7 +14409,7 @@ a@
 template <typename KernelName, typename KernelType>
 void single_task(const KernelType& kernelFunc)
 ----
-   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda function
+   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda expression
       or a named function object type.
       Specification of a <<kernel-name>> ([code]#typename KernelName#), as
       described in <<subsec:invokingkernels>>, is optional.
@@ -14424,7 +14424,7 @@ a@
 template <typename KernelName, int Dimensions, typename... Rest>
 void parallel_for(range<Dimensions> numWorkItems, Rest&&... rest)
 ----
-   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda function
+   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda expression
       or a named function object type,
       for the specified range and given an item or integral type (e.g [code]#int#,
       [code]#size_t)#, if range is 1-dimensional, for indexing in the indexing
@@ -14451,7 +14451,7 @@ void parallel_for(range<Dimensions> numWorkItems, id<Dimensions> workItemOffset,
     // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
-      Defines and invokes a <<sycl-kernel-function>> as a lambda function
+      Defines and invokes a <<sycl-kernel-function>> as a lambda expression
       or a named function object type,
       for the specified range and offset and given an item or integral type
       (e.g [code]#int#, [code]#size_t)#, if range is 1-dimensional,
@@ -14474,7 +14474,7 @@ a@
 template <typename KernelName, int Dimensions, typename... Rest>
 void parallel_for(nd_range<Dimensions> executionRange, Rest&&... rest)
 ----
-   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda function
+   a@ Defines and invokes a <<sycl-kernel-function>> as a lambda expression
       or a named function object type,
       for the specified <<nd-range>> and given an <<nd-item>>
       for indexing in the indexing space defined by the <<nd-range>>.
@@ -14503,7 +14503,7 @@ template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
 void parallel_for_work_group(range<Dimensions> numWorkGroups,
                              const WorkgroupFunctionType& kernelFunc)
 ----
-   a@ Defines and invokes a hierarchical kernel as a lambda function
+   a@ Defines and invokes a hierarchical kernel as a lambda expression
       or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#. May
@@ -14524,7 +14524,7 @@ void parallel_for_work_group(range<Dimensions> numWorkGroups,
                              range<Dimensions> workGroupSize,
                              const WorkgroupFunctionType& kernelFunc)
 ----
-   a@ Defines and invokes a hierarchical kernel as a lambda function
+   a@ Defines and invokes a hierarchical kernel as a lambda expression
       or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#.
@@ -14685,7 +14685,7 @@ What differs is the functionality that is available to the SYCL kernel function
 via the respective interfaces.
 
 Below is an example of invoking a SYCL kernel function with [code]#parallel_for#
-using a lambda function, and passing a SYCL [code]#id# parameter.
+using a lambda expression, and passing a SYCL [code]#id# parameter.
 In this case, only the global id is available.
 This variant of [code]#parallel_for# is designed for when it is not necessary to
 query the global range of the index space being executed across.
@@ -14696,7 +14696,7 @@ include::{code_dir}/basicparallelfor.cpp[lines=4..-1]
 ----
 
 Below is an example of invoking a SYCL kernel function with [code]#parallel_for#
-using a lambda function and passing a SYCL [code]#item# parameter.
+using a lambda expression and passing a SYCL [code]#item# parameter.
 In this case, both the global id and global range are queryable.
 This variant of [code]#parallel_for# is designed for when it is necessary to
 query the global range of the index space being executed across.
@@ -14707,7 +14707,7 @@ include::{code_dir}/basicParallelForItem.cpp[lines=4..-1]
 ----
 
 Below is an example of invoking a SYCL kernel function with [code]#parallel_for#
-using a lambda function and passing [code]#auto# parameter, treated as
+using a lambda expression and passing [code]#auto# parameter, treated as
 [code]#item#.
 In this case, both the global id and global range are queryable.
 The same effect can be achieved using class with templatized [code]#operator()#.
@@ -14720,7 +14720,7 @@ include::{code_dir}/basicParallelForGeneric.cpp[lines=4..-1]
 ----
 
 Below is an example of invoking a SYCL kernel function with [code]#parallel_for#
-using a lambda function and passing an integral type parameter.
+using a lambda expression and passing an integral type parameter.
 This example is only valid when calling [code]#parallel_for# with
 [code]#range<1>#.
 In this case only the global id is available.
@@ -14854,7 +14854,7 @@ runtime, or by the number of work-groups and number of work-items for users who
 need more control.
 
 The body of the outer [code]#parallel_for_work_group# call consists of a lambda
-function or function object.
+expression or function object.
 The body of this function object contains code that is executed only once for
 the entire work-group.
 If the code has no side-effects and the compiler heuristic suggests that it is
@@ -16015,8 +16015,8 @@ template <typename KernelName> kernel_id get_kernel_id();
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
 <<type-kernel-name>> of a kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to obtain their identifier via this
 function.
 Applications which call [code]#get_kernel_id()# for a [code]#KernelName# that is
@@ -16220,8 +16220,8 @@ kernel_bundle<State> get_kernel_bundle(const context& ctxt,
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
 <<type-kernel-name>> of a kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to use these functions.
 Applications which call these functions for a [code]#KernelName# that is not
 defined are ill formed, and the implementation must issue a diagnostic in this
@@ -16316,8 +16316,8 @@ bool has_kernel_bundle(const context& ctxt, const std::vector<device>& devs);
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
 <<type-kernel-name>> of a kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to use these functions.
 Applications which call these functions for a [code]#KernelName# that is not
 defined are ill formed, and the implementation must issue a diagnostic in this
@@ -16364,8 +16364,8 @@ template <typename KernelName> bool is_compatible(const device& dev);
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
 <<type-kernel-name>> of a kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to use this function.
 Applications which call this function for a [code]#KernelName# that is not
 defined are ill formed, and the implementation must issue a diagnostic in this
@@ -16637,8 +16637,8 @@ bool has_kernel(const device& dev) const noexcept; // (2)
 
 _Preconditions:_ The template parameter [code]#KernelName# must be the
 <<type-kernel-name>> of a kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to use these functions.
 Applications which call these functions for a [code]#KernelName# that is not
 defined are ill formed, and the implementation must issue a diagnostic in this
@@ -16683,8 +16683,8 @@ _Preconditions:_ This member function is only available if the kernel bundle's
 state is [code]#bundle_state::executable#.
 The template parameter [code]#KernelName# must be the <<type-kernel-name>> of a
 kernel that is defined in the <<sycl-application>>.
-Since lambda functions have no standard type name, kernels defined as lambda
-functions must specify a [code]#KernelName# in their
+Since lambda expressions have no standard type name, kernels defined as lambda
+expressions must specify a [code]#KernelName# in their
 <<kernel-invocation-command>> in order to use this function.
 Applications which call this function for a [code]#KernelName# that is not
 defined are ill formed, and the implementation must issue a diagnostic in this
@@ -17154,7 +17154,7 @@ accesses between host and device are through <<accessor,accessors>> or through
 <<sec:usm, USM pointers>>.
 
 There are two ways of defining kernels: as named function objects or as lambda
-functions.
+expressions.
 A backend may also provide interoperability interfaces for defining kernels.
 
 
@@ -17195,23 +17195,23 @@ include::{code_dir}/myfunctor.cpp[lines=4..-1]
 
 
 [[sec:interfaces.kernels.as.lambdas]]
-=== Defining kernels as lambda functions
+=== Defining kernels as lambda expressions
 
-In {cpp}, function objects can be defined using lambda functions.
-Kernels may be defined as lambda functions in SYCL.
-The name of a lambda function in SYCL may optionally be specified by passing it
-as a template parameter to the invoking member function, and in that case, the
-lambda name is a [keyword]#{cpp} typename# which must be forward declarable at
-namespace scope.
-If the lambda function relies on template arguments, then if specified, the name
-of the lambda function must contain those template arguments which must also be
-forward declarable at namespace scope.
-The class used for the name of a lambda function is only used for naming
+In {cpp}, function objects can be defined using lambda expressions.
+Kernels may be defined as lambda expressions in SYCL.
+The name of a lambda expression in SYCL may optionally be specified by passing
+it as a template parameter to the invoking member function, and in that case,
+the lambda name is a [keyword]#{cpp} typename# which must be forward declarable
+at namespace scope.
+If the lambda expression relies on template arguments, then if specified, the
+name of the lambda expression must contain those template arguments which must
+also be forward declarable at namespace scope.
+The class used for the name of a lambda expression is only used for naming
 purposes and is not required to be defined.
 For details on restrictions for kernel naming, please refer to
 <<sec:naming.kernels>>.
 
-The kernel function for the lambda function is the lambda function itself.
+The kernel function for the lambda expression is the lambda expression itself.
 The kernel lambda must use copy for all of its captures (i.e. [code]#[=]#), and
 the lambda must not use the [code]#mutable# specifier.
 
@@ -17271,13 +17271,13 @@ a device copyable type in that case and the specialization is ignored.
 === Rules for parameter passing to kernels
 
 A SYCL application passes parameters to a kernel in different ways depending on
-whether the kernel is a named function object or a lambda function.
+whether the kernel is a named function object or a lambda expression.
 If the kernel is a named function object, the [code]#operator()# member function
 (or other member functions that it calls) may reference member variables inside
 the same named function object.
 Any such member variables become parameters to the kernel.
-If the kernel is a lambda function, any variables captured by the lambda become
-parameters to the kernel.
+If the kernel is a lambda expression, any variables captured by the lambda
+become parameters to the kernel.
 
 Regardless of how the parameter is passed, the following rules define the
 allowable types for a kernel parameter:
@@ -17374,8 +17374,8 @@ When an <<async-error>> instance has been passed to an <<async-handler>>, then
 that instance of the error has been consumed for handling and is not reported on
 any subsequent invocations of the <<async-handler>>.
 
-The <<async-handler>> may be a named function object type, a lambda function or
-a [code]#std::function#.
+The <<async-handler>> may be a named function object type, a lambda expression
+or a [code]#std::function#.
 The [code]#exception_list# object passed to the <<async-handler>> is constructed
 by the <<sycl-runtime>>.
 
@@ -17705,7 +17705,7 @@ kernel_argument
 ----
    a@ The application has passed an invalid argument to a
       <<sycl-kernel-function>>.  This includes captured variables if the
-      <<sycl-kernel-function>> is a lambda function.
+      <<sycl-kernel-function>> is a lambda expression.
 
 a@
 [source]

--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -23,7 +23,7 @@ described in <<sec:progmodel.minimumcppversion>>.
 Features of {cpp17} are now enabled within the specification, such as deduction
 guides for class template argument deduction.
 
-Naming of lambda functions passed to kernel invocations is now optional.
+Naming of lambda expressions passed to kernel invocations is now optional.
 
 Changes to buffers, images and accessors:
 


### PR DESCRIPTION
"lambda expression" is aligned with ISO C++ terminology.

Closes #175.