### PR TITLE
Remove spurious line from device info descriptor code

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3155,7 +3155,6 @@ backend of this device is not OpenCL.
 [source,role=synopsis,id=api:info-device-parent-device]
 ----
 namespace sycl::info::device {
-info::device::parent_device
 struct parent_device {
   using return_type = device;
 };


### PR DESCRIPTION
I'm pretty sure this line shouldn't be here.