### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: 🐛 Bug report
+description: Report something broken in the specification.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug!
+
+        Please remember that this GitHub repository is for the SYCL *specification*; if you have found a bug in a SYCL *implementation*, you should contact the developers of that implementation instead.
+
+  - type: dropdown
+    id: specification-version
+    attributes:
+      label: Specification Version
+      description: |
+        What version of the specification contains the bug?
+      options:
+        - SYCL 2020 (Revision 9)
+        - SYCL 2020 (Source)
+        - SYCL Next (Source)
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: section-numbers
+    attributes:
+      label: Section Number(s)
+      description: List out the section(s) containing the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: |
+        Explain why the specification is wrong.
+        Please be as detailed as possible, and quote the specification text.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/clarification_request.yml
+++ b/.github/ISSUE_TEMPLATE/clarification_request.yml
@@ -1,0 +1,50 @@
+name: ❓ Clarification request
+description: Highlight an inconsistency or unclear description.
+labels: ["clarification"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to improve the SYCL specification.
+
+  - type: dropdown
+    id: specification-version
+    attributes:
+      label: Specification Version
+      description: |
+        What version of the specification is unclear?
+      options:
+        - SYCL 2020 (Revision 9)
+        - SYCL 2020 (Source)
+        - SYCL Next (Source)
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: section-numbers
+    attributes:
+      label: Section Number(s)
+      description: List out the section(s) that are unclear.
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: |
+        Explain why you think the specification is unclear.
+        Please be as detailed as possible, and quote the specification text.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-example
+    attributes:
+      label: Code Example (Optional)
+      description: |
+        Provide one or more SYCL examples to demonstrate the issue.
+        This is not required, but may help others to understand the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: 🚀 Feature request
+description: Request a new SYCL feature or extension.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to improve the SYCL specification.
+
+  - type: dropdown
+    id: extension-type
+    attributes:
+      label: Extension Type
+      description: |
+        Does this feature build on an existing SYCL feature?
+      options:
+        - "Yes"
+        - "No"
+      default: 1
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: |
+        Describe the desired feature in as much detail as possible.
+        Be sure to explain why existing features are insufficient.
+    validations:
+      required: true
+
+  - type: textarea
+    id: cpp-features
+    attributes:
+      label: Related Functionality in C++
+      description: |
+        If related functionality already exists in C++, please provide
+        details. 
+    validations:
+      required: false
+
+  - type: textarea
+    id: similar-features
+    attributes:
+      label: Related Functionality in Other Languages
+      description: |
+        If related functionality already exists in other languages (e.g.,
+        OpenCL, CUDA, OpenMP), please provide details.
+    validations:
+      required: false
+
+  - type: textarea
+    id: existing-extensions
+    attributes:
+      label: Related SYCL Extensions
+      description: |
+        If related functionality already exists in the form of a SYCL
+        extension, please provide a link to that extension.
+    validations:
+      required: false
+


### PR DESCRIPTION
Managing and automating our handling of GitHub issues would be easier if we imposed more consistent formatting and encouraged contributors to provide specific information.

This commit introduces three different templates:

- Bug Report: Report a bug in the specification.
- Clarification Request: Highlight that something is unclear.
- Feature Request: Request a new SYCL feature/extension.

We may require additional issue types in the future, but based on recent efforts to reduce the GitHub backlog, it seems like the majority of issues fall into one of these categories.

---

Issue templates are only visible once merged to main, but you can see the effects of this change on my fork: https://github.com/Pennycook/SYCL-Docs/issues/new/choose. Selecting an issue type prompts the reporter to provide certain information and automatically applies appropriate labels.  My hope is that this will make it easier for us to triage new issues; we'll have more information to help us identify which areas of the specification to review/change, and we'll no longer have to read an issue to determine whether it is a bug report, clarification request or feature request.