### PR TITLE
Clarify `vec::as` behavior

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18019,14 +18019,9 @@ vec<ConvertT, NumElements> convert() const
 a@
 [source]
 ----
-template <typename asT> asT as() const
+template <typename AsT> AsT as() const
 ----
-   a@ Bitwise reinterprets this SYCL [code]#vec# as a SYCL [code]#vec# of a
-      different element type and number of elements specified by [code]#asT#.
-      The new SYCL [code]#vec# type must have the same storage size in bytes as
-      this SYCL [code]#vec#, and the size of the elements in the new SYCL
-      [code]#vec# ([code]#NumElements * sizeof(DataT)#) must be the same as the
-      size of the elements in this SYCL [code]#vec#.
+   a@ Equivalent to [code]#bit_cast<AsT>(*this)#.
 
 a@
 [source]


### PR DESCRIPTION
The original description did not cover various corner-cases that could lead to undefined behavior (e.g., reinterpreting using `vec::as<bool>`).

Since C++20 defines `std::bit_cast`, and SYCL 2020 pre-adopts `sycl::bit_cast`, defining `vec::as` equivalent to `bit_cast<AsT>` has two advantages:

- It simplifies the specification of `vec::as` significantly; and
- It enables `vec::as` to inherit undefined behavior, etc from `bit_cast`.

Closes #455.