### PR TITLE
Remove "implementation note"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -942,9 +942,6 @@ There is no requirement for the implementation to have for example
 [code]#sycl::gpu_selector_v# being an instance of [code]#sycl::gpu_selector#.
 ====
 
-NOTE: Implementation note: the SYCL API might rely on SFINAE or {cpp20} concepts
-to resolve some ambiguity in constructors with default parameters.
-
 
 [[sec:platform-class]]
 === Platform class


### PR DESCRIPTION
This is the only such "implementation note" in the specification, and it doesn't seem to add anything.

---

I found this by accident, while trying to write some tooling to extract things from the SYCL specification.  This "implementation note" doesn't have the same formatting as other non-normative notes, which broke my tooling. 😄 

I originally intended to just fix the admonition block, but I think it would be better to remove this note entirely. Implementers can use SFINAE and/or concepts anywhere they like, and calling this out specifically in the device selector section doesn't seem valuable to me.