### PR TITLE
Fix issues using buffer in examples

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -7010,7 +7010,7 @@ if set final data is [code]#nullptr)#.
 {
   std::shared_ptr<int> ptr { data };
   {
-    buffer<int, 1> b { ptr, range<2>{ 10, 10 } };
+    buffer<int, 2> b { ptr, { 10, 10 } };
     // update the data
     [...]
   } // Data is copied back because there is an user side shared_ptr
@@ -7022,7 +7022,7 @@ if set final data is [code]#nullptr)#.
 {
   std::shared_ptr<int> ptr { data };
   {
-    buffer<int, 1> b { ptr, range<2>{ 10, 10 } };
+    buffer<int, 2> b { ptr, { 10, 10 } };
     // update the data
     [...]
     ptr.reset();

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -16,7 +16,7 @@ int main() {
   // because the destructor of resultBuf will wait
   {
     // Wrap our data variable in a buffer
-    buffer<int, 1> resultBuf{data, range<1>{1024}};
+    buffer resultBuf{data, {1024}};
 
     // Create a command group to issue commands to the queue
     myQueue.submit([&](handler& cgh) {

--- a/adoc/code/queueShortcuts.cpp
+++ b/adoc/code/queueShortcuts.cpp
@@ -7,7 +7,7 @@ queue myQueue;
 auto usmPtr = malloc_device<int>(1024, myQueue);  // USM pointer
 
 int* data = /* pointer to some data */;
-buffer<int, 1> buf{data, range<1>{1024}};
+buffer buf{data, {1024}};
 accessor acc{buf};  // Placeholder accessor
 
 // Queue shortcut for a kernel invocation

--- a/adoc/code/queueShortcuts.cpp
+++ b/adoc/code/queueShortcuts.cpp
@@ -7,7 +7,7 @@ queue myQueue;
 auto usmPtr = malloc_device<int>(1024, myQueue);  // USM pointer
 
 int* data = /* pointer to some data */;
-buffer buf{data, 1024};
+buffer<int, 1> buf{data, range<1>{1024}};
 accessor acc{buf};  // Placeholder accessor
 
 // Queue shortcut for a kernel invocation


### PR DESCRIPTION
Some examples using buffers fail to compile: 
Buffer type is either incorrectly specified or incompatible range parameter is passed.
With SYCL 2020 we can improve examples, writing more compact code.
Aligning all other examples using buffers will require a follow up PR.