### PR TITLE
Clarify that RandomFiller uses one random number

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17177,7 +17177,7 @@ If the [code]#operator()# function writes to any of the member variables, the
 behavior is undefined.
 
 The following example defines a <<sycl-kernel-function>>, _RandomFiller_, which
-initializes a buffer with a random number.
+initializes all elements of a buffer with the same random number.
 The random number is generated during the construction of the function object
 while processing the command group.
 The [code]#operator()# member function of the function object receives an

--- a/adoc/code/myfunctor.cpp
+++ b/adoc/code/myfunctor.cpp
@@ -9,8 +9,7 @@ class RandomFiller {
     std::uniform_int_distribution<> r { 1, 100 };
     randomNum_ = r(hwRand);
   }
-  void operator()(item<1> item) const { ptr_[item.get_id()] = get_random(); }
-  int get_random() const { return randomNum_; }
+  void operator()(item<1> item) const { ptr_[item.get_id()] = randomNum_; }
 
  private:
   accessor<int> ptr_;


### PR DESCRIPTION
This commit adjusts the `RandomFiller` example and its introduction in text to clarify that all elements of the buffer are initialized to the same random number, as opposed to generating a random number on each work-item.

Closes #198.