### PR TITLE
clarify_event_complete_synchronization

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -4917,6 +4917,8 @@ info::event_command_status::complete
 ----
    a@ Indicates that the command has finished running on the device.
       Attempting to wait on such an event will not block.
+      
+      Synchronization: Equivalent to event::wait().
 
 |====
 


### PR DESCRIPTION
We didn't specify that from a synchronization perspective, an event returning `complete` is the same as a `wait`. 


It provides the same warranty (it will be more useful when we will have a flush, and we can have a `completed` event without ever calling wait).

I guess we need to port this thing to the `non-table` new way, but did the lazy hack...