### PR TITLE
Clarify `vec::as` behavior

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -18075,14 +18075,17 @@ vec<ConvertT, NumElements> convert() const
 a@
 [source]
 ----
-template <typename asT> asT as() const
+template <typename AsT> AsT as() const
 ----
-   a@ Bitwise reinterprets this SYCL [code]#vec# as a SYCL [code]#vec# of a
-      different element type and number of elements specified by [code]#asT#.
-      The new SYCL [code]#vec# type must have the same storage size in bytes as
-      this SYCL [code]#vec#, and the size of the elements in the new SYCL
-      [code]#vec# ([code]#NumElements * sizeof(DataT)#) must be the same as the
-      size of the elements in this SYCL [code]#vec#.
+   a@ Equivalent to [code]#sycl::bit_cast<AsT>(*this)#.
+
+[NOTE]
+====
+Since the object representation of a [code]#vec<T, 3># contains padding bits
+(see <<memory-layout-and-alignment>>), using [code]#as# or [code]#bit_cast# to
+create a [code]#vec# with a different number of elements can lead to undefined
+behavior.
+====
 
 a@
 [source]


### PR DESCRIPTION
Cherry pick #724 from main
(cherry picked from commit e81c734bf3bed16cfc79370362944780aa5d5108)