### PR TITLE
Remove minimum max_mem_alloc_size

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2112,9 +2112,6 @@ struct max_mem_alloc_size {
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ The maximum size of memory object allocation in bytes.
-The minimum value is max (1/4th of
-[code]#info::device::global_mem_size#,128*1024*1024) if this device is not of
-device type [api]#info::device_type::custom#.
 
 '''
 


### PR DESCRIPTION
This minimum value was originally inherited from OpenCL 1.2. Most OpenCL 1.2-specific text was removed between SYCL 1.2.1 and SYCL 2020, but this was missed.

This change doesn't prevent OpenCL-based implementations from returning these values, but removes the restriction that implementations using other backends must enforce the same limits as OpenCL.

Closes #378. 