### PR TITLE
Fix `local_accessor::swap(accessor &other);` typo

### DIFF
--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -31,7 +31,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
 
   /* -- common interface members -- */
 
-  void swap(accessor& other);
+  void swap(local_accessor& other);
 
   size_type byte_size() const noexcept;
 


### PR DESCRIPTION
Table 78 lists it as `void swap(local_accessor& other);` which makes much more sense. Align synopsis with the description of member functions for the `local_accessor` class.