### PR TITLE
Fix definition of marray::size()

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19520,7 +19520,7 @@ a@
 ----
 static constexpr std::size_t size() noexcept
 ----
-   a@ Returns the size of this SYCL [code]#marray# in bytes.
+   a@ Returns the number of elements in this SYCL [code]#marray# (i.e., [code]#NumElements#).
 
 a@
 [source]


### PR DESCRIPTION
Cherry pick #716 from main
(cherry picked from commit 7499fc7d1b5332938f42409cb8b975aeacc99fda)