### PR TITLE
Remove references to `compile`/`build_with_source`

### DIFF
--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -1056,9 +1056,9 @@ C libraries during offline compilation or during online compilation by the
 Linking with OpenCL C kernel functions offline is an optional feature and is
 unspecified.
 Linking with OpenCL C kernel functions online is performed via the
-[code]#sycl::make_kernel_bundle# or [code]#sycl::opencl::create_bundle# functions, which both
-provide a mechanism to create an instance of a SYCL [code]#kernel_bundle# from a
-[code]#cl_program#.
+[code]#sycl::make_kernel_bundle# or [code]#sycl::opencl::create_bundle#
+functions, which both provide a mechanism to create an instance of a SYCL
+[code]#kernel_bundle# from a [code]#cl_program#.
 
 OpenCL C functions that are linked with, using either offline or online
 compilation, must be declared as [code]#extern "C"# function declarations.

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -1056,7 +1056,7 @@ C libraries during offline compilation or during online compilation by the
 Linking with OpenCL C kernel functions offline is an optional feature and is
 unspecified.
 Linking with OpenCL C kernel functions online is performed via the
-[code]#make_kernel_bundle# or [code]#create_kernel_bundle# functions, which both
+[code]#sycl::make_kernel_bundle# or [code]#sycl::opencl::create_bundle# functions, which both
 provide a mechanism to create an instance of a SYCL [code]#kernel_bundle# from a
 [code]#cl_program#.
 

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -1055,9 +1055,10 @@ C libraries during offline compilation or during online compilation by the
 
 Linking with OpenCL C kernel functions offline is an optional feature and is
 unspecified.
-Linking with OpenCL C kernel functions online is performed by using the SYCL
-[code]#kernel_bundle# class to compile and link an OpenCL C source; using the
-[code]#compile_with_source# or [code]#build_with_source# member functions.
+Linking with OpenCL C kernel functions online is performed via the
+[code]#make_kernel_bundle# or [code]#create_kernel_bundle# functions, which both
+provide a mechanism to create an instance of a SYCL [code]#kernel_bundle# from a
+[code]#cl_program#.
 
 OpenCL C functions that are linked with, using either offline or online
 compilation, must be declared as [code]#extern "C"# function declarations.


### PR DESCRIPTION
These functions were removed alongside the `program` object in SYCL 2020.

The section correctly pointed to `kernel_bundle` as the replacement, but referred to member functions that didn't exist.

Closes #389.

---

I'm honestly not sure whether I've fixed this correctly, and I was surprised to discover that we define both a `make_kernel_bundle` and a `create_bundle` function.  I _think_ this is correct, though -- a developer can create a `cl_program` from source using OpenCL functionality, and then create a `kernel_bundle` from that.