### PR TITLE
Fix description of `sycl::free`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11777,35 +11777,31 @@ necessary [code]#device#.
 
 ==== Memory deallocation functions
 
-[[table.usm.free]]
-.USM Deallocation Functions
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Function @ Description
-a@
-[source]
+.[apidef]#free#
+[source,role=synopsis,id=api:free]
 ----
-void sycl::free(void* ptr, const context& syclContext)
+void free(void* ptr, const context& ctxt); (1)
+void free(void* ptr, const queue& q);      (2)
 ----
-a@ Frees an allocation.
-The memory pointed to by [code]#ptr# must have been allocated using one of the
-USM allocation routines or it must be a null pointer.
-If [code]#ptr# is not null, the [code]#syclContext# must be the same
-[code]#context# that was used to allocate the memory.
-If [code]#ptr# is null, this function has no effect.
-Otherwise, the memory is freed without waiting for <<command, commands>>
-operating on it to be completed.
-If <<command, commands>> that use this memory are in-progress or are enqueued,
-the behavior is undefined.
 
-a@
-[source]
-----
-void sycl::free(void* ptr, const queue& syclQueue)
-----
-a@ Alternate form where [code]#syclQueue# provides the [code]#context#.
+*Overload (1):*
 
-|====
+_Preconditions_:
+
+* [code]#ptr# points to memory allocated against [code]#ctxt# using one of the
+  USM allocation routines, or is a null pointer; and
+
+* There are no in-progress or enqueued <<command, commands>> using the memory
+  pointed to by [code]#ptr#.
+
+_Effects_: The memory pointed to by [code]#ptr# is freed, without waiting for
+<<command, commands>> operating on it to be completed.
+
+_Remarks_: If [code]#ptr# is null, this function has no effect.
+
+*Overload (2):*
+
+_Effects_: Equivalent to [code]#return free(ptr, q.get_context());#.
 
 === Unified shared memory pointer queries
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11789,7 +11789,9 @@ void free(void* ptr, const queue& q);      (2)
 _Preconditions_:
 
 * [code]#ptr# points to memory allocated against [code]#ctxt# using one of the
-  USM allocation routines, or is a null pointer; and
+  USM allocation routines, or is a null pointer;
+
+* [code]#ptr# has not previously been deallocated; and
 
 * There are no in-progress or enqueued <<command, commands>> using the memory
   pointed to by [code]#ptr#.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11808,6 +11808,10 @@ _Remarks_: If [code]#ptr# is null, this function has no effect.
 
 _Effects_: Equivalent to [code]#return free(ptr, q.get_context());#.
 
+{note}Although this overload accepts a [code]#queue# argument, it does not
+submit a "free" <<command>> to the device; the [code]#queue# argument is only
+used to determine the [code]#context# associated with [code]#ptr#.{endnote}
+
 === Unified shared memory pointer queries
 
 Since USM pointers look like raw {cpp} pointers, users cannot deduce what kind

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11796,6 +11796,10 @@ _Preconditions_:
 
 _Effects_: The memory pointed to by [code]#ptr# is deallocated.
 
+{note}Whether [code]#free# is blocking or non-blocking is unspecified.
+Applications should not rely on [code]#free# for synchronization, nor assume
+that [code]#free# cannot cause deadlocks.{endnote}
+
 _Remarks_: If [code]#ptr# is null, this function has no effect.
 
 *Overload (2):*

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11794,8 +11794,7 @@ _Preconditions_:
 * There are no in-progress or enqueued <<command, commands>> using the memory
   pointed to by [code]#ptr#.
 
-_Effects_: The memory pointed to by [code]#ptr# is freed, without waiting for
-<<command, commands>> operating on it to be completed.
+_Effects_: The memory pointed to by [code]#ptr# is deallocated.
 
 _Remarks_: If [code]#ptr# is null, this function has no effect.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11796,7 +11796,7 @@ _Preconditions_:
 * There are no in-progress or enqueued <<command, commands>> using the memory
   pointed to by [code]#ptr#.
 
-_Effects_: The memory pointed to by [code]#ptr# is deallocated.
+_Effects_: Causes the memory pointed to by [code]#ptr# to be deallocated.
 
 {note}Whether [code]#free# is blocking or non-blocking is unspecified.
 Applications should not rely on [code]#free# for synchronization, nor assume


### PR DESCRIPTION
This PR makes three changes, which I've split into three commits to simplify review.

1. The description of `sycl::free` is migrated to the new format.

2. An unnecessary statement about "waiting" is removed.  This statement was already covered by (and in fact, inconsistent with!) `sycl::free` having undefined behavior in the case where `sycl::free` is called while a command is in-progress.  Whether an implementation waits for in-progress commands or not doesn't matter, because that usage is invalid.

3. I added a non-normative note to highlight that `sycl::free` is not guaranteed to be blocking or non-blocking.  The old wording implied that `sycl::free` was always guaranteed to be non-blocking, but this isn't the case for existing implementations.