### PR TITLE
Fix reference to rule of five in common-byval.h

### DIFF
--- a/adoc/headers/common-byval.h
+++ b/adoc/headers/common-byval.h
@@ -8,9 +8,10 @@ class T {
 
       public
       :
-      // If any of the following five special member functions are not
-      // public, inline or defaulted, then all five of them should be
-      // explicitly declared (see rule of five).
+      // If any of the following five special member functions are declared,
+      // then all five of them should be explicitly declared (see rule of
+      // five).
+      //
       // Otherwise, none of them should be explicitly declared
       // (see rule of zero).
 


### PR DESCRIPTION
Fixes #489, using wording proposed by @nliber and aligned with the glossary.

#489 says the code snippet is non-normative, so I've marked this editorial.