### PR TITLE
Improve description of information descriptors

### DIFF
--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -287,9 +287,9 @@ For the full description please refer to <<subsec:buffers>>.
 [[information-descriptor]]information descriptor::
     A class encapsulating an information query and its return type.
     For example, an information descriptor called
-    [code]#sycl::info::class::name# would describe a query for the name of the
-    entity represented by that class, and would define a return type of
-    [code]#std::string#.
+    [code]#sycl::info::class::name# with a return type of [code]#std::string#
+    would describe a query for the name of the entity represented by that class,
+    where the name is an arbitrary string.
     Any information descriptors supported by a SYCL class are listed alongside
     the definition of that class, or in a <<backend>> specification.
 

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -290,8 +290,8 @@ For the full description please refer to <<subsec:buffers>>.
     [code]#sycl::info::class::name# would describe a query for the name of the
     entity represented by that class, and would define a return type of
     [code]#std::string#.
-    A full list of information descriptors for various SYCL classes can be found
-    in <<sec:information-descriptors>>.
+    Any information descriptors supported by a SYCL class are listed alongside
+    the definition of that class.
 
 [[input]]input::
     A state which a <<kernel-bundle>> can be in, representing

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -289,7 +289,7 @@ For the full description please refer to <<subsec:buffers>>.
     For example, an information descriptor called
     [code]#sycl::info::class::name# with a return type of [code]#std::string#
     would describe a query for the name of the entity represented by that class,
-    where the name is an arbitrary string.
+    where the name can be an arbitrary string.
     Any information descriptors supported by a SYCL class are listed alongside
     the definition of that class, or in a <<backend>> specification.
 

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -284,6 +284,15 @@ For the full description please refer to <<subsec:buffers>>.
   * [code]#sycl::group# : The <<group>> class that contains the
     <<work-group-id>> and the member functions on a <<work-group>>.
 
+[[information-descriptor]]information descriptor::
+    A class encapsulating an information query and its return type.
+    For example, an information descriptor called
+    [code]#sycl::info::class::name# would describe a query for the name of the
+    entity represented by that class, and would define a return type of
+    [code]#std::string#.
+    A full list of information descriptors for various SYCL classes can be found
+    in <<sec:information-descriptors>>.
+
 [[input]]input::
     A state which a <<kernel-bundle>> can be in, representing
     <<sycl-kernel-function,SYCL kernel functions>> as a source or intermediate

--- a/adoc/chapters/glossary.adoc
+++ b/adoc/chapters/glossary.adoc
@@ -291,7 +291,7 @@ For the full description please refer to <<subsec:buffers>>.
     entity represented by that class, and would define a return type of
     [code]#std::string#.
     Any information descriptors supported by a SYCL class are listed alongside
-    the definition of that class.
+    the definition of that class, or in a <<backend>> specification.
 
 [[input]]input::
     A state which a <<kernel-bundle>> can be in, representing

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -716,6 +716,40 @@ Construct a SYCL [code]#property_list# with zero or more properties.
 
 |====
 
+=== Information queries
+
+Each of the following classes provides a generic mechanism for querying the
+class for information: [code]#context#, [code]#device#, [code]#event#,
+[code]#kernel#, [code]#platform#, and [code]#queue#.
+
+Each available query is described by an <<information-descriptor>>, which is is
+a class or class template implementing the interface below:
+
+[source]
+----
+class __InformationDescriptor__
+{
+ public:
+  using return_type = /* return type for this information query */;
+};
+----
+
+==== Information query interface
+
+The information query interface consists of a [code]#get_info()# function
+template, which is templated on an <<information-descriptor>>.
+
+[source,role=synopsis]
+----
+template <typename Param>
+typename Param::return_type get_info() const;
+----
+
+_Constraints_: [code]#Param# must be an <<information-descriptor>> compatible
+with the class, as listed in <<sec:information-descriptors>>.
+
+_Returns_: The information corresponding to [code]#Param# in the table of
+information descriptors associated with the class.
 
 
 == SYCL runtime classes

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -722,8 +722,8 @@ Each of the following classes provides a generic mechanism for querying the
 class for information: [code]#context#, [code]#device#, [code]#event#,
 [code]#kernel#, [code]#platform#, and [code]#queue#.
 
-Each available query is described by an <<information-descriptor>>, which is
-a class or class template implementing the interface below:
+Each available query is described by an <<information-descriptor>>, which is a
+class or class template implementing the interface below:
 
 [source]
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -718,38 +718,20 @@ Construct a SYCL [code]#property_list# with zero or more properties.
 
 === Information queries
 
-Each of the following classes provides a generic mechanism for querying the
-class for information: [code]#context#, [code]#device#, [code]#event#,
-[code]#kernel#, [code]#platform#, and [code]#queue#.
+Several classes in SYCL provide a generic mechanism for querying the class for
+information.
 
 Each available query is described by an <<information-descriptor>>, which is a
-class or class template implementing the interface below:
-
-[source]
-----
-class __InformationDescriptor__
-{
- public:
-  using return_type = /* return type for this information query */;
-};
-----
+class or class template that encapsulates an information query and its return
+type.
 
 ==== Information query interface
 
 The information query interface consists of a [code]#get_info()# function
 template, which is templated on an <<information-descriptor>>.
 
-[source,role=synopsis]
-----
-template <typename Param>
-typename Param::return_type get_info() const;
-----
-
-_Constraints_: [code]#Param# must be an <<information-descriptor>> compatible
-with the class, as listed in <<sec:information-descriptors>>.
-
-_Returns_: The information corresponding to [code]#Param# in the table of
-information descriptors associated with the class.
+The information that can be queried for a specific class is listed alongside the
+definition of that class.
 
 
 == SYCL runtime classes

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -722,7 +722,7 @@ Each of the following classes provides a generic mechanism for querying the
 class for information: [code]#context#, [code]#device#, [code]#event#,
 [code]#kernel#, [code]#platform#, and [code]#queue#.
 
-Each available query is described by an <<information-descriptor>>, which is is
+Each available query is described by an <<information-descriptor>>, which is
 a class or class template implementing the interface below:
 
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -727,11 +727,19 @@ type.
 
 ==== Information query interface
 
-The information query interface consists of a [code]#get_info()# function
-template, which is templated on an <<information-descriptor>>.
+The information query interface consists of two function templates, templated on
+an <<information-descriptor>>:
 
-The information that can be queried for a specific class is listed alongside the
-definition of that class.
+* The [code]#get_info()# function template can be used to query general
+  information that is available with any backend; and
+
+* The [code]#get_backend_info()# function template can be used to query
+  backend-specific information.
+
+The information that can be queried with [code]#get_info()# for a specific class
+is listed alongside the definition of that class.
+The information that can be queried with [code]#get_backend_info()# is defined
+in the corresponding <<backend>> specification.
 
 
 == SYCL runtime classes


### PR DESCRIPTION
Previously, the description of information descriptors was spread out across multiple sections and appendices. This commit introduces a new section and a glossary entry to more clearly explain the concept of an information descriptor prior to detailing the behavior of each SYCL class.

Closes #410.  Addresses feedback originally raised by @nmnobre in #407. 

---

I deliberately added this to the end of the "Common interface" section so that it wouldn't affect renumbering, should we choose to cherry-pick it to SYCL 2020.