### PR TITLE
Clarify `is_available`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2759,6 +2759,8 @@ _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ The value [code]#true# if the device is available and [code]#false#
 if the device is not available.
+A device is considered to be available if the device can be expected to
+successfully execute commands enqueued to the device.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2761,6 +2761,8 @@ _Returns:_ The value [code]#true# if the device is available and [code]#false#
 if the device is not available.
 A device is considered to be available if the device can be expected to
 successfully execute commands enqueued to the device.
+The conditions that lead to a device being considered available or not available
+are implementation-defined.
 
 '''
 


### PR DESCRIPTION
The `is_available` query is based on `CL_DEVICE_AVAILABLE` from OpenCL. The most recent OpenCL standard includes an extra sentence that wasn't copied over to SYCL 2020, and this PR fixes that.

I also added an extra sentence to clarify that what causes a device to move between available and not available is implementation-defined.  This wasn't part of OpenCL, but I can't see a way to avoid specifying it this way in SYCL: the least surprising way to implement this on an OpenCL backend would be to say "It returns the result of `CL_DEVICE_AVAILABLE`", but that is only possible if it's implementation-defined.

Closes #347.

---

My personal opinion is that this query isn't very useful, and that we should deprecate it and remove it in SYCL-Next. But that's a separate issue to what the behavior should be in SYCL 2020.