### PR TITLE
Let implementations elect not to use secondary queues

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1497,10 +1497,12 @@ must include the <<backend>>-specific headers for said <<backend>>.
 A <<command-group-function-object>> can be submitted either to a single queue to
 be executed on, or to a secondary queue.
 If a <<command-group-function-object>> fails to be enqueued to the primary
-queue, then the system will attempt to enqueue it to the secondary queue, if
+queue, then the system may attempt to enqueue it to the secondary queue, if
 given as a parameter to the submit function.
 If the <<command-group-function-object>> fails to be queued to both of these
-queues, then a synchronous SYCL exception will be thrown.
+queues, or if it fails to be queued to the primary queue and the implementation
+elects not to enqueue it to the secondary queue, then a synchronous SYCL
+exception will be thrown.
 
 It is possible that a command group may be successfully enqueued, but then
 asynchronously fail to run, for some reason.

--- a/adoc/chapters/device_compiler.adoc
+++ b/adoc/chapters/device_compiler.adoc
@@ -427,8 +427,10 @@ the feature.
 If the application submits a <<command-group>> using a secondary queue, then any
 kernel submitted from the <<command-group>> should use only features that are
 supported by both the primary queue's device and the secondary queue's device.
-If an application fails to do this, the implementation must throw a synchronous
-exception with the [code]#errc::kernel_not_supported# error code from the
+If an application fails to do this and the implementation elects to use the
+secondary queue in the case of the <<command-group>> failing to enqueue on the
+primary queue, the implementation must throw a synchronous exception with the
+[code]#errc::kernel_not_supported# error code from the
 <<kernel-invocation-command>> (e.g. [code]#parallel_for()#).
 
 It is legal for a SYCL application to define several kernels in the same
@@ -630,10 +632,11 @@ Specifying this attribute on a kernel has two effects.  First, it causes the
 [code]#errc::kernel_not_supported# error code if the kernel is submitted to a
 device that does not have one of the listed aspects.  (This includes the device
 associated with the secondary queue if the kernel is submitted from a
-<<command-group>> that has a secondary queue.)  Second, it causes the compiler
-to issue a diagnostic if the kernel (or any of the functions it calls) uses an
-optional feature that is associated with an aspect that is not listed in the
-attribute.
+<<command-group>> that has a secondary queue and the implementation intends on
+using the secondary queue in the case of failing to enqueue on the primary
+queue.)  Second, it causes the compiler to issue a diagnostic if the kernel (or
+any of the functions it calls) uses an optional feature that is associated with
+an aspect that is not listed in the attribute.
 
 The value of each parameter to this attribute must be equal to one of the
 values in the [code]#sycl::aspect# enumeration type (including any extended

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5534,9 +5534,10 @@ the implementation to throw an [code]#exception# with the [code]#errc::invalid#
 error code from the [code]#accessor# constructor (if the accessor is not a
 placeholder) or from [code]#handler::require()# (if the accessor is a
 placeholder).  If the accessor is bound to a <<command-group>> with a secondary
-queue, the sub-buffer's alignment must be compatible with both the primary
-queue's device and the secondary queue's device, otherwise this exception is
-thrown.
+queue that the implementation intends on using in case of failure during
+enqueuing the <<command-group>> to the primary queue, the sub-buffer's alignment
+must be compatible with both the primary queue's device and the secondary
+queue's device, otherwise this exception is thrown.
 
 Must throw an [code]#exception# with the [code]#errc::invalid# error code if
 [code]#b# is a sub-buffer.
@@ -14288,7 +14289,7 @@ A user can therefore supply a secondary queue when submitting a command group to
 the primary queue.
 If the <<sycl-runtime>> fails to enqueue or execute a command group on a primary
 queue, it can attempt to run the command group on the secondary queue.
-The circumstances in which it is, or is not, possible for a <<sycl-runtime>> to
+The circumstances in which the <<sycl-runtime>> may elect to
 fall-back from primary to secondary queue are unspecified in the specification.
 Even if a command group is run on the secondary queue, the requirement that host
 code within the command group is executed exactly once remains, regardless of
@@ -14598,9 +14599,13 @@ This invocation function ignores any [code]#kernel_bundle# that was bound to
 this command group handler via [code]#handler::use_kernel_bundle()# and instead
 implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
