### PR TITLE
Deprecate hierarchical parallelism

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1253,20 +1253,11 @@ Variables with <<reduction>> semantics can be added to work-group data parallel
 kernels using the features described in <<sec:reduction>>.
 
 
-=== Hierarchical data parallel kernels
+=== Hierarchical data parallel kernels (deprecated)
 
-[NOTE]
-====
-Based on developer and implementation feedback, the hierarchical data parallel
-kernel feature described next is undergoing improvements to better align with
-the frameworks and patterns prevalent in modern programming.
-As this is a key part of the SYCL API and we expect to make changes to it, we
-temporarily recommend that new codes refrain from using this feature until the
-new API is finished in a near-future version of the SYCL specification, when
-full use of the updated feature will be recommended for use in new code.
-Existing codes using this feature will of course be supported by conformant
-implementations of this specification.
-====
+Hierarchical data parallel kernels and all classes that are only available
+within such kernels are deprecated in SYCL 2020, and will be removed in a future
+version of SYCL.
 
 The SYCL compiler provides a way of specifying data parallel kernels that
 execute within work-groups via a different syntax which highlights the

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14864,6 +14864,9 @@ include::{code_dir}/parallelForWithKernelHandler.cpp[lines=4..-1]
 [[sec:parallel-for-hierarchical]]
 ===== Parallel for hierarchical invoke (deprecated)
 
+The behavior in this section and the [code]#private_memory# class are deprecated
+in SYCL 2020.
+
 The hierarchical parallel kernel execution interface provides the same
 functionality as is available from the <<nd-range>> interface, but exposed
 differently.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12972,6 +12972,8 @@ template <typename... EventTN> void wait_for(EventTN... events) const
 [[hitem-class]]
 ==== [code]#h_item# class (deprecated)
 
+The [code]#h_item# class is deprecated in SYCL 2020.
+
 [code]#h_item<int Dimensions># identifies an instance of a
 [code]#group::parallel_for_work_item# function object executing at each point in
 a local [code]#range<int Dimensions># passed to a [code]#parallel_for_work_item#

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12970,7 +12970,7 @@ template <typename... EventTN> void wait_for(EventTN... events) const
 
 
 [[hitem-class]]
-==== [code]#h_item# class
+==== [code]#h_item# class (deprecated)
 
 [code]#h_item<int Dimensions># identifies an instance of a
 [code]#group::parallel_for_work_item# function object executing at each point in
@@ -13335,7 +13335,8 @@ a@
 template <typename WorkItemFunctionT>
 void parallel_for_work_item(const WorkItemFunctionT& func) const
 ----
-   a@ Launch the work-items for this work-group.
+   a@ Deprecated in SYCL 2020.
+      Launch the work-items for this work-group.
 
 [code]#func# is a function object type with a public member function
 [code]#void F::operator()(h_item<Dimensions>)#
@@ -13358,7 +13359,8 @@ template <typename WorkItemFunctionT>
 void parallel_for_work_item(range<Dimensions> logicalRange,
                             const WorkItemFunctionT& func) const
 ----
-   a@ Launch the work-items for this work-group using a logical local range.
+   a@ Deprecated in SYCL 2020.
+      Launch the work-items for this work-group using a logical local range.
       The function object [code]#func# is executed as if the kernel were
       invoked with [code]#logicalRange# as the local range. This new local
       range is emulated and may not map one-to-one with the physical range.
@@ -14519,7 +14521,8 @@ template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
 void parallel_for_work_group(range<Dimensions> numWorkGroups,
                              const WorkgroupFunctionType& kernelFunc)
 ----
-   a@ Defines and invokes a hierarchical kernel as a lambda expression
+   a@ Deprecated in SYCL 2020.
+      Defines and invokes a hierarchical kernel as a lambda expression
       or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#. May
@@ -14540,7 +14543,8 @@ void parallel_for_work_group(range<Dimensions> numWorkGroups,
                              range<Dimensions> workGroupSize,
                              const WorkgroupFunctionType& kernelFunc)
 ----
-   a@ Defines and invokes a hierarchical kernel as a lambda expression
+   a@ Deprecated in SYCL 2020.
+      Defines and invokes a hierarchical kernel as a lambda expression
       or a named function object type,
       encoding the body of each work-group to launch. Generic kernel
       functions are permitted, in that case the argument type is a [code]#group#.
@@ -14856,7 +14860,7 @@ include::{code_dir}/parallelForWithKernelHandler.cpp[lines=4..-1]
 
 
 [[sec:parallel-for-hierarchical]]
-===== Parallel for hierarchical invoke
+===== Parallel for hierarchical invoke (deprecated)
 
 The hierarchical parallel kernel execution interface provides the same
 functionality as is available from the <<nd-range>> interface, but exposed

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -48,10 +48,12 @@ class handler {
   template <typename KernelName, int Dimensions, typename... Rest>
   void parallel_for(nd_range<Dimensions> executionRange, Rest&&... rest);
 
+  // Deprecated in SYCL 2020.
   template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
   void parallel_for_work_group(range<Dimensions> numWorkGroups,
                                const WorkgroupFunctionType& kernelFunc);
 
+  // Deprecated in SYCL 2020.
   template <typename KernelName, typename WorkgroupFunctionType, int Dimensions>
   void parallel_for_work_group(range<Dimensions> numWorkGroups,
                                range<Dimensions> workGroupSize,

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -42,9 +42,11 @@ template <int Dimensions = 1> class group {
 
   bool leader() const;
 
+  // Deprecated in SYCL 2020.
   template <typename WorkItemFunctionT>
   void parallel_for_work_item(const WorkItemFunctionT& func) const;
 
+  // Deprecated in SYCL 2020.
   template <typename WorkItemFunctionT>
   void parallel_for_work_item(range<Dimensions> logicalRange,
                               const WorkItemFunctionT& func) const;

--- a/adoc/headers/hitem.h
+++ b/adoc/headers/hitem.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
+/* Deprecated in SYCL 2020 */
 template <int Dimensions> class h_item {
  public:
   static constexpr int dimensions = Dimensions;

--- a/adoc/headers/priv.h
+++ b/adoc/headers/priv.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
+/* Deprecated in SYCL 2020 */
 template <typename T, int Dimensions = 1> class private_memory {
  public:
   // Construct based directly off the number of work-items


### PR DESCRIPTION
The working group decided that the previous wording was strong enough that it signalled an intent to deprecate hierarchical parallelism.

This commit replaces the non-normative note about hierarchical parallelism with appropriate deprecation notices, specifically:

- Function descriptions are updated to include "Deprecated in SYCL 2020";

- Deprecated features are marked with a "Deprecated in SYCL 2020" comment; and

- Sections related to deprecated features are marked "(deprecated)".

Closes #620. 