### PR TITLE
Fix regex in api_xrefs

### DIFF
--- a/adoc/config/api_xrefs/extension.rb
+++ b/adoc/config/api_xrefs/extension.rb
@@ -70,16 +70,16 @@ class AddApiXrefs < Extensions::Postprocessor
       api_id_array = []
       if document.attr? 'api-xrefs'
         (document.attr 'api-xrefs').scan(/([^=\s]+)=([^=\s]+)/) do |api, id|
-          if not all_ids.key?(id)
-            logger.error "Id '#{id}' from api-xrefs is not defined"
-            next
-          end
           if not /^[\w:]+$/.match?(api)
             logger.error "API '#{api}' from api-xrefs contains invalid characters"
             next
           end
           if not /^[\w:-]+$/.match?(id)
             logger.error "Id '#{id}' from api-xrefs contains invalid characters"
+            next
+          end
+          if not all_ids.key?(id)
+            logger.error "Id '#{id}' from api-xrefs is not defined"
             next
           end
           api_id_array.push([api, id])

--- a/adoc/config/api_xrefs/extension.rb
+++ b/adoc/config/api_xrefs/extension.rb
@@ -53,10 +53,10 @@ include ::Asciidoctor
 class AddApiXrefs < Extensions::Postprocessor
   include Asciidoctor::Logging
 
-  Id = /<\w+ id="([\w:-]*)"/
-  ApiSpan = /<span class="api">([\w:]*)<\/span>/
-  ApiDefSpan = /<span class="apidef">([\w:]*)<\/span>/
-  ApiIdDiv = /<div id="([\w:-]*)"/
+  Id = /<\w+ id="([\w:-]+)"/
+  ApiSpan = /<span class="api">([\w:]+)<\/span>/
+  ApiDefSpan = /<span class="apidef">([\w:]+)<\/span>/
+  ApiIdDiv = /<div id="([\w:-]+)"/
 
   def process document, output
 
@@ -69,12 +69,20 @@ class AddApiXrefs < Extensions::Postprocessor
       # in the document.  Populate "api_id_array" with this information.
       api_id_array = []
       if document.attr? 'api-xrefs'
-        (document.attr 'api-xrefs').scan(/([\w:-]*)=([\w:-]*)/) do |api, id|
+        (document.attr 'api-xrefs').scan(/([^=\s]+)=([^=\s]+)/) do |api, id|
           if not all_ids.key?(id)
             logger.error "Id '#{id}' from api-xrefs is not defined"
-          else
-            api_id_array.push([api, id])
+            next
           end
+          if not /^[\w:]+$/.match?(api)
+            logger.error "API '#{api}' from api-xrefs contains invalid characters"
+            next
+          end
+          if not /^[\w:-]+$/.match?(id)
+            logger.error "Id '#{id}' from api-xrefs contains invalid characters"
+            next
+          end
+          api_id_array.push([api, id])
         end
       end
 


### PR DESCRIPTION
~~Based on line 72, I *think* the intent was always that `-` would be a valid character for api-xrefs IDs (even though it's not a valid character for C++ identifiers). Prior to this fix, API IDs with `-` characters (e.g., `[api]#my-api#` in asciidoc) were silently not getting the `href` treatment, because they were missed by the regex on line 117. I.e., `[api]#my_api#` would get a link in the HTML, `[api]#my-api#` would not, and no error was generated.~~

~~This took a while to debug.~~

~~Caveat: I know nothing about Ruby.~~

* Make `-` an invalid character in API names
* Improve error messages when invalid characters used in `api-xrefs` variable
* Replace `*` with `+`, since I don't think matching 0-length strings was ever intended