### PR TITLE
Fix reference to rule of five in common-byval.h

### DIFF
--- a/adoc/headers/common-byval.h
+++ b/adoc/headers/common-byval.h
@@ -8,9 +8,10 @@ class T {
 
       public
       :
-      // If any of the following five special member functions are not
-      // public, inline or defaulted, then all five of them should be
-      // explicitly declared (see rule of five).
+      // If any of the following five special member functions are declared,
+      // then all five of them should be explicitly declared (see rule of
+      // five).
+      //
       // Otherwise, none of them should be explicitly declared
       // (see rule of zero).
 


### PR DESCRIPTION
Cherry pick #737 from main
(cherry picked from commit 65bb36484fac73e3a23b7bc899e78c7f275cc8e3)