### PR TITLE
Clarify requirements for types in device code

### DIFF
--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -216,132 +216,31 @@ The restriction waiver in <<discarded-statement>> or
 <<device-function>>.
 ====
 
-[[subsec:scalartypes]]
-== Built-in scalar data types
+== Data types
 
-In a SYCL device compiler, the device definition of all standard {cpp}
-fundamental types from <<table.types.fundamental>> must match the host
-definition of those types, in both size and alignment.
-A device compiler may have this preconfigured so that it can match them based on
-the definitions of those types on the platform, or there may be a necessity for
-a device compiler command-line option to ensure the types are the same.
+The following types must be available in device code:
 
-The standard {cpp} fixed width types, e.g. [code]#int8_t#, [code]#int16_t#,
-[code]#int32_t#,[code]#int64_t#, should have the same size as defined by the
-{cpp} standard for host and device.
+- The fundamental data types defined by the {cpp} core language (i.e.,
+  [code]#bool#, [code]#char#, [code]#signed char#, [code]#unsigned char#,
+  [code]#short int#, [code]#unsigned short int#, [code]#int#, [code]#unsigned
+  int#, [code]#long int#, [code]#unsigned long int#, [code]#long long int#,
+  [code]#unsigned long long int#, [code]#float# and [code]#double#);
 
+- The fixed width types defined by the {cpp} core language (e.g.,
+  [code]#int8_t#, [code]#int16_t#, [code]#int32_t#, [code]#int64_t#); and
 
-[[table.types.fundamental]]
-.Fundamental data types supported by SYCL
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Fundamental data type @ Description
-a@
-[source]
-----
-bool
-----
-   a@ A conditional data type which can be either true or false. The value
-      true expands to the integer constant 1 and the value false expands to the
-      integer constant 0.
+- Any type aliases defined by the {cpp} core language (e.g.,
+  [code]#std::size_t#, [code]#std::ptrdiff_t#).
 
-a@
-[source]
-----
-char
-----
-   a@ A signed or unsigned 8-bit integer, as defined by the {cpp} core language
+All types which are available in device code must have the same size, alignment
+requirements, and representation on both host and device.
+A device compiler may rely on additional command-line options to provide this
+guarantee for specific combinations of host and device.
 
-a@
-[source]
-----
-signed char
-----
-   a@ A signed 8-bit integer, as defined by the {cpp} core language
-
-a@
-[source]
-----
-unsigned char
-----
-   a@ An unsigned 8-bit integer, as defined by the {cpp} core language
-
-a@
-[source]
-----
-short int
-----
-   a@ A signed integer of at least 16-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-unsigned short int
-----
-   a@ An unsigned integer of at least 16-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-int
-----
-   a@ A signed integer of at least 16-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-unsigned int
-----
-   a@ An unsigned integer of at least 16-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-long int
-----
-   a@ A signed integer of at least 32-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-unsigned long int
-----
-   a@ An unsigned integer of at least 32-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-long long int
-----
-   a@ An integer of at least 64-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-unsigned long long int
-----
-   a@ An unsigned integer of at least 64-bits, as defined by the {cpp} core language
-
-a@
-[source]
-----
-float
-----
-   a@ A 32-bit floating-point. The float data type must conform to the IEEE 754
-      single precision storage format.
-
-a@
-[source]
-----
-double
-----
-   a@ A 64-bit floating-point. The double data type must conform to the IEEE 754
-      double precision storage format.  This type is only supported on devices
-      that have [code]#aspect::fp64#.
-
-|====
-
-
+The availability of these types in device code does not guarantee that they will
+be supported by all devices.
+Some types are only supported on devices with specific device aspects, as
+descrived in <<sec:device-aspects>>.
 
 == Preprocessor directives and macros
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17809,25 +17809,13 @@ std::error_code make_error_code(errc e) noexcept;
 
 == Data types
 
-SYCL as a {cpp} programming model supports the {cpp} core language data types,
-and it also provides the ability for all SYCL applications to be executed on
-SYCL compatible devices.
-The scalar and vector data types that are supported by the SYCL system are
-defined below.
-More details about the SYCL device compiler support for fundamental and backend
-interoperability types are found in <<subsec:scalartypes>>.
+All types which are available in device code must have the same size, alignment
+requirements, and representation on both host and device.
 
+=== Scalar types
 
-=== Scalar data types
-
-The fundamental {cpp} data types which are supported in SYCL are described in
-<<table.types.fundamental>>.
-Note these types are fundamental and therefore do not exist within the
-[code]#sycl# namespace.
-
-Additional scalar data types which are supported by SYCL within the [code]#sycl#
-namespace are described in <<table.types.additional>>.
-
+In addition to the scalar types defined by {cpp}, SYCL defines a number of
+scalar types as described in <<table.types.additional>>.
 
 [[table.types.additional]]
 .Additional scalar data types supported by SYCL


### PR DESCRIPTION
The goal of this PR is to clarify:
- Which types are guaranteed to be available in device code; and
- What guarantees exist for consistency of types across host and device.

As part of this change I removed the table of fundamental types, which duplicated a lot of information defined in C++.  Just saying that we support the types with the same meaning as C++ seems simpler.  I kept the list of types, but long-term I'd prefer to be able to say that SYCL supports all the C++ fundamental types and leave it at that.

Closes #372 and closes #373.

---

I can't assign this to you, @tahonermann, but since you originally opened these issues I'd appreciate it if you could take a look at this proposed fix.

I've opened it as a draft because it currently doesn't build, due to a broken reference to the table I removed.  That reference will ve removed if we merge #730, though, so I wanted to open a PR and get some feedback.