### PR TITLE
Fix definition of marray::size()

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19525,7 +19525,7 @@ a@
 ----
 static constexpr std::size_t size() noexcept
 ----
-   a@ Returns the size of this SYCL [code]#marray# in bytes.
+   a@ Returns the number of elements in this SYCL [code]#marray# (i.e., [code]#NumElements#).
 
 a@
 [source]


### PR DESCRIPTION
This should return the number of elements in the marray, not its size in bytes.

Closes #525.