-code if the [code]#kernelObject# is not compatible with either the device
-associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+code if the [code]#kernelObject# is not compatible with the device
+associated with the primary queue of the <<command-group>>.
+Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
+code if the <<command-group>> has a secondary queue associated that the
+implementation intends on using in the case that the <<command-group>> fails to
+enqueue on the primary queue, and the [code]#kernelObject# is not compatible
+with the device associated with the secondary queue of the <<command-group>>.
 
 a@
 [source]
@@ -14620,9 +14625,13 @@ This invocation function ignores any [code]#kernel_bundle# that was bound to
 this command group handler via [code]#handler::use_kernel_bundle()# and instead
 implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
-code if the [code]#kernelObject# is not compatible with either the device
-associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+code if the [code]#kernelObject# is not compatible with the device associated
+with the primary queue of the <<command-group>>.
+Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
+code if the <<command-group>> has a secondary queue associated that the
+implementation intends on using in the case that the <<command-group>> fails to
+enqueue on the primary queue, and the [code]#kernelObject# is not compatible
+with the device associated with the secondary queue of the <<command-group>>.
 
 a@
 [source]
@@ -14647,9 +14656,13 @@ This invocation function ignores any [code]#kernel_bundle# that was bound to
 this command group handler via [code]#handler::use_kernel_bundle()# and instead
 implicitly uses the kernel bundle that contains the [code]#kernelObject#.
 Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
-code if the [code]#kernelObject# is not compatible with either the device
-associated with the primary queue of the <<command-group>> or with the device
-associated with the secondary queue (if specified).
+code if the [code]#kernelObject# is not compatible with the device associated
+with the primary queue of the <<command-group>>.
+Throws an [code]#exception# with the [code]#errc::kernel_not_supported# error
+code if the <<command-group>> has a secondary queue associated that the
+implementation intends on using in the case that the <<command-group>> fails to
+enqueue on the primary queue, and the [code]#kernelObject# is not compatible
+with the device associated with the secondary queue of the <<command-group>>.
 
 |====
 
@@ -15280,10 +15293,11 @@ If the <<command-group>> attempts to invoke a kernel that is not contained by a
 compatible device image in [code]#execBundle#, the <<kernel-invocation-command>>
 throws a synchronous [code]#exception# with the
 [code]#errc::kernel_not_supported# error code.
-If the <<command-group>> has a secondary queue, then the [code]#execBundle# must
-contain a kernel that is compatible with both the primary queue's device and the
-secondary queue's device, otherwise the <<kernel-invocation-command>> throws
-this exception.
+If the <<command-group>> has a secondary queue that the implementation intends
+on using in the case that the <<command-group>> fails to enqueue on the primary
+queue, then the [code]#execBundle# must contain a kernel that is compatible
+with both the primary queue's device and the secondary queue's device,
+otherwise the <<kernel-invocation-command>> throws this exception.
 
 Since the handler method for setting specialization constants is incompatible
 with the kernel bundle method, applications should not call this function if
@@ -15294,9 +15308,16 @@ _Throws:_
 
   * An [code]#exception# with the [code]#errc::invalid# error code if the
     <<context>> associated with the <<handler>> via its associated primary
-    <<queue>> or the <<context>> associated with the secondary <<queue>> (if
-    provided) is different from the <<context>> associated with the
+    <<queue>> is different from the <<context>> associated with the
     <<kernel-bundle>> specified by [code]#execBundle#.
+
+  * An [code]#exception# with the [code]#errc::invalid# error code if the
+    <<handler>> has an associated secondary
+    <<queue>> that the implementation intends on using in the case that the
+    primary <<queue>> associated with the <<handler>> fails to enqueue this
+    <<command-group>>, and the <<context>> of the secondary queue is different
+    from the <<context>> associated with the <<kernel-bundle>> specified by
+    [code]#execBundle#.
 
   * An [code]#exception# with the [code]#errc::invalid# error code if
     [code]#handler::set_specialization_constant()# has been called for this


### PR DESCRIPTION
This change changes the wording of secondary queues and their exception conditions to specify that an implementation may elect to not use the specified secondary queue.