### PR TITLE
Remove reference to OpenCL 1.2 memory model

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -903,7 +903,7 @@ image::{images}/host-acc.svg[align="center",opts="{imageopts}"]
 
 === SYCL device memory model
 
-The memory model for SYCL devices is based on the OpenCL 1.2 memory model.
+The memory model for SYCL devices is based on the OpenCL memory model.
 Work-items executing in a kernel have access to three distinct address spaces
 (memory regions) and a virtual address space overlapping some concrete address
 spaces:


### PR DESCRIPTION
After the addition of the generic space, SYCL's memory model is no longer aligned with that of OpenCL 1.2. This commit removes the "1.2", but keeps the more general reference to OpenCL.

Closes #131. 