### PR TITLE
Fix `local_accessor::swap(accessor &other);` typo

### DIFF
--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -31,7 +31,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
 
   /* -- common interface members -- */
 
-  void swap(accessor& other);
+  void swap(local_accessor& other);
 
   size_type byte_size() const noexcept;
 


### PR DESCRIPTION
Cherry pick #735 from main
(cherry picked from commit 4a0f18751018ffcdc343689c6a0d97878bf43eb1)