### PR TITLE
Add integral overloads for `id` and `range` operators

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12076,6 +12076,7 @@ a@
 [source]
 ----
 // Available only when std::is_integral_v<T> is true
+template <typename T>
 range operatorOP(const range& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
@@ -12097,6 +12098,7 @@ a@
 [source]
 ----
 // Available only when std::is_integral_v<T> is true
+template <typename T>
 range operatorOP(const T& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
@@ -12131,6 +12133,7 @@ a@
 [source]
 ----
 // Available only when std::is_integral_v<T> is true
+template <typename T>
 range& operatorOP(range& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -12420,6 +12423,7 @@ a@
 [source]
 ----
 // Available only when std::is_integral_v<T> is true
+template <typename T>
 id operatorOP(const id& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12437,6 +12441,7 @@ a@
 [source]
 ----
 // Only available when std::is_integral_v<T> is true
+template <typename T>
 id operatorOP(const T& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12468,6 +12473,7 @@ the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
+template <typename T>
 id& operatorOP(id& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12075,7 +12075,8 @@ is the cast to [code]#size_t#.
 a@
 [source]
 ----
-range operatorOP(const range& lhs, const size_t& rhs)
+// Available only when std::is_integral_v<T> is true
+range operatorOP(const range& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12088,8 +12089,8 @@ Constructs and returns a new instance of the SYCL [code]#range# class
 template with the same dimensionality as [code]#lhs# [code]#range#,
 where each element of the new SYCL [code]#range# instance is the result
 of an element-wise [code]#OP# operator between each element of this
-SYCL [code]#range# and the [code]#rhs# [code]#size_t#. If
-the operator returns a [code]#bool#, the result is the cast to
+SYCL [code]#range# and the [code]#rhs# integral type. If
+the operator returns a [code]#bool#, the result is then cast to
 [code]#size_t#.
 
 a@
@@ -12108,20 +12109,22 @@ to [code]#size_t#.
 a@
 [source]
 ----
-range& operatorOP(range& lhs, const size_t& rhs)
+// Available only when std::is_integral_v<T> is true
+range& operatorOP(range& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
 Assigns each element of [code]#lhs# [code]#range# instance with the
 result of an element-wise [code]#OP# operator between each element
-of [code]#lhs# [code]#range# and the [code]#rhs# [code]#size_t# and returns [code]#lhs# [code]#range#. If the
-operator returns a [code]#bool#, the result is the cast to
+of [code]#lhs# [code]#range# and the [code]#rhs# integral type and returns [code]#lhs# [code]#range#. If the
+operator returns a [code]#bool#, the result is then cast to
 [code]#size_t#.
 
 a@
 [source]
 ----
-range operatorOP(const size_t& lhs, const range& rhs)
+// Available only when std::is_integral_v<T> is true
+range operatorOP(const T& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12134,9 +12137,9 @@ Constructs and returns a new instance of the SYCL [code]#range# class
 template with the same dimensionality as the [code]#rhs# SYCL
 [code]#range#, where each element of the new SYCL [code]#range#
 instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# [code]#size_t# and each element of the
+the [code]#lhs# integral type and each element of the
 [code]#rhs# SYCL [code]#range#. If the operator returns a
-[code]#bool#, the result is the cast to [code]#size_t#.
+[code]#bool#, the result is then cast to [code]#size_t#.
 
 a@
 [source]
@@ -12416,7 +12419,8 @@ If the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id operatorOP(const id& lhs, const size_t& rhs)
+// Available only when std::is_integral_v<T> is true
+id operatorOP(const id& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12425,8 +12429,8 @@ Constructs and returns a new instance of the SYCL [code]#id# class
 template with the same dimensionality as [code]#lhs# [code]#id#, where
 each element of the new SYCL [code]#id# instance is the result of an
 element-wise [code]#OP# operator between each element of [code]#lhs#
-[code]#id# and the [code]#rhs# [code]#size_t#. If the
-operator returns a [code]#bool# the result is the cast to
+[code]#id# and the [code]#rhs# integral type. If the
+operator returns a [code]#bool# the result is then cast to
 [code]#size_t#.
 
 a@
@@ -12447,21 +12451,22 @@ the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id& operatorOP(id& lhs, const size_t& rhs)
+id& operatorOP(id& lhs, const T& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
 Assigns each element of [code]#lhs# [code]#id# instance with the
 result of an element-wise [code]#OP# operator between each element
-of [code]#lhs# [code]#id# and the [code]#rhs# [code]#size_t#
+of [code]#lhs# [code]#id# and the [code]#rhs# integral type
 and returns [code]#lhs# [code]#id#. If the operator
-returns a [code]#bool# the result is the cast to [code]#size_t#.
+returns a [code]#bool# the result is then cast to [code]#size_t#.
 
 a@
 [source]
 ----
-id operatorOP(const size_t& lhs, const id& rhs)
+// Only available when std::is_integral_v<T> is true
+id operatorOP(const T& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12470,9 +12475,9 @@ Constructs and returns a new instance of the SYCL [code]#id# class
 template with the same dimensionality as the [code]#rhs# SYCL
 [code]#id#, where each element of the new SYCL [code]#id#
 instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# [code]#size_t# and each element of the
+the [code]#lhs# integral type and each element of the
 [code]#rhs# SYCL [code]#id#. If the operator returns a
-[code]#bool# the result is the cast to [code]#size_t#.
+[code]#bool# the result is then cast to [code]#size_t#.
 
 a@
 [source]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12096,6 +12096,27 @@ the operator returns a [code]#bool#, the result is then cast to
 a@
 [source]
 ----
+// Available only when std::is_integral_v<T> is true
+range operatorOP(const T& lhs, const range& rhs)
+----
+   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
+      [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
+      [code]#&#, [code]#|#, [code]#^#,
+      [code]#&&#, [code]#||#,
+      [code]#<#, [code]#>#, [code]#+<=+#,
+      [code]#>=#.
+
+Constructs and returns a new instance of the SYCL [code]#range# class
+template with the same dimensionality as the [code]#rhs# SYCL
+[code]#range#, where each element of the new SYCL [code]#range#
+instance is the result of an element-wise [code]#OP# operator between
+the [code]#lhs# integral type and each element of the
+[code]#rhs# SYCL [code]#range#. If the operator returns a
+[code]#bool#, the result is then cast to [code]#size_t#.
+
+a@
+[source]
+----
 range& operatorOP(range& lhs, const range& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -12119,27 +12140,6 @@ result of an element-wise [code]#OP# operator between each element
 of [code]#lhs# [code]#range# and the [code]#rhs# integral type and returns [code]#lhs# [code]#range#. If the
 operator returns a [code]#bool#, the result is then cast to
 [code]#size_t#.
-
-a@
-[source]
-----
-// Available only when std::is_integral_v<T> is true
-range operatorOP(const T& lhs, const range& rhs)
-----
-   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
-      [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
-      [code]#&#, [code]#|#, [code]#^#,
-      [code]#&&#, [code]#||#,
-      [code]#<#, [code]#>#, [code]#+<=+#,
-      [code]#>=#.
-
-Constructs and returns a new instance of the SYCL [code]#range# class
-template with the same dimensionality as the [code]#rhs# SYCL
-[code]#range#, where each element of the new SYCL [code]#range#
-instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# integral type and each element of the
-[code]#rhs# SYCL [code]#range#. If the operator returns a
-[code]#bool#, the result is then cast to [code]#size_t#.
 
 a@
 [source]
@@ -12436,6 +12436,23 @@ operator returns a [code]#bool# the result is then cast to
 a@
 [source]
 ----
+// Only available when std::is_integral_v<T> is true
+id operatorOP(const T& lhs, const id& rhs)
+----
+   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
+      [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
+
+Constructs and returns a new instance of the SYCL [code]#id# class
+template with the same dimensionality as the [code]#rhs# SYCL
+[code]#id#, where each element of the new SYCL [code]#id#
+instance is the result of an element-wise [code]#OP# operator between
+the [code]#lhs# integral type and each element of the
+[code]#rhs# SYCL [code]#id#. If the operator returns a
+[code]#bool# the result is then cast to [code]#size_t#.
+
+a@
+[source]
+----
 id& operatorOP(id& lhs, const id& rhs)
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
@@ -12461,23 +12478,6 @@ result of an element-wise [code]#OP# operator between each element
 of [code]#lhs# [code]#id# and the [code]#rhs# integral type
 and returns [code]#lhs# [code]#id#. If the operator
 returns a [code]#bool# the result is then cast to [code]#size_t#.
-
-a@
-[source]
-----
-// Only available when std::is_integral_v<T> is true
-id operatorOP(const T& lhs, const id& rhs)
-----
-   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
-      [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
-
-Constructs and returns a new instance of the SYCL [code]#id# class
-template with the same dimensionality as the [code]#rhs# SYCL
-[code]#id#, where each element of the new SYCL [code]#id#
-instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# integral type and each element of the
-[code]#rhs# SYCL [code]#id#. If the operator returns a
-[code]#bool# the result is then cast to [code]#size_t#.
 
 a@
 [source]

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -36,11 +36,13 @@ template <int Dimensions = 1> class id {
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend id operatorOP(const id& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend id operatorOP(const T& lhs, const id& rhs) { /* ... */
   }
 
@@ -50,6 +52,7 @@ template <int Dimensions = 1> class id {
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend id& operatorOP(id& lhs, const T& rhs) { /* ... */
   }
 

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -33,17 +33,24 @@ template <int Dimensions = 1> class id {
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   friend id operatorOP(const id& lhs, const id& rhs) { /* ... */
   }
-  friend id operatorOP(const id& lhs, const size_t& rhs) { /* ... */
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  friend id operatorOP(const id& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend id& operatorOP(id& lhs, const id& rhs) { /* ... */
   }
-  friend id& operatorOP(id& lhs, const size_t& rhs) { /* ... */
+
+  // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
+  // Available only when std::is_integral_v<T> is true
+  friend id& operatorOP(id& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend id operatorOP(const size_t& lhs, const id& rhs) { /* ... */
+  // Available only when std::is_integral_v<T> is true
+  friend id operatorOP(const T& lhs, const id& rhs) { /* ... */
   }
 
   // OP is unary +, -

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -39,6 +39,11 @@ template <int Dimensions = 1> class id {
   friend id operatorOP(const id& lhs, const T& rhs) { /* ... */
   }
 
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  friend id operatorOP(const T& lhs, const id& rhs) { /* ... */
+  }
+
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend id& operatorOP(id& lhs, const id& rhs) { /* ... */
   }
@@ -46,11 +51,6 @@ template <int Dimensions = 1> class id {
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   // Available only when std::is_integral_v<T> is true
   friend id& operatorOP(id& lhs, const T& rhs) { /* ... */
-  }
-
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  // Available only when std::is_integral_v<T> is true
-  friend id operatorOP(const T& lhs, const id& rhs) { /* ... */
   }
 
   // OP is unary +, -

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -29,17 +29,24 @@ template <int Dimensions = 1> class range {
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   friend range operatorOP(const range& lhs, const range& rhs) { /* ... */
   }
-  friend range operatorOP(const range& lhs, const size_t& rhs) { /* ... */
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  friend range operatorOP(const range& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend range& operatorOP(range& lhs, const range& rhs) { /* ... */
   }
-  friend range& operatorOP(range& lhs, const size_t& rhs) { /* ... */
+
+  // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
+  // Available only when std::is_integral_v<T> is true
+  friend range& operatorOP(range& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const size_t& lhs, const range& rhs) { /* ... */
+  // Available only when std::is_integral_v<T> is true
+  friend range operatorOP(const T& lhs, const range& rhs) { /* ... */
   }
 
   // OP is unary +, -

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -32,11 +32,13 @@ template <int Dimensions = 1> class range {
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend range operatorOP(const range& lhs, const T& rhs) { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend range operatorOP(const T& lhs, const range& rhs) { /* ... */
   }
 
@@ -46,6 +48,7 @@ template <int Dimensions = 1> class range {
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   // Available only when std::is_integral_v<T> is true
+  template <typename T>
   friend range& operatorOP(range& lhs, const T& rhs) { /* ... */
   }
 

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -35,6 +35,11 @@ template <int Dimensions = 1> class range {
   friend range operatorOP(const range& lhs, const T& rhs) { /* ... */
   }
 
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  friend range operatorOP(const T& lhs, const range& rhs) { /* ... */
+  }
+
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend range& operatorOP(range& lhs, const range& rhs) { /* ... */
   }
@@ -42,11 +47,6 @@ template <int Dimensions = 1> class range {
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   // Available only when std::is_integral_v<T> is true
   friend range& operatorOP(range& lhs, const T& rhs) { /* ... */
-  }
-
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  // Available only when std::is_integral_v<T> is true
-  friend range operatorOP(const T& lhs, const range& rhs) { /* ... */
   }
 
   // OP is unary +, -


### PR DESCRIPTION
The specification previously only listed an overload for `size_t`. However, all existing SYCL implementations provide overloads for
all integral types to avoid ambiguity in operator overloads.

This change aligns the specification with the behavior of existing SYCL implementations.

Closes #539, closes #711.

---

Note that I also re-ordered the synopses for `id` and `range` based on an observation made during discussion in #711.  It might be easier to review the changes from the two commits separately: the first commit adjusts the overloads, and the second commit reorders things.