### PR TITLE
Fix swizzle-to-vec conversion

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18930,8 +18930,6 @@ operator vec<DataT, NumElements>() const
 _Availability:_ These functions are available in both
 [code]#+__writeable_swizzle__+# and [code]#+__const_swizzle__+#.
 
-_Constraints:_ Available only when [code]#NumElements > 1#.
-
 _Returns:_ A new [code]#vec# object that contains the result of the captured
 swizzle operation.
 


### PR DESCRIPTION
We discovered one other problem with the `vec` specification during implementation.  The conversion operator from a swizzle to a `vec` with the same number of elements currently has a constraint that disables the conversion for a 1-element swizzle.  This prevents code like this from compiling:

```
void foo(sycl::vec<int, 1>) {}

int main() {
  sycl::vec<int, 2> v;
  foo(v.swizzle<1>());
}
```

I think this slipped through the cracks because at one point we were thinking that the variadic `vec` constructor would handle this conversion.  However, we ended up adding a constraint to that variadic constructor which disables it for 1-element parameters.  As a result the variadic constructor does not handle this case.

The CTS already tests this case, so the CTS will not pass in its current form unless an implementation removes the constraint as shown in this PR.