### PR TITLE
Specify return type for "queue_profiling"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -2827,7 +2827,7 @@ backend of this device is not OpenCL.
 ----
 namespace sycl::info::device {
 struct queue_profiling {
-  using return_type =
+  using return_type = bool;
 };
 } // namespace sycl::info::device
 ----


### PR DESCRIPTION
The synopsis for `sycl::info::device::queue_profiling` was missing the return type.  Fix this.

I'm certain that `bool` is correct because that is what we said in revision 9 of the SYCL-2020 spec.  It also makes sense because the definition of this info descriptor says it returns the same value as `device::has(aspect::queue_profiling)`, which is a `bool`.