### PR TITLE
Align `wait_and_throw` from `queue::` and `event::`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4145,13 +4145,10 @@ void wait_and_throw()
 _Effects:_ Blocks the calling thread until all commands previously submitted to
 this queue have completed.
 Synchronous errors are reported through SYCL exceptions.
-Any unconsumed <<async-error,asynchronous errors>> are passed to the
-<<async-handler>> associated with the queue or to the <<async-handler>>
-associated with the queue's context.
-If no user defined asynchronous error handler is associated with the queue or
-its context, then an implementation-defined default <<async-handler>> is called
-to handle any errors, as described in <<subsubsec:exception.nohandler>>.
 
+At least all unconsumed <<async-error,asynchronous errors>> held by this queue
+(or its associated context) are passed to the appropriate <<async-handler>> as
+described in <<subsubsec:async.handler.priorities>>.
 '''
 
 .[apidef]#queue::throw_asynchronous#


### PR DESCRIPTION
The wording of these two functions had diverged over time, and needed to be pulled together again.

Closes #299.

---

Note that the wording for `event::wait_and_throw()` changed after @gmlueck proposed to align the two function descriptions in #299. What I've done here is try to update the `queue::wait_and_throw()` wording to match the new wording for `event::wait_and_throw()`.