### PR TITLE
Fix incorrect reference to vec::as

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -19345,8 +19345,8 @@ _Returns:_ A [code]#vec# object that represents the result of the operation.
 
 ==== Rounding modes
 
-The various rounding modes that can be used in the [code]#as# member function
-template are described in <<table.vec.roundingmodes>>.
+The various rounding modes that can be used in the [code]#convert# member
+function template are described in <<table.vec.roundingmodes>>.
 
 
 [[table.vec.roundingmodes]]


### PR DESCRIPTION
Cherry pick #718 from main
(cherry picked from commit 14a512877592aa08122d4b57b430f210a76ff82c)