### PR TITLE
Highlight variable templates for known_identity

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -13640,9 +13640,11 @@ identity value automatically in order to avoid performance penalties.
 
 If an implementation can identify an identity value for a given combination of
 accumulator type and function object type, the value is defined as a member of
-the [code]#known_identity# trait class.
+the [code]#known_identity# trait class and can be retrieved using the
+[code]#known_identity_v# variable template.
 Whether this member value exists can be tested using the
-[code]#has_known_identity# trait class.
+[code]#has_known_identity# trait class or the [code]#has_known_identity_v#
+variable template.
 
 [source,,linenums]
 ----


### PR DESCRIPTION
`known_identity_v` and `has_known_identity_v` appear in a synopsis block, but the text preceding it recommends to use `known_identity` and `has_known_identity` instead. We should highlight that these helper variable templates exist when they are first introduced.

Closes #189.