### PR TITLE
Replace "inverse sqrt" with "reciprocal" sqrt

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -24715,7 +24715,7 @@ template<typename NonScalar>        (4)
 
 *Overloads (1) - (3):*
 
-_Returns:_ The inverse square root of [code]#x#.
+_Returns:_ The reciprocal square root of [code]#x#.
 
 *Overload (4):*
 
@@ -24725,7 +24725,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   type; and
 * The element type is [code]#float#, [code]#double#, or [code]#half#.
 
-_Returns:_ For each element of [code]#x#, the inverse square root of
+_Returns:_ For each element of [code]#x#, the reciprocal square root of
 [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
@@ -25406,7 +25406,7 @@ template<typename NonScalar>        (2)
 
 *Overload (1):*
 
-_Returns:_ The inverse square root of [code]#x#.
+_Returns:_ The reciprocal square root of [code]#x#.
 
 *Overload (2):*
 
@@ -25416,7 +25416,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the inverse square root of
+_Returns:_ For each element of [code]#x#, the reciprocal square root of
 [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the
@@ -25848,7 +25848,7 @@ template<typename NonScalar>        (2)
 
 *Overload (1):*
 
-_Returns:_ The inverse square root of [code]#x#.
+_Returns:_ The reciprocal square root of [code]#x#.
 
 *Overload (2):*
 
@@ -25858,7 +25858,7 @@ _Constraints:_ Available only if all of the following conditions are met:
   type; and
 * The element type is [code]#float#.
 
-_Returns:_ For each element of [code]#x#, the inverse square root of
+_Returns:_ For each element of [code]#x#, the reciprocal square root of
 [code]#x[i]#.
 
 The return type is [code]#NonScalar# unless [code]#NonScalar# is the


### PR DESCRIPTION
The "inverse" of sqrt is x*x. Referring to "reciprocal" sqrt is more accurate.

Closes #655.