### PR TITLE
Editorial changes to sycl_khr_queue_empty_query

### DIFF
--- a/adoc/extensions/sycl_khr_queue_empty_query.adoc
+++ b/adoc/extensions/sycl_khr_queue_empty_query.adoc
@@ -32,10 +32,6 @@ below.
 This extension adds the following function to the [code]#sycl::queue# class,
 which provides information about the emptiness of the queue.
 
-{node} This khr is more usefull when used in conjuction with
-[code]#queue::khr_flush()#.
-{endnode}
-
 '''
 
 .[apidef]#queue::khr_empty#
@@ -45,7 +41,7 @@ bool khr_empty() const
 ----
 
 _Synchronization_: When this function returns [code]#true#, equivalent to
-[code]#queue::wait()#.
+[api]#queue::wait#.
 
 _Returns:_ [code]#true# if all <<command,commands>> enqueued on this queue have
 completed, [code]#false# otherwise.


### PR DESCRIPTION
* Remove non-normative note referring to `queue::khr_flush` because that API is not merged to the spec yet.  We should instead add this note to #809.

* Change reference to `queue::wait` to be a hyperlink.