### PR TITLE
Fix description of `sycl::free`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11784,35 +11784,40 @@ necessary [code]#device#.
 
 ==== Memory deallocation functions
 
-[[table.usm.free]]
-.USM Deallocation Functions
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Function @ Description
-a@
-[source]
+.[apidef]#free#
+[source,role=synopsis,id=api:free]
 ----
-void sycl::free(void* ptr, const context& syclContext)
+void free(void* ptr, const context& ctxt); (1)
+void free(void* ptr, const queue& q);      (2)
 ----
-a@ Frees an allocation.
-The memory pointed to by [code]#ptr# must have been allocated using one of the
-USM allocation routines or it must be a null pointer.
-If [code]#ptr# is not null, the [code]#syclContext# must be the same
-[code]#context# that was used to allocate the memory.
-If [code]#ptr# is null, this function has no effect.
-Otherwise, the memory is freed without waiting for <<command, commands>>
-operating on it to be completed.
-If <<command, commands>> that use this memory are in-progress or are enqueued,
-the behavior is undefined.
 
-a@
-[source]
-----
-void sycl::free(void* ptr, const queue& syclQueue)
-----
-a@ Alternate form where [code]#syclQueue# provides the [code]#context#.
+*Overload (1):*
 
-|====
+_Preconditions_:
+
+* [code]#ptr# points to memory allocated against [code]#ctxt# using one of the
+  USM allocation routines, or is a null pointer;
+
+* [code]#ptr# has not previously been deallocated; and
+
+* There are no in-progress or enqueued <<command, commands>> using the memory
+  pointed to by [code]#ptr#.
+
+_Effects_: Causes the memory pointed to by [code]#ptr# to be deallocated.
+
+{note}Whether [code]#free# is blocking or non-blocking is unspecified.
+Applications should not rely on [code]#free# for synchronization, nor assume
+that [code]#free# cannot cause deadlocks.{endnote}
+
+_Remarks_: If [code]#ptr# is null, this function has no effect.
+
+*Overload (2):*
+
+_Effects_: Equivalent to [code]#return free(ptr, q.get_context());#.
+
+{note}Although this overload accepts a [code]#queue# argument, it does not
+submit a "free" <<command>> to the device; the [code]#queue# argument is only
+used to determine the [code]#context# associated with [code]#ptr#.{endnote}
 
 === Unified shared memory pointer queries
 


### PR DESCRIPTION
Cherry pick #758 from main
(cherry picked from commit 912cef9396d1c0317972d5ac9bc4ef31554eab04)