### PR TITLE
Remove reference to OpenCL 1.2 memory model

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -949,7 +949,7 @@ image::{images}/host-acc.svg[align="center",opts="{imageopts}"]
 
 === SYCL device memory model
 
-The memory model for SYCL devices is based on the OpenCL 1.2 memory model.
+The memory model for SYCL devices is based on the OpenCL memory model.
 Work-items executing in a kernel have access to three distinct address spaces
 (memory regions) and a virtual address space overlapping some concrete address
 spaces:


### PR DESCRIPTION
Cherry pick #714 from main
(cherry picked from commit 30f2d95bd39e5fabad253f613b5bd82bd180b1fd)