### PR TITLE
Change buffer API descriptions to use new style

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5217,10 +5217,10 @@ _Effects (2):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
 .[apititle]#Construct with host memory#
 [source,role=synopsis,id=api:buffer-ctor-host-mem]
 ----
-buffer(T* hostData, const range<Dimensions>& bufferRange,          (2)
+buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
        AllocatorT allocator, const property_list& propList = {});
 
-buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
+buffer(T* hostData, const range<Dimensions>& bufferRange,          (2)
        const property_list& propList = {});
 
 buffer(const T* hostData, const range<Dimensions>& bufferRange,    (3)
@@ -5405,6 +5405,7 @@ later.
 [code]#baseIndex# specifies the origin of the sub-buffer inside the buffer
 [code]#b#.
 [code]#subRange# specifies the size of the sub-buffer.
+
 The origin (based on [code]#baseIndex#) of the sub-buffer being constructed must
 be a multiple of the memory base address alignment of each SYCL [code]#device#
 which accesses data from the buffer.
@@ -5423,12 +5424,13 @@ _Throws:_
 * An [code]#exception# with the [code]#errc::invalid# error code if [code]#b# is
 a sub-buffer.
 
-* An [code]#exception# with the [code]#errc::invalid# error code if
-[code]#subRange# corresponds to a a non-contiguous region of [code]#b#.
+* An [code]#exception# with the [code]#errc::invalid# error code if the subrange
+formed by [code]#baseIndex# and [code]#subRange# is not a contiguous region of
+[code]#b#.
 
 * An [code]#exception# with the [code]#errc::invalid# error code if the sum of
 [code]#baseIndex# and [code]#subRange# in any dimension exceeds the parent
-buffer [code]#b# size [code]#bufferRange# in that dimension.
+buffer [code]#b# size ([code]#bufferRange#) in that dimension.
 
 '''
 
@@ -5552,10 +5554,10 @@ Deprecated in SYCL 2020.
 Use [code]#get_host_access()# instead.
 
 _Returns (1):_ A valid host [code]#accessor# to the buffer with the specified
-access mode and target.
+access mode.
 
 _Returns (2):_ A valid host [code]#accessor# to the buffer with the specified
-access mode and target.
+access mode.
 The accessor is a <<ranged-accessor>>, where the range starts at the given
 offset from the beginning of the buffer.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5728,7 +5728,7 @@ use_mutex(std::mutex& mutexRef);
 ----
 
 _Effects:_ Constructs a SYCL [code]#use_mutex# property instance with a
-reference to [code]#mutexRef# parameter provided.
+reference to [code]#mutexRef#.
 
 '''
 
@@ -5738,8 +5738,8 @@ reference to [code]#mutexRef# parameter provided.
 std::mutex* get_mutex_ptr() const;
 ----
 
-_Returns:_ The [code]#std::mutex# which was specified when constructing this
-SYCL [code]#use_mutex# property.
+_Returns:_ A pointer to the [code]#std::mutex# provided when constructing this
+property.
 
 '''
 
@@ -5779,8 +5779,7 @@ copy of a SYCL [code]#context#.
 context get_context() const;
 ----
 
-_Returns:_ The [code]#context# which was specified when constructing this SYCL
-[code]#context_bound# property.
+_Returns:_ The [code]#context# provided when constructing this property.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5279,7 +5279,7 @@ buffer(Container& container, AllocatorT allocator,
 template <typename Container>
 buffer(Container& container, const property_list& propList = {}); (2)
 ----
-Constraints:_ Available only if [code]#Container# is a contiguous container,
+_Constraints:_ Available only if [code]#Container# is a contiguous container,
 that is the following requirements must be met:
 
 * [code]#std::data(container)# and [code]#std::size(container)# are well formed;

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5207,14 +5207,16 @@ buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
 _Effects (1):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
 
 _Effects (2):_ Construct a SYCL [code]#buffer# instance with uninitialized
-memory. The constructed SYCL [code]#buffer# will use the [code]#allocator#
-parameter provided when allocating memory on the host. The range of the
-constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
-parameter provided. Data is not written back to the host on destruction of the
-[code]#buffer# unless the [code]#buffer# has a valid non-null pointer specified
-via the member function [code]#set_final_data()#. Zero or more properties can be
-provided to the constructed SYCL [code]#buffer# via an instance of
-[code]#property_list#.
+memory.
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.
+The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.
+Data is not written back to the host on destruction of the [code]#buffer# unless
+the [code]#buffer# has a valid non-null pointer specified via the member
+function [code]#set_final_data()#.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 '''
 
 .[apititle]#Construct with host memory#
@@ -5232,35 +5234,39 @@ buffer(const T* hostData, const range<Dimensions>& bufferRange,
 buffer(const T* hostData, const range<Dimensions>& bufferRange,
        AllocatorT allocator, const property_list& propList = {}); (4)
 ----
-_Effects (1):_ Equivalent to
-`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+_Effects (1):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
 
 _Effects (2):_ Construct a SYCL [code]#buffer# instance with the
-[code]#hostData# parameter provided. The buffer is initialized with the memory
-specified by [code]#hostData#, and the buffer assumes exclusive access to this
-memory for the duration of its lifetime.  The constructed SYCL [code]#buffer#
-will use the [code]#allocator# parameter provided when allocating memory on the
-host.  The range of the constructed SYCL [code]#buffer# is specified by the
-[code]#bufferRange# parameter provided.  Zero or more properties can be provided
-to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+[code]#hostData# parameter provided.
+The buffer is initialized with the memory specified by [code]#hostData#, and the
+buffer assumes exclusive access to this memory for the duration of its lifetime.
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.
+The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 
-_Effects (3):_ Equivalent to
-`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+_Effects (3):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
 
 _Effects (4):_ Construct a SYCL [code]#buffer# instance with the
-[code]#hostData# parameter provided.  The buffer assumes exclusive access to
-this memory for the duration of its lifetime.
+[code]#hostData# parameter provided.
+The buffer assumes exclusive access to this memory for the duration of its
+lifetime.
 
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
 
 The host address is [code]#const T#, so the host accesses can be read-only.
 However, the [code]#typename T# is not const so the device accesses can be both
-read and write accesses. Since, the [code]#hostData# is const, this buffer is
-only initialized with this memory and there is no write back after its
-destruction, unless the [code]#buffer# has another valid non-null final data
-address specified via the member function [code]#set_final_data()# after
-construction of the [code]#buffer#.
+read and write accesses.
+Since, the [code]#hostData# is const, this buffer is only initialized with this
+memory and there is no write back after its destruction, unless the
+[code]#buffer# has another valid non-null final data address specified via the
+member function [code]#set_final_data()# after construction of the
+[code]#buffer#.
 
 The range of the constructed SYCL [code]#buffer# is specified by the
 [code]#bufferRange# parameter provided.
@@ -5293,13 +5299,13 @@ _Effects (1):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
 
 _Effects (2):_ Construct a one dimensional SYCL [code]#buffer# instance from the
 elements starting at [code]#std::data(container)# and containing
-[code]#std::size(container)# number of elements. The buffer is initialized with
-the contents of [code]#container#, and the buffer assumes exclusive access to
-[code]#container# for the duration of its lifetime.
+[code]#std::size(container)# number of elements.
+The buffer is initialized with the contents of [code]#container#, and the buffer
+assumes exclusive access to [code]#container# for the duration of its lifetime.
 
 Data is written back to [code]#container# before the completion of
-[code]#buffer# destruction if the return type of [code]#std::data(container)#
-is not [code]#const#.
+[code]#buffer# destruction if the return type of [code]#std::data(container)# is
+not [code]#const#.
 
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
@@ -5327,41 +5333,47 @@ via an instance of [code]#property_list#.
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 ----
-_Effects (1):_ Equivalent to
-`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+_Effects (1):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
 
 _Effects (2):_ When [code]#hostData# is not empty, construct a SYCL buffer with
-the contents of its stored pointer.  The buffer assumes exclusive access to this
-memory for the duration of its lifetime.  The buffer also creates its own
-internal copy of the [code]#shared_ptr# that shares ownership of the
-[code]#hostData# memory, which means the application can safely release
-ownership of this [code]#shared_ptr# when the constructor returns.
+the contents of its stored pointer.
+The buffer assumes exclusive access to this memory for the duration of its
+lifetime.
+The buffer also creates its own internal copy of the [code]#shared_ptr# that
+shares ownership of the [code]#hostData# memory, which means the application can
+safely release ownership of this [code]#shared_ptr# when the constructor
+returns.
 
 When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
 memory.
 
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
-provided when allocating memory on the host.  The range of the constructed SYCL
-[code]#buffer# is specified by the [code]#bufferRange# parameter provided. Zero
-or more properties can be provided to the constructed SYCL [code]#buffer# via an
-instance of [code]#property_list#.
+provided when allocating memory on the host.
+The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 
-_Effects (3):_ Equivalent to
-`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+_Effects (3):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
 
 _Effects (4):_ When [code]#hostData# is not empty, construct a SYCL buffer with
-the contents of its stored pointer.  The buffer assumes exclusive access to this
-memory for the duration of its lifetime.  The buffer also creates its own
-internal copy of the [code]#shared_ptr# that shares ownership of the
-[code]#hostData# memory, which means the application can safely release
-ownership of this [code]#shared_ptr# when the constructor returns.
+the contents of its stored pointer.
+The buffer assumes exclusive access to this memory for the duration of its
+lifetime.
+The buffer also creates its own internal copy of the [code]#shared_ptr# that
+shares ownership of the [code]#hostData# memory, which means the application can
+safely release ownership of this [code]#shared_ptr# when the constructor
+returns.
 
 When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
 memory.
 
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
-provided when allocating memory on the host.  The range of the constructed SYCL
-[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
+provided when allocating memory on the host.
+The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 '''
@@ -5378,15 +5390,16 @@ buffer<T, 1>(InputIterator first, InputIterator last,
              const property_list& propList = {});
 ----
 _Effects (1):_ Create a new allocated 1D buffer initialized from the given
-elements ranging from [code]#first# up to one before [code]#last#. The data is
-copied to an intermediate memory position by the runtime. Data is not written
-back to the same iterator set provided. However, if the [code]#buffer# has a
-valid non-const iterator specified via the member function
-[code]#set_final_data()#, data will be copied back to that iterator. The
-constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
-provided when allocating memory on the host. Zero or more properties can be
-provided to the constructed SYCL [code]#buffer# via an instance of
-[code]#property_list#.
+elements ranging from [code]#first# up to one before [code]#last#.
+The data is copied to an intermediate memory position by the runtime.
+Data is not written back to the same iterator set provided.
+However, if the [code]#buffer# has a valid non-const iterator specified via the
+member function [code]#set_final_data()#, data will be copied back to that
+iterator.
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
 
 _Effects (2):_ Equivalent to `buffer(first, last, AllocatorT{}, propList)`.
 '''
@@ -5398,33 +5411,35 @@ buffer(buffer& b, const id<Dimensions>& baseIndex,
        const range<Dimensions>& subRange);
 ----
 _Effects:_ Create a new sub-buffer without allocation to have separate accessors
-later. [code]#b# is the buffer with the real data. [code]#baseIndex# specifies
-the origin of the sub-buffer inside the buffer [code]#b#. [code]#subRange#
-specifies the size of the sub-buffer.
+later.
+[code]#b# is the buffer with the real data.
+[code]#baseIndex# specifies the origin of the sub-buffer inside the buffer
+[code]#b#.
+[code]#subRange# specifies the size of the sub-buffer.
 
-The origin (based on [code]#baseIndex#) of the sub-buffer being constructed
-must be a multiple of the memory base address alignment of each SYCL
-[code]#device# which accesses data from the buffer.  This value is retrievable
-via the SYCL [code]#device# class info query
-[code]#info::device::mem_base_addr_align#.  Violating this requirement causes
-the implementation to throw an [code]#exception# with the [code]#errc::invalid#
-error code from the [code]#accessor# constructor (if the accessor is not a
-placeholder) or from [code]#handler::require()# (if the accessor is a
-placeholder).  If the accessor is bound to a <<command-group>> with a secondary
-queue, the sub-buffer's alignment must be compatible with both the primary
-queue's device and the secondary queue's device, otherwise this exception is
-thrown.
+The origin (based on [code]#baseIndex#) of the sub-buffer being constructed must
+be a multiple of the memory base address alignment of each SYCL [code]#device#
+which accesses data from the buffer.
+This value is retrievable via the SYCL [code]#device# class info query
+[code]#info::device::mem_base_addr_align#.
+Violating this requirement causes the implementation to throw an
+[code]#exception# with the [code]#errc::invalid# error code from the
+[code]#accessor# constructor (if the accessor is not a placeholder) or from
+[code]#handler::require()# (if the accessor is a placeholder).
+If the accessor is bound to a <<command-group>> with a secondary queue, the
+sub-buffer's alignment must be compatible with both the primary queue's device
+and the secondary queue's device, otherwise this exception is thrown.
 
 _Throws:_
 
-* An [code]#exception# with the [code]#errc::invalid# error code if [code]#b#
-is a sub-buffer.
+* An [code]#exception# with the [code]#errc::invalid# error code if [code]#b# is
+a sub-buffer.
 
 * An [code]#exception# with the [code]#errc::invalid# error code if
 [code]#subRange# corresponds to a a non-contiguous region of [code]#b#.
 
-- An [code]#exception# with the [code]#errc::invalid# error code if the sum
-of [code]#baseIndex# and [code]#subRange# in any dimension exceeds the parent
+* An [code]#exception# with the [code]#errc::invalid# error code if the sum of
+[code]#baseIndex# and [code]#subRange# in any dimension exceeds the parent
 buffer [code]#b# size [code]#bufferRange# in that dimension.
 '''
 
@@ -5446,8 +5461,8 @@ of elements in each dimension as passed to the constructor.
 ----
 size_t byte_size() const noexcept;
 ----
-_Returns:_ The size of the buffer storage in bytes. Equal to
-[code]#size()*sizeof(T)#.
+_Returns:_ The size of the buffer storage in bytes.
+Equal to [code]#size()*sizeof(T)#.
 '''
 
 .[apititle]#buffer::size#
@@ -5455,8 +5470,9 @@ _Returns:_ The size of the buffer storage in bytes. Equal to
 ----
 size_t size() const noexcept;
 ----
-_Returns:_ The total number of elements in the buffer. Equal to
-[code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
+mode and target in the command group buffer.
+The value of target can be [code]#target::device#,
+[code]#target::constant_buffer# or [code]#target::host_task#.
 '''
 
 .[apititle]#buffer::get_count#
@@ -5510,13 +5526,14 @@ mode and target in the command group buffer. The value of target can be
 [code]#target::host_task#.
 
 _Returns (2):_ A valid [code]#accessor# to the buffer with the specified access
-mode and target in the command group buffer.  The accessor is a
-<<ranged-accessor>>, where the range starts at the given offset from the
-beginning of the buffer.  The value of target can be [code]#target::device#,
+mode and target in the command group buffer.
+The accessor is a <<ranged-accessor>>, where the range starts at the given
+offset from the beginning of the buffer.
+The value of target can be [code]#target::device#,
 [code]#target::constant_buffer# or [code]#target::host_task#.
 
-_Returns (3):_ A  valid [code]#accessor# as if constructed via passing the
-buffer and all provided arguments to the [code]#accessor# constructor.
+_Returns (3):_ A valid [code]#accessor# as if constructed via passing the buffer
+and all provided arguments to the [code]#accessor# constructor.
 
 Possible implementation:
 
@@ -5530,8 +5547,8 @@ Possible implementation:
 [code]#+return host_accessor{*this, args...};+#
 
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
-the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
-the buffer in any dimension.
+the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
+buffer in any dimension.
 '''
 
 .[apititle]#Deprecated buffer::get_access#
@@ -5544,19 +5561,21 @@ template <access_mode Mode>
 accessor<T, Dimensions, Mode, target::host_buffer>
 get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {}); (2)
 ----
-Deprecated in SYCL 2020.  Use [code]#get_host_access()# instead.
+Deprecated in SYCL 2020.
+Use [code]#get_host_access()# instead.
 
 _Returns (1):_ A valid host [code]#accessor# to the buffer with the specified
 access mode and target.
 
-_Returns (2):_ A valid host [code]#accessor# to the buffer with the specified access
-mode and target.  The accessor is a <<ranged-accessor>>, where the range starts
-at the given offset from the beginning of the buffer.  The value of target can
-only be [code]#target::host_buffer#.
+_Returns (2):_ A valid host [code]#accessor# to the buffer with the specified
+access mode and target.
+The accessor is a <<ranged-accessor>>, where the range starts at the given
+offset from the beginning of the buffer.
+The value of target can only be [code]#target::host_buffer#.
 
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
-the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
-the buffer in any dimension.
+the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
+buffer in any dimension.
 '''
 
 .[apititle]#buffer::set_final_data#
@@ -5587,7 +5606,7 @@ happen.
 void set_write_back(bool flag = true);
 ----
 _Effects:_ Dynamically forces or cancels the write-back of the data of a buffer
-on destruction according to       the value of [code]#flag#.
+on destruction according to the value of [code]#flag#.
 
 Forcing the write-back is similar to what happens during a normal write-back as
 described in <<sec:buf-sync-rules>> and <<sec:sharing-host-memory-with-dm>>.
@@ -5614,13 +5633,15 @@ _Returns:_ [code]#true# if this SYCL [code]#buffer# is a sub-buffer and
   reinterpret(range<ReinterpretDim> reinterpretRange) const;
 ----
 _Preconditions (2):_ Available when [code]#(ReinterpretDim == 1)# or when
-[code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) == sizeof(T)))#.
+[code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) ==
+sizeof(T)))#.
 
-_Effects:_ Creates a reinterpreted SYCL [code]#buffer#. The buffer object being
-reinterpreted can be a SYCL sub-buffer that was created from a SYCL
-[code]#buffer#. Reinterpreting a sub-buffer provides a reinterpreted view of
-the sub-buffer only, and does not change the offset or size of the sub-buffer
-view (in bytes) relative to the parent [code]#buffer#.
+_Effects:_ Creates a reinterpreted SYCL [code]#buffer#.
+The buffer object being reinterpreted can be a SYCL sub-buffer that was created
+from a SYCL [code]#buffer#.
+Reinterpreting a sub-buffer provides a reinterpreted view of the sub-buffer
+only, and does not change the offset or size of the sub-buffer view (in bytes)
+relative to the parent [code]#buffer#.
 
 _Returns (1):_ A reinterpreted SYCL [code]#buffer# with the type specified by
 [code]#ReinterpretT#, dimensions specified by [code]#ReinterpretDim# and range
@@ -5661,14 +5682,16 @@ class use_host_ptr {
 
 The [code]#use_host_ptr# property adds the requirement that the <<sycl-runtime>>
 must not allocate any memory for the SYCL [code]#buffer# and instead uses the
-provided host pointer directly. This prevents the <<sycl-runtime>> from
-allocating additional temporary storage on the host.
+provided host pointer directly.
+This prevents the <<sycl-runtime>> from allocating additional temporary storage
+on the host.
 
 This property has a special guarantee for buffers that are constructed from a
-[code]#hostData# pointer.  If a [code]#host_accessor# is constructed from such
-a buffer, then the address of the [code]#reference# type returned from the
-accessor's member functions such as [code]#operator[](id<>)# will be the same
-as the corresponding [code]#hostData# address.
+[code]#hostData# pointer.
+If a [code]#host_accessor# is constructed from such a buffer, then the address
+of the [code]#reference# type returned from the accessor's member functions such
+as [code]#operator[](id<>)# will be the same as the corresponding
+[code]#hostData# address.
 
 _Effects (1):_ Constructs an [code]#use_host_ptr# property object.
 
@@ -5687,13 +5710,14 @@ class use_mutex {
 ----
 
 The [code]#use_mutex# property is valid for the SYCL [code]#buffer#,
-[code]#unsampled_image# and [code]#sampled_image# classes. The property adds the
-requirement that the memory which is owned by the SYCL [code]#buffer# can be
-shared with the application via a [code]#std::mutex# provided to the property.
+[code]#unsampled_image# and [code]#sampled_image# classes.
+The property adds the requirement that the memory which is owned by the SYCL
+[code]#buffer# can be shared with the application via a [code]#std::mutex#
+provided to the property.
 The mutex [code]#m# is locked by the runtime whenever the data is in use and
-unlocked otherwise. The contents of [code]#hostData# are guaranteed to reflect
-the contents of the buffer when the [code]#std::mutex# is unlocked by the
-runtime.
+unlocked otherwise.
+The contents of [code]#hostData# are guaranteed to reflect the contents of the
+buffer when the [code]#std::mutex# is unlocked by the runtime.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5521,9 +5521,9 @@ template <typename... Ts> auto get_access(Ts...); (3)
 template <typename... Ts> auto get_host_access(Ts...); (4)
 ----
 _Returns (1):_ A valid [code]#accessor# to the buffer with the specified access
-mode and target in the command group buffer. The value of target can be
-[code]#target::device#, [code]#target::constant_buffer# or
-[code]#target::host_task#.
+mode and target in the command group buffer.
+The value of target can be [code]#target::device#,
+[code]#target::constant_buffer# or [code]#target::host_task#.
 
 _Returns (2):_ A valid [code]#accessor# to the buffer with the specified access
 mode and target in the command group buffer.
@@ -5768,8 +5768,8 @@ provided to the property.
 context_bound(context boundContext);
 ----
 
-_Effects:_ Constructs a SYCL [code]#context_bound# property instance with a
-copy of a SYCL [code]#context#.
+_Effects:_ Constructs a SYCL [code]#context_bound# property instance with a copy
+of a SYCL [code]#context#.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5275,11 +5275,11 @@ via an instance of [code]#property_list#.
 [source,role=synopsis,id=api:buffer-ctor-container]
 ----
 template <typename Container>                                      (1)
-buffer(Container& container, AllocatorT allocator,
-       const property_list& propList = {});
+buffer(Container& container, const property_list& propList = {});
 
 template <typename Container>                                      (2)
-buffer(Container& container, const property_list& propList = {});
+buffer(Container& container, AllocatorT allocator,
+       const property_list& propList = {});
 ----
 _Constraints:_ Available only if [code]#Container# is a contiguous container,
 that is the following requirements must be met:
@@ -5290,8 +5290,6 @@ that is the following requirements must be met:
   and
 
 * [code]#Dimensions == 1#.
-
-_Effects (1):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
 
 _Effects (2):_ Construct a one dimensional SYCL [code]#buffer# instance from the
 elements starting at [code]#std::data(container)# and containing
@@ -5309,31 +5307,30 @@ provided when allocating memory on the host.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
+_Effects (1):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
+
 '''
 
 .[apititle]#Construct from memory owned by a shared pointer#
 [source,role=synopsis,id=api:buffer-ctor-shared-ptr]
 ----
   buffer(const std::shared_ptr<T>& hostData,                          (1)
-         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
   buffer(const std::shared_ptr<T>& hostData,                          (2)
-         const range<Dimensions>& bufferRange,
-         const property_list& propList = {});
-
-  buffer(const std::shared_ptr<T[]>& hostData,                        (3)
          const range<Dimensions>& bufferRange, AllocatorT allocator,
          const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]>& hostData,                        (4)
+  buffer(const std::shared_ptr<T[]>& hostData,                        (3)
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T[]>& hostData,                        (4)
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
 ----
-_Effects (1):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
-propList)`.
-
-_Effects (2):_ When [code]#hostData# is not empty, construct a SYCL buffer with
+_Effects (1):_ When [code]#hostData# is not empty, construct a SYCL buffer with
 the contents of its stored pointer.
 The buffer assumes exclusive access to this memory for the duration of its
 lifetime.
@@ -5352,10 +5349,10 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
-_Effects (3):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+_Effects (2):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
 propList)`.
 
-_Effects (4):_ When [code]#hostData# is not empty, construct a SYCL buffer with
+_Effects (3):_ When [code]#hostData# is not empty, construct a SYCL buffer with
 the contents of its stored pointer.
 The buffer assumes exclusive access to this memory for the duration of its
 lifetime.
@@ -5373,6 +5370,9 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 [code]#bufferRange# parameter provided.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
+
+_Effects (4):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
 
 '''
 
@@ -5380,12 +5380,12 @@ via an instance of [code]#property_list#.
 [source,role=synopsis,id=api:buffer-ctor-iterator]
 ----
 template <class InputIterator>                                               (1)
-buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
-             const property_list& propList = {});
+buffer(InputIterator first, InputIterator last, AllocatorT allocator,
+       const property_list& propList = {});
 
 template <class InputIterator>                                               (2)
-buffer<T, 1>(InputIterator first, InputIterator last,
-             const property_list& propList = {});
+buffer(InputIterator first, InputIterator last,
+       const property_list& propList = {});
 ----
 _Effects (1):_ Create a new allocated 1D buffer initialized from the given
 elements ranging from [code]#first# up to one before [code]#last#.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5184,8 +5184,8 @@ include::{header_dir}/buffer.h[lines=4..-1]
 
 All [code]#buffer# constructors take a parameter named [code]#propList# which
 allows the application to pass zero or more properties.
-These properties may specify additional effects of the constructor and
-resulting [code]#buffer# object.
+These properties may specify additional effects of the constructor and resulting
+[code]#buffer# object.
 See <<sec:buffer-properties>> for the buffer properties that are defined by the
 <<core-spec>>.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5281,8 +5281,9 @@ buffer(Container& container, AllocatorT allocator,
 template <typename Container>                                      (2)
 buffer(Container& container, const property_list& propList = {});
 ----
-_Constraints:_ Available only if [code]#Container# is a contiguous container,
-that is the following requirements must be met:
+Preconditions: [code]#container# is a contiguous container.
+
+Constraints: Available only when:
 
 * [code]#std::data(container)# and [code]#std::size(container)# are well formed;
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5471,7 +5471,8 @@ Equal to [code]#size()*sizeof(T)#.
 size_t size() const noexcept;
 ----
 _Returns:_ The total number of elements in the buffer.
-Equal to [code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
+Equal to [code]#+get_range()[0] * ...
+* get_range()[Dimensions-1]+#.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5220,8 +5220,8 @@ via an instance of [code]#property_list#.
 buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
        const property_list& propList = {});
 
-buffer(T* hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator, const property_list& propList = {});  (2)
+buffer(T* hostData, const range<Dimensions>& bufferRange,          (2)
+       AllocatorT allocator, const property_list& propList = {});
 
 buffer(const T* hostData, const range<Dimensions>& bufferRange,    (3)
        const property_list& propList = {});
@@ -5274,12 +5274,12 @@ via an instance of [code]#property_list#.
 .[apititle]#Construct from a container#
 [source,role=synopsis,id=api:buffer-ctor-container]
 ----
-template <typename Container>
-buffer(Container& container, AllocatorT allocator,                 (1)
+template <typename Container>                                      (1)
+buffer(Container& container, AllocatorT allocator,
        const property_list& propList = {});
 
-template <typename Container>
-buffer(Container& container, const property_list& propList = {});  (2)
+template <typename Container>                                      (2)
+buffer(Container& container, const property_list& propList = {});
 ----
 _Constraints:_ Available only if [code]#Container# is a contiguous container,
 that is the following requirements must be met:
@@ -5314,8 +5314,8 @@ via an instance of [code]#property_list#.
 .[apititle]#Construct from memory owned by a shared pointer#
 [source,role=synopsis,id=api:buffer-ctor-shared-ptr]
 ----
-  buffer(const std::shared_ptr<T>& hostData,
-         const range<Dimensions>& bufferRange, AllocatorT allocator,  (1)
+  buffer(const std::shared_ptr<T>& hostData,                          (1)
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
          const property_list& propList = {});
 
   buffer(const std::shared_ptr<T>& hostData,                          (2)
@@ -5379,12 +5379,12 @@ via an instance of [code]#property_list#.
 .[apititle]#Construct from iterators#
 [source,role=synopsis,id=api:buffer-ctor-iterator]
 ----
-template <class InputIterator>
-buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,  (1)
+template <class InputIterator>                                               (1)
+buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
              const property_list& propList = {});
 
-template <class InputIterator>
-buffer<T, 1>(InputIterator first, InputIterator last,                        (2)
+template <class InputIterator>                                               (2)
+buffer<T, 1>(InputIterator first, InputIterator last,
              const property_list& propList = {});
 ----
 _Effects (1):_ Create a new allocated 1D buffer initialized from the given
@@ -5512,14 +5512,14 @@ _Returns:_ The allocator provided to the buffer.
 .[apititle]#buffer::get_access#
 [source,role=synopsis,id=api:buffer-get-access]
 ----
-template <access_mode Mode = access_mode::read_write,
+template <access_mode Mode = access_mode::read_write,                          (1)
           target Targ = target::device>
-accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler);  (1)
+accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler);
 
-template <access_mode Mode = access_mode::read_write,
+template <access_mode Mode = access_mode::read_write,                          (2)
           target Targ = target::device>
 accessor<T, Dimensions, Mode, Targ>
-get_access(handler& commandGroupHandler, range<Dimensions> accessRange,        (2)
+get_access(handler& commandGroupHandler, range<Dimensions> accessRange,
            id<Dimensions> accessOffset = {});
 
 template <typename... Ts> auto get_access(Ts...);                              (3)
@@ -5561,12 +5561,12 @@ buffer in any dimension.
 .[apititle]#Deprecated buffer::get_access#
 [source,role=synopsis,id=api:buffer-get-access-deprecated]
 ----
-template <access_mode Mode>
-accessor<T, Dimensions, Mode, target::host_buffer> get_access();              (1)
+template <access_mode Mode>                                                   (1)
+accessor<T, Dimensions, Mode, target::host_buffer> get_access();
 
-template <access_mode Mode>
+template <access_mode Mode>                                                   (2)
 accessor<T, Dimensions, Mode, target::host_buffer>
-get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {});  (2)
+get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {});
 ----
 Deprecated in SYCL 2020.
 Use [code]#get_host_access()# instead.
@@ -5637,17 +5637,17 @@ _Returns:_ [code]#true# if this SYCL [code]#buffer# is a sub-buffer and
 .[apititle]#buffer::reinterpret#
 [source,role=synopsis,id=api:buffer-reinterpret]
 ----
-template <typename ReinterpretT, int ReinterpretDim>
+template <typename ReinterpretT, int ReinterpretDim>                       (1)
 buffer<ReinterpretT, ReinterpretDim,
        typename std::allocator_traits<AllocatorT>::template rebind_alloc<
            ReinterpretT>>
-reinterpret(range<ReinterpretDim> reinterpretRange) const;                 (1)
+reinterpret(range<ReinterpretDim> reinterpretRange) const;
 
-template <typename ReinterpretT, int ReinterpretDim = Dimensions>
+template <typename ReinterpretT, int ReinterpretDim = Dimensions>          (2)
 buffer<ReinterpretT, ReinterpretDim,
        typename std::allocator_traits<AllocatorT>::template rebind_alloc<
            ReinterpretT>>
-reinterpret() const;                                                       (2)
+reinterpret() const;
 ----
 _Preconditions (2):_ Available when [code]#(ReinterpretDim == 1)# or when
 [code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) ==

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5291,7 +5291,7 @@ that is the following requirements must be met:
 
 * [code]#Dimensions == 1#.
 
-_Effects (2):_ Construct a one dimensional SYCL [code]#buffer# instance from the
+_Effects (1):_ Construct a one dimensional SYCL [code]#buffer# instance from the
 elements starting at [code]#std::data(container)# and containing
 [code]#std::size(container)# number of elements.
 The buffer is initialized with the contents of [code]#container#, and the buffer
@@ -5307,7 +5307,7 @@ provided when allocating memory on the host.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
-_Effects (1):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
+_Effects (2):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5247,13 +5247,10 @@ _Effects (3):_ Construct a SYCL [code]#buffer# instance with the
 [code]#hostData# parameter provided.
 The buffer assumes exclusive access to this memory for the duration of its
 lifetime.
-
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
-
 The range of the constructed SYCL [code]#buffer# is specified by the
 [code]#bufferRange# parameter provided.
-
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
@@ -5332,10 +5329,8 @@ The buffer also creates its own internal copy of the [code]#shared_ptr# that
 shares ownership of the [code]#hostData# memory, which means the application can
 safely release ownership of this [code]#shared_ptr# when the constructor
 returns.
-
 When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
 memory.
-
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
 The range of the constructed SYCL [code]#buffer# is specified by the
@@ -5354,10 +5349,8 @@ The buffer also creates its own internal copy of the [code]#shared_ptr# that
 shares ownership of the [code]#hostData# memory, which means the application can
 safely release ownership of this [code]#shared_ptr# when the constructor
 returns.
-
 When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
 memory.
-
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
 The range of the constructed SYCL [code]#buffer# is specified by the
@@ -5412,7 +5405,6 @@ later.
 [code]#baseIndex# specifies the origin of the sub-buffer inside the buffer
 [code]#b#.
 [code]#subRange# specifies the size of the sub-buffer.
-
 The origin (based on [code]#baseIndex#) of the sub-buffer being constructed must
 be a multiple of the memory base address alignment of each SYCL [code]#device#
 which accesses data from the buffer.
@@ -5582,15 +5574,11 @@ void set_final_data(Destination finalData = nullptr);
 _Effects:_ The [code]#finalData# points to where the outcome of all the buffer
 processing is going to be copied to at destruction time, if the buffer was
 involved with a write accessor.
-
 Destination can be either an output iterator or a [code]#std::weak_ptr<T>#.
-
 Note that a raw pointer is a special case of output iterator and thus defines
 the host memory to which the result is to be copied.
-
 In the case of a weak pointer, the output is not updated if the weak pointer has
 expired.
-
 If [code]#Destination# is [code]#std::nullptr_t#, then the copy back will not
 happen.
 
@@ -5603,10 +5591,8 @@ void set_write_back(bool flag = true);
 ----
 _Effects:_ Dynamically forces or cancels the write-back of the data of a buffer
 on destruction according to the value of [code]#flag#.
-
 Forcing the write-back is similar to what happens during a normal write-back as
 described in <<sec:buf-sync-rules>> and <<sec:sharing-host-memory-with-dm>>.
-
 If there is nowhere to write-back, using this function does not have any effect.
 
 '''

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5164,19 +5164,6 @@ still undefined behavior.
 The SYCL [code]#buffer# class template provides the common reference semantics
 (see <<sec:reference-semantics>>).
 
-
-==== Buffer interface
-
-The constructors and member functions of the SYCL [code]#buffer# class template
-are listed in <<sec:buffer-ctors>> and <<sec:buffer-member-funcs>>,
-respectively.
-The additional common special member functions and common member functions are
-listed in <<table.specialmembers.common.reference>> and
-<<table.hiddenfriends.common.reference>>, respectively.
-
-Each constructor takes as the last parameter an optional SYCL
-[code]#property_list# to provide properties to the SYCL [code]#buffer#.
-
 The SYCL [code]#buffer# class template takes a template parameter
 [code]#AllocatorT# for specifying an allocator which is used by the
 <<sycl-runtime>> when allocating temporary memory on the host.
@@ -5186,7 +5173,7 @@ If no template argument is provided, then the default allocator for the SYCL
 
 // Interface for class: buffer
 
-[source,,linenums]
+[source,role=synopsis]
 ----
 include::{header_dir}/buffer.h[lines=4..-1]
 ----
@@ -5195,14 +5182,21 @@ include::{header_dir}/buffer.h[lines=4..-1]
 [[sec:buffer-ctors]]
 ==== Constructors
 
+All [code]#buffer# constructors take a parameter named [code]#propList# which
+allows the application to pass zero or more properties.
+These properties may specify additional effects of the constructor and
+resulting [code]#buffer# object.
+See <<sec:buffer-properties>> for the buffer properties that are defined by the
+<<core-spec>>.
+
 .[apititle]#Construct with uninitialized memory#
 [source,role=synopsis,id=api:buffer-ctor-uninit]
 ----
-buffer(const range<Dimensions>& bufferRange,
-       const property_list& propList = {}); (1)
+buffer(const range<Dimensions>& bufferRange,                        (1)
+       const property_list& propList = {});
 
-buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
-       const property_list& propList = {}); (2)
+buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,  (2)
+       const property_list& propList = {});
 ----
 _Effects (1):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
 
@@ -5217,22 +5211,23 @@ the [code]#buffer# has a valid non-null pointer specified via the member
 function [code]#set_final_data()#.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
+
 '''
 
 .[apititle]#Construct with host memory#
 [source,role=synopsis,id=api:buffer-ctor-host-mem]
 ----
-buffer(T* hostData, const range<Dimensions>& bufferRange,
-       const property_list& propList = {}); (1)
+buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
+       const property_list& propList = {});
 
 buffer(T* hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator, const property_list& propList = {}); (2)
+       AllocatorT allocator, const property_list& propList = {});  (2)
 
-buffer(const T* hostData, const range<Dimensions>& bufferRange,
-       const property_list& propList = {}); (3)
+buffer(const T* hostData, const range<Dimensions>& bufferRange,    (3)
+       const property_list& propList = {});
 
-buffer(const T* hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator, const property_list& propList = {}); (4)
+buffer(const T* hostData, const range<Dimensions>& bufferRange,    (4)
+       AllocatorT allocator, const property_list& propList = {});
 ----
 _Effects (1):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
 propList)`.
@@ -5273,17 +5268,18 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
+
 '''
 
 .[apititle]#Construct from a container#
 [source,role=synopsis,id=api:buffer-ctor-container]
 ----
 template <typename Container>
-buffer(Container& container, AllocatorT allocator,
-       const property_list& propList = {}); (1)
+buffer(Container& container, AllocatorT allocator,                 (1)
+       const property_list& propList = {});
 
 template <typename Container>
-buffer(Container& container, const property_list& propList = {}); (2)
+buffer(Container& container, const property_list& propList = {});  (2)
 ----
 _Constraints:_ Available only if [code]#Container# is a contiguous container,
 that is the following requirements must be met:
@@ -5312,24 +5308,25 @@ provided when allocating memory on the host.
 
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
+
 '''
 
 .[apititle]#Construct from memory owned by a shared pointer#
 [source,role=synopsis,id=api:buffer-ctor-shared-ptr]
 ----
   buffer(const std::shared_ptr<T>& hostData,
-         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,  (1)
          const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T>& hostData,
+  buffer(const std::shared_ptr<T>& hostData,                          (2)
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]>& hostData,
+  buffer(const std::shared_ptr<T[]>& hostData,                        (3)
          const range<Dimensions>& bufferRange, AllocatorT allocator,
          const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]>& hostData,
+  buffer(const std::shared_ptr<T[]>& hostData,                        (4)
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 ----
@@ -5376,17 +5373,18 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 [code]#bufferRange# parameter provided.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
+
 '''
 
 .[apititle]#Construct from iterators#
 [source,role=synopsis,id=api:buffer-ctor-iterator]
 ----
 template <class InputIterator>
-buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
+buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,  (1)
              const property_list& propList = {});
 
 template <class InputIterator>
-buffer<T, 1>(InputIterator first, InputIterator last,
+buffer<T, 1>(InputIterator first, InputIterator last,                        (2)
              const property_list& propList = {});
 ----
 _Effects (1):_ Create a new allocated 1D buffer initialized from the given
@@ -5402,6 +5400,7 @@ Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
 _Effects (2):_ Equivalent to `buffer(first, last, AllocatorT{}, propList)`.
+
 '''
 
 .[apititle]#Construct sub-buffer#
@@ -5441,6 +5440,7 @@ a sub-buffer.
 * An [code]#exception# with the [code]#errc::invalid# error code if the sum of
 [code]#baseIndex# and [code]#subRange# in any dimension exceeds the parent
 buffer [code]#b# size [code]#bufferRange# in that dimension.
+
 '''
 
 
@@ -5454,6 +5454,7 @@ range<Dimensions> get_range() const;
 ----
 _Returns:_ A range object representing the size of the buffer in terms of number
 of elements in each dimension as passed to the constructor.
+
 '''
 
 .[apititle]#buffer::byte_size#
@@ -5463,6 +5464,7 @@ size_t byte_size() const noexcept;
 ----
 _Returns:_ The size of the buffer storage in bytes.
 Equal to [code]#size()*sizeof(T)#.
+
 '''
 
 .[apititle]#buffer::size#
@@ -5473,6 +5475,7 @@ size_t size() const noexcept;
 mode and target in the command group buffer.
 The value of target can be [code]#target::device#,
 [code]#target::constant_buffer# or [code]#target::host_task#.
+
 '''
 
 .[apititle]#buffer::get_count#
@@ -5483,6 +5486,7 @@ size_t get_count() const;
 Deprecated by SYCL 2020.
 
 _Effects:_ Equivalent to [code]#return size()#.
+
 '''
 
 .[apititle]#buffer::get_size#
@@ -5493,6 +5497,7 @@ size_t get_size() const;
 Deprecated by SYCL 2020.
 
 _Effects:_ Equivalent to [code]#return byte_size()#.
+
 '''
 
 .[apititle]#buffer::get_allocator#
@@ -5501,6 +5506,7 @@ _Effects:_ Equivalent to [code]#return byte_size()#.
 AllocatorT get_allocator() const;
 ----
 _Returns:_ The allocator provided to the buffer.
+
 '''
 
 .[apititle]#buffer::get_access#
@@ -5508,17 +5514,17 @@ _Returns:_ The allocator provided to the buffer.
 ----
 template <access_mode Mode = access_mode::read_write,
           target Targ = target::device>
-accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler); (1)
+accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler);  (1)
 
 template <access_mode Mode = access_mode::read_write,
           target Targ = target::device>
 accessor<T, Dimensions, Mode, Targ>
-get_access(handler& commandGroupHandler, range<Dimensions> accessRange,
-           id<Dimensions> accessOffset = {}); (2)
+get_access(handler& commandGroupHandler, range<Dimensions> accessRange,        (2)
+           id<Dimensions> accessOffset = {});
 
-template <typename... Ts> auto get_access(Ts...); (3)
+template <typename... Ts> auto get_access(Ts...);                              (3)
 
-template <typename... Ts> auto get_host_access(Ts...); (4)
+template <typename... Ts> auto get_host_access(Ts...);                         (4)
 ----
 _Returns (1):_ A valid [code]#accessor# to the buffer with the specified access
 mode and target in the command group buffer.
@@ -5549,17 +5555,18 @@ Possible implementation:
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
 the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
 buffer in any dimension.
+
 '''
 
 .[apititle]#Deprecated buffer::get_access#
 [source,role=synopsis,id=api:buffer-get-access-deprecated]
 ----
 template <access_mode Mode>
-accessor<T, Dimensions, Mode, target::host_buffer> get_access(); (1)
+accessor<T, Dimensions, Mode, target::host_buffer> get_access();              (1)
 
 template <access_mode Mode>
 accessor<T, Dimensions, Mode, target::host_buffer>
-get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {}); (2)
+get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {});  (2)
 ----
 Deprecated in SYCL 2020.
 Use [code]#get_host_access()# instead.
@@ -5576,6 +5583,7 @@ The value of target can only be [code]#target::host_buffer#.
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
 the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
 buffer in any dimension.
+
 '''
 
 .[apititle]#buffer::set_final_data#
@@ -5598,6 +5606,7 @@ expired.
 
 If [code]#Destination# is [code]#std::nullptr_t#, then the copy back will not
 happen.
+
 '''
 
 .[apititle]#buffer::set_write_back#
@@ -5612,6 +5621,7 @@ Forcing the write-back is similar to what happens during a normal write-back as
 described in <<sec:buf-sync-rules>> and <<sec:sharing-host-memory-with-dm>>.
 
 If there is nowhere to write-back, using this function does not have any effect.
+
 '''
 
 .[apititle]#buffer::is_sub_buffer#
@@ -5621,16 +5631,23 @@ bool is_sub_buffer() const;
 ----
 _Returns:_ [code]#true# if this SYCL [code]#buffer# is a sub-buffer and
 [code]#false# otherwise.
+
 '''
 
 .[apititle]#buffer::reinterpret#
 [source,role=synopsis,id=api:buffer-reinterpret]
 ----
-  template <typename ReinterpretT, int ReinterpretDim>
-  buffer<ReinterpretT, ReinterpretDim,
-         typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-             ReinterpretT>>
-  reinterpret(range<ReinterpretDim> reinterpretRange) const;
+template <typename ReinterpretT, int ReinterpretDim>
+buffer<ReinterpretT, ReinterpretDim,
+       typename std::allocator_traits<AllocatorT>::template rebind_alloc<
+           ReinterpretT>>
+reinterpret(range<ReinterpretDim> reinterpretRange) const;                 (1)
+
+template <typename ReinterpretT, int ReinterpretDim = Dimensions>
+buffer<ReinterpretT, ReinterpretDim,
+       typename std::allocator_traits<AllocatorT>::template rebind_alloc<
+           ReinterpretT>>
+reinterpret() const;                                                       (2)
 ----
 _Preconditions (2):_ Available when [code]#(ReinterpretDim == 1)# or when
 [code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) ==
@@ -5658,15 +5675,15 @@ represented by the type and range of this SYCL [code]#buffer# (or sub-buffer).
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
 the total size in bytes represented by this SYCL [code]#buffer# (or sub-buffer)
 is not evenly divisible by [code]#sizeof(ReinterpretT)#.
+
 '''
 
 
 [[sec:buffer-properties]]
-==== Buffer properties
+==== Properties
 
 This section describes the properties that can be passed in the [code]#propList#
 parameter of the <<sec:buffer-ctors, buffer constructors>>.
-
 
 '''
 
@@ -5785,7 +5802,7 @@ _Returns:_ The [code]#context# provided when constructing this property.
 
 
 [[sec:buf-sync-rules]]
-==== Buffer destruction rules
+==== Destruction rules
 
 Buffers are reference-counted.
 When a buffer value is constructed from another buffer, the two values reference

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5276,9 +5276,9 @@ buffer(Container& container, AllocatorT allocator,
 template <typename Container>                                      (2)
 buffer(Container& container, const property_list& propList = {});
 ----
-Preconditions: [code]#container# is a contiguous container.
+_Preconditions:_ [code]#container# is a contiguous container.
 
-Constraints: Available only when:
+_Constraints:_ Available only when:
 
 * [code]#std::data(container)# and [code]#std::size(container)# are well formed;
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5524,7 +5524,7 @@ template <typename... Ts> auto get_access(Ts...);                              (
 
 template <typename... Ts> auto get_host_access(Ts...);                         (4)
 ----
-_Constraints (1-2):_ Available only when [code]#Targ# is [code]#target::device#,
+_Constraints (1)-(2):_ Available only when [code]#Targ# is [code]#target::device#,
 [code]#target::constant_buffer# or [code]#target::host_task#.
 
 _Returns (1):_ A valid [code]#accessor# to the buffer with the specified access

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5292,10 +5292,8 @@ elements starting at [code]#std::data(container)# and containing
 [code]#std::size(container)# number of elements.
 The buffer is initialized with the contents of [code]#container#, and the buffer
 assumes exclusive access to [code]#container# for the duration of its lifetime.
-
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
-
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5168,7 +5168,7 @@ The SYCL [code]#buffer# class template provides the common reference semantics
 ==== Buffer interface
 
 The constructors and member functions of the SYCL [code]#buffer# class template
-are listed in <<table.constructors.buffer>> and <<table.members.buffer>>,
+are listed in <<sec:buffer-ctors>> and <<sec:buffer-member-funcs>>,
 respectively.
 The additional common special member functions and common member functions are
 listed in <<table.specialmembers.common.reference>> and
@@ -5192,342 +5192,225 @@ include::{header_dir}/buffer.h[lines=4..-1]
 ----
 
 
-[[table.constructors.buffer]]
-.Constructors of the [code]#buffer# class
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Constructor @ Description
-a@
-[source]
+[[sec:buffer-ctors]]
+==== Constructors
+
+.[apititle]#Construct with uninitialized memory#
+[source,role=synopsis,id=api:buffer-ctor-uninit]
 ----
 buffer(const range<Dimensions>& bufferRange,
-       const property_list& propList = {})
-----
-   a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
-      The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Data is not written back to the host on destruction of the [code]#buffer# unless the [code]#buffer# has a valid non-null pointer specified via the member function [code]#set_final_data()#.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+       const property_list& propList = {}); (1)
 
-a@
-[source]
+buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
+       const property_list& propList = {}); (2)
 ----
-buffer(const range<Dimensions>& bufferRange,
-       AllocatorT allocator,
-       const property_list& propList = {})
-----
-   a@ Construct a SYCL [code]#buffer# instance with uninitialized memory.
-      The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
-      The range of the constructed SYCL [code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-      Data is not written back to the host on destruction of the [code]#buffer# unless the [code]#buffer# has a valid non-null pointer specified via the member function [code]#set_final_data()#.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
+_Effects (1):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
 
-a@
-[source]
+_Effects (2):_ Construct a SYCL [code]#buffer# instance with uninitialized
+memory. The constructed SYCL [code]#buffer# will use the [code]#allocator#
+parameter provided when allocating memory on the host. The range of the
+constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
+parameter provided. Data is not written back to the host on destruction of the
+[code]#buffer# unless the [code]#buffer# has a valid non-null pointer specified
+via the member function [code]#set_final_data()#. Zero or more properties can be
+provided to the constructed SYCL [code]#buffer# via an instance of
+[code]#property_list#.
+'''
+
+.[apititle]#Construct with host memory#
+[source,role=synopsis,id=api:buffer-ctor-host-mem]
 ----
 buffer(T* hostData, const range<Dimensions>& bufferRange,
-       const property_list& propList = {})
-----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
-      parameter provided.  The buffer is initialized with the memory specified
-      by [code]#hostData#, and the buffer assumes exclusive access to this
-      memory for the duration of its lifetime.  The constructed SYCL
-      [code]#buffer# will use a default constructed [code]#AllocatorT# when
-      allocating memory on the host.  The range of the constructed SYCL
-      [code]#buffer# is specified by the [code]#bufferRange# parameter
-      provided.  Zero or more properties can be provided to the constructed
-      SYCL [code]#buffer# via an instance of [code]#property_list#.
+       const property_list& propList = {}); (1)
 
-a@
-[source]
-----
 buffer(T* hostData, const range<Dimensions>& bufferRange,
-       AllocatorT allocator,
-       const property_list& propList = {})
+       AllocatorT allocator, const property_list& propList = {}); (2)
+
+buffer(const T* hostData, const range<Dimensions>& bufferRange,
+       const property_list& propList = {}); (3)
+
+buffer(const T* hostData, const range<Dimensions>& bufferRange,
+       AllocatorT allocator, const property_list& propList = {}); (4)
 ----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
-      parameter provided.  The buffer is initialized with the memory specified
-      by [code]#hostData#, and the buffer assumes exclusive access to this
-      memory for the duration of its lifetime.  The constructed SYCL
-      [code]#buffer# will use the [code]#allocator# parameter provided when
-      allocating memory on the host.  The range of the constructed SYCL
-      [code]#buffer# is specified by the [code]#bufferRange# parameter
-      provided.  Zero or more properties can be provided to the constructed
-      SYCL [code]#buffer# via an instance of [code]#property_list#.
+_Effects (1):_ Equivalent to
+`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
 
-a@
-[source]
-----
-buffer(const T* hostData,
-       const range<Dimensions>& bufferRange,
-       const property_list& propList = {})
-----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
-      parameter provided.  The buffer assumes exclusive access to this memory
-      for the duration of its lifetime.
+_Effects (2):_ Construct a SYCL [code]#buffer# instance with the
+[code]#hostData# parameter provided. The buffer is initialized with the memory
+specified by [code]#hostData#, and the buffer assumes exclusive access to this
+memory for the duration of its lifetime.  The constructed SYCL [code]#buffer#
+will use the [code]#allocator# parameter provided when allocating memory on the
+host.  The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.  Zero or more properties can be provided
+to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
 
-The constructed SYCL [code]#buffer# will use a default
-constructed [code]#AllocatorT# when allocating memory on
-the host.
+_Effects (3):_ Equivalent to
+`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
 
-The host address is [code]#const T#, so the host accesses
-can be read-only. However, the [code]#typename T# is not const so
-the device accesses can be both read and write accesses. Since
-the [code]#hostData# is const, this buffer is only initialized with
-this memory and there is no write back after its destruction,
-unless the [code]#buffer# has another valid non-null final
-data address specified via the member function
-[code]#set_final_data()# after construction of the
-[code]#buffer#.
+_Effects (4):_ Construct a SYCL [code]#buffer# instance with the
+[code]#hostData# parameter provided.  The buffer assumes exclusive access to
+this memory for the duration of its lifetime.
 
-The range of the constructed SYCL [code]#buffer# is
-specified by the [code]#bufferRange# parameter provided.
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.
 
-Zero or more properties can be provided to the constructed SYCL
-[code]#buffer# via an instance of
-[code]#property_list#.
+The host address is [code]#const T#, so the host accesses can be read-only.
+However, the [code]#typename T# is not const so the device accesses can be both
+read and write accesses. Since, the [code]#hostData# is const, this buffer is
+only initialized with this memory and there is no write back after its
+destruction, unless the [code]#buffer# has another valid non-null final data
+address specified via the member function [code]#set_final_data()# after
+construction of the [code]#buffer#.
 
-a@
-[source]
-----
-buffer(const T* hostData,
-       const range<Dimensions>& bufferRange,
-       AllocatorT allocator,
-       const property_list& propList = {})
-----
-   a@ Construct a SYCL [code]#buffer# instance with the [code]#hostData#
-      parameter provided.  The buffer assumes exclusive access to this
-      memory for the duration of its lifetime.
+The range of the constructed SYCL [code]#buffer# is specified by the
+[code]#bufferRange# parameter provided.
 
-The constructed SYCL [code]#buffer# will use the
-[code]#allocator# parameter provided when allocating
-memory on the host.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
+'''
 
-The host address is [code]#const T#, so the host accesses
-can be read-only. However, the [code]#typename T# is not const so
-the device accesses can be both read and write accesses. Since,
-the [code]#hostData# is const, this buffer is only initialized
-with this memory and there is no write back after its
-destruction, unless the [code]#buffer# has another valid
-non-null final data address specified via the member function
-[code]#set_final_data()# after construction of the
-[code]#buffer#.
-
-The range of the constructed SYCL [code]#buffer# is
-specified by the [code]#bufferRange# parameter provided.
-
-Zero or more properties can be provided to the constructed SYCL
-[code]#buffer# via an instance of
-[code]#property_list#.
-
-
-a@
-[source]
-----
-template <typename Container>
-buffer(Container& container,
-       const property_list& propList = {})
-----
-   a@ Construct a one dimensional SYCL [code]#buffer# instance
-      from the elements starting at [code]#std::data(container)#
-      and containing [code]#std::size(container)# number of elements.
-      The buffer is initialized with the contents of [code]#container#,
-      and the buffer assumes exclusive access to [code]#container# for
-      the duration of its lifetime.
-
-Data is written back to [code]#container# before the completion of
-[code]#buffer# destruction if the return type of [code]#std::data(container)#
-is not [code]#const#.
-
-The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-
-Zero or more properties can be provided to the constructed SYCL
-[code]#buffer# via an instance of
-[code]#property_list#.
-
-This constructor is only defined for a [code]#buffer# parameterized
-with [code]#Dimensions == 1#, and when [code]#std::data(container)#
-is convertible to [code]#T*#.
-
-
-a@
-[source]
+.[apititle]#Construct from a container#
+[source,role=synopsis,id=api:buffer-ctor-container]
 ----
 template <typename Container>
 buffer(Container& container, AllocatorT allocator,
-       const property_list& propList = {})
+       const property_list& propList = {}); (1)
+
+template <typename Container>
+buffer(Container& container, const property_list& propList = {}); (2)
 ----
-   a@ Construct a one dimensional SYCL [code]#buffer# instance
-      from the elements starting at [code]#std::data(container)#
-      and containing [code]#std::size(container)# number of elements.
-      The buffer is initialized with the contents of [code]#container#,
-      and the buffer assumes exclusive access to [code]#container# for
-      the duration of its lifetime.
+Constraints:_ Available only if [code]#Container# must be a contiguous
+container, that is the following requirements must be met:
+
+* [code]#std::data(container)# and [code]#std::size(container)# are well formed;
+
+* the return type of [code]#std::data(container)# is convertible to [code]#T*#;
+  and
+
+* [code]#Dimensions == 1#.
+
+_Effects (1):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
+
+_Effects (2):_ Construct a one dimensional SYCL [code]#buffer# instance from the
+elements starting at [code]#std::data(container)# and containing
+[code]#std::size(container)# number of elements. The buffer is initialized with
+the contents of [code]#container#, and the buffer assumes exclusive access to
+[code]#container# for the duration of its lifetime.
 
 Data is written back to [code]#container# before the completion of
 [code]#buffer# destruction if the return type of [code]#std::data(container)#
 is not [code]#const#.
 
-The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.
 
-Zero or more properties can be provided to the constructed SYCL
-[code]#buffer# via an instance of
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
+'''
+
+.[apititle]#Construct from memory owned by a shared pointer#
+[source,role=synopsis,id=api:buffer-ctor-shared-ptr]
+----
+  buffer(const std::shared_ptr<T>& hostData,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T>& hostData,
+         const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T[]>& hostData,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T[]>& hostData,
+         const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
+----
+_Effects (1):_ Equivalent to
+`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+
+_Effects (2):_ When [code]#hostData# is not empty, construct a SYCL buffer with
+the contents of its stored pointer.  The buffer assumes exclusive access to this
+memory for the duration of its lifetime.  The buffer also creates its own
+internal copy of the [code]#shared_ptr# that shares ownership of the
+[code]#hostData# memory, which means the application can safely release
+ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.  The range of the constructed SYCL
+[code]#buffer# is specified by the [code]#bufferRange# parameter provided. Zero
+or more properties can be provided to the constructed SYCL [code]#buffer# via an
+instance of [code]#property_list#.
+
+_Effects (3):_ Equivalent to
+`buffer(hostData, bufferRange, AllocatorT{}, propList)`.
+
+_Effects (4):_ When [code]#hostData# is not empty, construct a SYCL buffer with
+the contents of its stored pointer.  The buffer assumes exclusive access to this
+memory for the duration of its lifetime.  The buffer also creates its own
+internal copy of the [code]#shared_ptr# that shares ownership of the
+[code]#hostData# memory, which means the application can safely release
+ownership of this [code]#shared_ptr# when the constructor returns.
+
+When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
+memory.
+
+The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host.  The range of the constructed SYCL
+[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
+Zero or more properties can be provided to the constructed SYCL [code]#buffer#
+via an instance of [code]#property_list#.
+'''
+
+.[apititle]#Construct from iterators#
+[source,role=synopsis,id=api:buffer-ctor-iterator]
+----
+template <class InputIterator>
+buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
+             const property_list& propList = {});
+
+template <class InputIterator>
+buffer<T, 1>(InputIterator first, InputIterator last,
+             const property_list& propList = {});
+----
+_Effects (1):_ Create a new allocated 1D buffer initialized from the given
+elements ranging from [code]#first# up to one before [code]#last#. The data is
+copied to an intermediate memory position by the runtime. Data is not written
+back to the same iterator set provided. However, if the [code]#buffer# has a
+valid non-const iterator specified via the member function
+[code]#set_final_data()#, data will be copied back to that iterator. The
+constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
+provided when allocating memory on the host. Zero or more properties can be
+provided to the constructed SYCL [code]#buffer# via an instance of
 [code]#property_list#.
 
-This constructor is only defined for a [code]#buffer# parameterized
-with [code]#Dimensions == 1#, and when [code]#std::data(container)#
-is convertible to [code]#T*#.
+_Effects (2):_ Equivalent to `buffer(first, last, AllocatorT{}, propList)`.
+'''
 
-
-a@
-[source]
-----
-buffer(const std::shared_ptr<T>& hostData,
-       const range<Dimensions>& bufferRange,
-       const property_list& propList = {})
-----
-   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
-      contents of its stored pointer.  The buffer assumes exclusive access to
-      this memory for the duration of its lifetime.  The buffer also creates
-      its own internal copy of the [code]#shared_ptr# that shares ownership of
-      the [code]#hostData# memory, which means the application can safely
-      release ownership of this [code]#shared_ptr# when the constructor
-      returns.
-
-When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
-memory.
-
-The constructed SYCL [code]#buffer# will use a default constructed
-[code]#AllocatorT# when allocating memory on the host.  The range of the
-constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
-parameter provided.  Zero or more properties can be provided to the
-constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
-
-a@
-[source]
-----
-buffer(const std::shared_ptr<T>& hostData,
-       const range<Dimensions>& bufferRange,
-       AllocatorT allocator,
-       const property_list& propList = {})
-----
-   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
-      contents of its stored pointer.  The buffer assumes exclusive access to
-      this memory for the duration of its lifetime.  The buffer also creates
-      its own internal copy of the [code]#shared_ptr# that shares ownership of
-      the [code]#hostData# memory, which means the application can safely
-      release ownership of this [code]#shared_ptr# when the constructor
-      returns.
-
-When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
-memory.
-
-The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
-provided when allocating memory on the host.  The range of the constructed SYCL
-[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-Zero or more properties can be provided to the constructed SYCL [code]#buffer#
-via an instance of [code]#property_list#.
-
-a@
-[source,c++]
-----
-buffer(const std::shared_ptr<T[]>& hostData,
-       const range<Dimensions>&  bufferRange,
-       const property_list& propList = {})
-----
-   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
-      contents of its stored pointer.  The buffer assumes exclusive access to
-      this memory for the duration of its lifetime.  The buffer also creates
-      its own internal copy of the [code]#shared_ptr# that shares ownership of
-      the [code]#hostData# memory, which means the application can safely
-      release ownership of this [code]#shared_ptr# when the constructor
-      returns.
-
-When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
-memory.
-
-The constructed SYCL [code]#buffer# will use a default constructed
-[code]#AllocatorT# when allocating memory on the host.  The range of the
-constructed SYCL [code]#buffer# is specified by the [code]#bufferRange#
-parameter provided.  Zero or more properties can be provided to the
-constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
-
-a@
-[source,c++]
-----
-buffer(const std::shared_ptr<T[]>& hostData,
-       const range<Dimensions>& bufferRange,
-       AllocatorT allocator,
-       const property_list& propList = {})
-----
-   a@ When [code]#hostData# is not empty, construct a SYCL buffer with the
-      contents of its stored pointer.  The buffer assumes exclusive access to
-      this memory for the duration of its lifetime.  The buffer also creates
-      its own internal copy of the [code]#shared_ptr# that shares ownership of
-      the [code]#hostData# memory, which means the application can safely
-      release ownership of this [code]#shared_ptr# when the constructor
-      returns.
-
-When [code]#hostData# is empty, construct a SYCL buffer with uninitialized
-memory.
-
-The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
-provided when allocating memory on the host.  The range of the constructed SYCL
-[code]#buffer# is specified by the [code]#bufferRange# parameter provided.
-Zero or more properties can be provided to the constructed SYCL [code]#buffer#
-via an instance of [code]#property_list#.
-
-a@
-[source]
-----
-template <typename InputIterator>
-buffer(InputIterator first, InputIterator last,
-       const property_list& propList = {})
-----
-   a@ Create a new allocated 1D buffer initialized from the given elements
-      ranging from [code]#first# up to one before [code]#last#.
-      The data is copied to an intermediate memory position by the runtime.
-      Data is not written back to the same iterator set provided. However, if the [code]#buffer# has a valid non-const iterator specified via the member function [code]#set_final_data()#, data will be copied back to that iterator.
-      The constructed SYCL [code]#buffer# will use a default constructed [code]#AllocatorT# when allocating memory on the host.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
-
-a@
-[source]
-----
-template <typename InputIterator>
-buffer(InputIterator first, InputIterator last,
-       AllocatorT allocator = {},
-       const property_list& propList = {})
-----
-   a@ Create a new allocated 1D buffer initialized from the given elements
-      ranging from [code]#first# up to one before [code]#last#.
-      The data is copied to an intermediate memory position by the runtime.
-      Data is not written back to the same iterator set provided. However, if the [code]#buffer# has a valid non-const iterator specified via the member function [code]#set_final_data()#, data will be copied back to that iterator.
-      The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter provided when allocating memory on the host.
-      Zero or more properties can be provided to the constructed SYCL [code]#buffer# via an instance of [code]#property_list#.
-
-a@
-[source]
+.[apititle]#Construct sub-buffer#
+[source,role=synopsis,id=api:buffer-ctor-subbuffer]
 ----
 buffer(buffer& b, const id<Dimensions>& baseIndex,
-       const range<Dimensions>& subRange)
+       const range<Dimensions>& subRange);
 ----
-   a@ Create a new sub-buffer without allocation to have separate
-      accessors later. [code]#b# is the buffer with the real data, which must not be a sub-buffer.
-      [code]#baseIndex# specifies the origin of the sub-buffer inside the
-      buffer [code]#b#. [code]#subRange# specifies the size of the sub-buffer.
-      The sum of [code]#baseIndex# and [code]#subRange# in any dimension must not
-      exceed the parent buffer ([code]#b)# size ([code]#bufferRange)# in that dimension,
-      and an [code]#exception# with the [code]#errc::invalid# error code must be thrown if violated.
+_Preconditions_:
 
-The offset and range specified by [code]#baseIndex# and
-[code]#subRange# together must represent a contiguous
-region of the original SYCL [code]#buffer#.
+* The offset and range specified by [code]#baseIndex# and [code]#subRange#
+together must represent a contiguous region of the original SYCL [code]#buffer#.
 
-If a non-contiguous region of a buffer is requested when
-constructing a sub-buffer, then an [code]#exception# with
-the [code]#errc::invalid# error code must be
-thrown.
+* The sum of [code]#baseIndex# and [code]#subRange# in any dimension must not
+exceed the parent buffer [code]#b# size [code]#bufferRange# in that dimension.
+
+* The parent buffer [code]#b# must not be a sub-buffer.
+
+_Effects:_ Create a new sub-buffer without allocation to have separate accessors
+later. [code]#b# is the buffer with the real data. [code]#baseIndex# specifies
+the origin of the sub-buffer inside the buffer [code]#b#. [code]#subRange#
+specifies the size of the sub-buffer.
 
 The origin (based on [code]#baseIndex#) of the sub-buffer being constructed
 must be a multiple of the memory base address alignment of each SYCL
@@ -5542,267 +5425,254 @@ queue, the sub-buffer's alignment must be compatible with both the primary
 queue's device and the secondary queue's device, otherwise this exception is
 thrown.
 
-Must throw an [code]#exception# with the [code]#errc::invalid# error code if
-[code]#b# is a sub-buffer.
+_Throws:_
 
-|====
+* An [code]#exception# with the [code]#errc::invalid# error code if [code]#b#
+is a sub-buffer.
+
+* An [code]#exception# with the [code]#errc::invalid# error code if
+[code]#subRange# corresponds to a a non-contiguous region of [code]#b#.
+
+- An [code]#exception# with the [code]#errc::invalid# error code if the sum
+of [code]#baseIndex# and [code]#subRange# in any dimension exceeds the parent
+buffer [code]#b# size [code]#bufferRange# in that dimension.
+'''
 
 
+[[sec:buffer-member-funcs]]
+==== Member functions
 
-[[table.members.buffer]]
-.Member functions for the [code]#buffer# class
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Member function @ Description
-a@
-[source]
+.[apititle]#buffer::get_range#
+[source,role=synopsis,id=api:buffer-get-range]
 ----
-range<Dimensions> get_range() const
+range<Dimensions> get_range() const;
 ----
-   a@ Return a range object representing the
-      size of the buffer in terms of number
-      of elements in each dimension as passed
-      to the constructor.
+_Returns:_ A range object representing the size of the buffer in terms of number
+of elements in each dimension as passed to the constructor.
+'''
 
-a@
-[source]
+.[apititle]#buffer::byte_size#
+[source,role=synopsis,id=api:buffer-byte-size]
 ----
-size_t size() const noexcept
+size_t byte_size() const noexcept;
 ----
-   a@ Returns the total number of elements in the buffer.
-      Equal to [code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
-a@
-[source]
-----
-size_t get_count() const
-----
-   a@ Returns the same value as [code]#size()#. Deprecated.
-a@
-[source]
-----
-size_t byte_size() const noexcept
-----
-   a@ Returns the size of the buffer storage in bytes.
-      Equal to [code]#size()*sizeof(T)#.
-a@
-[source]
-----
-size_t get_size() const
-----
-   a@ Returns the same value as [code]#byte_size()#. Deprecated.
-a@
-[source]
-----
-AllocatorT get_allocator() const
-----
-   a@ Returns the allocator provided to the buffer.
+_Returns:_ The size of the buffer storage in bytes. Equal to
+[code]#size()*sizeof(T)#.
+'''
 
-a@
-[source]
+.[apititle]#buffer::size#
+[source,role=synopsis,id=api:buffer-size]
+----
+size_t size() const noexcept;
+----
+_Returns:_ The total number of elements in the buffer. Equal to
+[code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
+'''
+
+.[apititle]#buffer::get_count#
+[source,role=synopsis,id=api:buffer-get-count]
+----
+size_t get_count() const;
+----
+Deprecated by SYCL 2020.
+
+_Returns:_ The same value as [code]#size()#.
+'''
+
+.[apititle]#buffer::get_size#
+[source,role=synopsis,id=api:buffer-get-size]
+----
+size_t get_size() const;
+----
+Deprecated by SYCL 2020.
+
+_Returns:_ The same value as [code]#byte_size()#.
+'''
+
+.[apititle]#buffer::get_allocator#
+[source,role=synopsis,id=api:buffer-get-allocator]
+----
+AllocatorT get_allocator() const;
+----
+_Returns:_ The allocator provided to the buffer.
+'''
+
+.[apititle]#buffer::get_access#
+[source,role=synopsis,id=api:buffer-get-access]
 ----
 template <access_mode Mode = access_mode::read_write,
           target Targ = target::device>
-accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler)
-----
-   a@ Returns a valid [code]#accessor# to the buffer with the specified
-      access mode and target in the command group buffer.
-      The value of target can be [code]#target::device#,
-      [code]#target::constant_buffer# or
-      [code]#target::host_task#.
+accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler); (1)
 
-a@
-[source]
-----
-template <access_mode Mode>
-accessor<T, Dimensions, Mode, target::host_buffer> get_access()
-----
-   a@ Deprecated in SYCL 2020.  Use [code]#get_host_access()# instead.
-
-Returns a valid host [code]#accessor# to the buffer with the specified
-access mode and target.
-
-a@
-[source]
-----
 template <access_mode Mode = access_mode::read_write,
           target Targ = target::device>
-accessor<T, Dimensions, Mode, Targ> get_access(handler& commandGroupHandler,
-                                               range<Dimensions> accessRange,
-                                               id<Dimensions> accessOffset = {})
-----
-   a@ Returns a valid [code]#accessor# to the buffer with the specified access
-      mode and target in the command group buffer.  The accessor is a
-      <<ranged-accessor>>, where the range starts at the given offset from the
-      beginning of the buffer.  The value of target can be
-      [code]#target::device#, [code]#target::constant_buffer# or
-      [code]#target::host_task#.
+accessor<T, Dimensions, Mode, Targ>
+get_access(handler& commandGroupHandler, range<Dimensions> accessRange,
+           id<Dimensions> accessOffset = {}); (2)
 
-Throws an [code]#exception# with the [code]#errc::invalid# error code if
-the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
-the buffer in any dimension.
+template <typename... Ts> auto get_access(Ts...); (3)
 
-a@
-[source]
+template <typename... Ts> auto get_host_access(Ts...); (4)
 ----
-template <access_mode Mode>
-accessor<T, Dimensions, Mode, target::host_buffer>
-get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {})
-----
-   a@ Deprecated in SYCL 2020.  Use [code]#get_host_access()# instead.
+_Returns (1):_ A valid [code]#accessor# to the buffer with the specified access
+mode and target in the command group buffer. The value of target can be
+[code]#target::device#, [code]#target::constant_buffer# or
+[code]#target::host_task#.
 
-Returns a valid host [code]#accessor# to the buffer with the specified access
-mode and target.  The accessor is a <<ranged-accessor>>, where the range starts
-at the given offset from the beginning of the buffer.  The value of target can
-only be [code]#target::host_buffer#.
+_Returns (2):_ A valid [code]#accessor# to the buffer with the specified access
+mode and target in the command group buffer.  The accessor is a
+<<ranged-accessor>>, where the range starts at the given offset from the
+beginning of the buffer.  The value of target can be [code]#target::device#,
+[code]#target::constant_buffer# or [code]#target::host_task#.
 
-Throws an [code]#exception# with the [code]#errc::invalid# error code if
-the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
-the buffer in any dimension.
-
-a@
-[source]
-----
-template <typename... Ts> auto get_access(Ts... args)
-----
-   a@ Returns a valid [code]#accessor# as if constructed via passing the buffer
-      and all provided arguments to the [code]#accessor# constructor.
+_Returns (3):_ A  valid [code]#accessor# as if constructed via passing the
+buffer and all provided arguments to the [code]#accessor# constructor.
 
 Possible implementation:
 
 [code]#+return accessor{*this, args...};+#
 
-a@
-[source]
-----
-template <typename... Ts> auto get_host_access(Ts... args)
-----
-   a@ Returns a valid [code]#host_accessor# as if constructed via passing the
-      buffer and all provided arguments to the [code]#host_accessor#
-      constructor.
+_Returns (4):_ A valid [code]#host_accessor# as if constructed via passing the
+buffer and all provided arguments to the [code]#host_accessor# constructor.
 
 Possible implementation:
 
 [code]#+return host_accessor{*this, args...};+#
 
-a@
-[source]
+_Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
+the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
+the buffer in any dimension.
+'''
+
+.[apititle]#Deprecated buffer::get_access#
+[source,role=synopsis,id=api:buffer-get-access-deprecated]
+----
+template <access_mode Mode>
+accessor<T, Dimensions, Mode, target::host_buffer> get_access(); (1)
+
+template <access_mode Mode>
+accessor<T, Dimensions, Mode, target::host_buffer>
+get_access(range<Dimensions> accessRange, id<Dimensions> accessOffset = {}); (2)
+----
+Deprecated in SYCL 2020.  Use [code]#get_host_access()# instead.
+
+_Returns (1):_ A valid host [code]#accessor# to the buffer with the specified
+access mode and target.
+
+_Returns (2):_ A valid host [code]#accessor# to the buffer with the specified access
+mode and target.  The accessor is a <<ranged-accessor>>, where the range starts
+at the given offset from the beginning of the buffer.  The value of target can
+only be [code]#target::host_buffer#.
+
+_Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
+the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
+the buffer in any dimension.
+'''
+
+.[apititle]#buffer::set_final_data#
+[source,role=synopsis,id=api:buffer-set-final-data]
 ----
 template <typename Destination = std::nullptr_t>
-void set_final_data(Destination finalData = nullptr)
+void set_final_data(Destination finalData = nullptr);
 ----
-   a@ The [code]#finalData# points to where the outcome of all
-      the buffer processing is going to be copied to at destruction
-      time, if the buffer was involved with a write accessor.
+_Effects:_ The [code]#finalData# points to where the outcome of all the buffer
+processing is going to be copied to at destruction time, if the buffer was
+involved with a write accessor.
 
-Destination can be either an output iterator or a
-[code]#std::weak_ptr<T>#.
+Destination can be either an output iterator or a [code]#std::weak_ptr<T>#.
 
-Note that a raw pointer is a special case of output iterator and
-thus defines the host memory to which the result is to be
-copied.
+Note that a raw pointer is a special case of output iterator and thus defines
+the host memory to which the result is to be copied.
 
-In the case of a weak pointer, the output is not updated if the
-weak pointer has expired.
+In the case of a weak pointer, the output is not updated if the weak pointer has
+expired.
 
-If [code]#Destination# is [code]#std::nullptr_t#, then
-the copy back will not happen.
+If [code]#Destination# is [code]#std::nullptr_t#, then the copy back will not
+happen.
+'''
 
-a@
-[source]
+.[apititle]#buffer::set_write_back#
+[source,role=synopsis,id=api:buffer-set-write-back]
 ----
-void set_write_back(bool flag = true)
+void set_write_back(bool flag = true);
 ----
-   a@ This member function allows dynamically forcing or canceling the
-      write-back of the data of a buffer on destruction according to
-      the value of [code]#flag#.
+_Effects:_ Dynamically forces or cancels the write-back of the data of a buffer
+on destruction according to       the value of [code]#flag#.
 
-Forcing the write-back is similar to what happens during a
-normal write-back as described in <<sec:buf-sync-rules>>
-and <<sec:sharing-host-memory-with-dm>>.
+Forcing the write-back is similar to what happens during a normal write-back as
+described in <<sec:buf-sync-rules>> and <<sec:sharing-host-memory-with-dm>>.
 
-If there is nowhere to write-back, using this function does not
-have any effect.
+If there is nowhere to write-back, using this function does not have any effect.
+'''
 
-a@
-[source]
+.[apititle]#buffer::is_sub_buffer#
+[source,role=synopsis,id=api:buffer-is-sub-buffer]
 ----
-bool is_sub_buffer() const
+bool is_sub_buffer() const;
 ----
-   a@ Returns true if this SYCL [code]#buffer# is a sub-buffer, otherwise
-      returns false.
+_Returns:_ [code]#true# if this SYCL [code]#buffer# is a sub-buffer and
+[code]#false# otherwise.
+'''
 
-a@
-[source]
+.[apititle]#buffer::reinterpret#
+[source,role=synopsis,id=api:buffer-reinterpret]
 ----
-template <typename ReinterpretT, int ReinterpretDim>
-buffer<ReinterpretT, ReinterpretDim,
-       typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-           std::remove_const_t<ReinterpretT>>>
-reinterpret(range<ReinterpretDim> reinterpretRange) const
+  template <typename ReinterpretT, int ReinterpretDim>
+  buffer<ReinterpretT, ReinterpretDim,
+         typename std::allocator_traits<AllocatorT>::template rebind_alloc<
+             ReinterpretT>>
+  reinterpret(range<ReinterpretDim> reinterpretRange) const;
 ----
-   a@ Creates and returns a reinterpreted SYCL [code]#buffer#
-      with the type specified by [code]#ReinterpretT#,
-      dimensions specified by [code]#ReinterpretDim# and range
-      specified by [code]#reinterpretRange#.  The buffer object
-      being reinterpreted can be a SYCL sub-buffer that was created
-      from a SYCL [code]#buffer# and must throw
-      [code]#exception# with the
-      [code]#errc::invalid# error code if the total
-      size in bytes represented by the type and range of the
-      reinterpreted SYCL [code]#buffer# (or sub-buffer) does not
-      equal the total size in bytes represented by the type and range
-      of this SYCL [code]#buffer# (or sub-buffer).
-      Reinterpreting a sub-buffer provides a reinterpreted view of
-      the sub-buffer only, and does not change the offset or size of
-      the sub-buffer view (in bytes) relative to the parent
-      [code]#buffer#.
+_Preconditions (2):_ Available when [code]#(ReinterpretDim == 1)# or when
+[code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) == sizeof(T)))#.
 
-a@
-[source]
-----
-template <typename ReinterpretT, int ReinterpretDim = Dimensions>
-buffer<ReinterpretT, ReinterpretDim,
-       typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-           std::remove_const_t<ReinterpretT>>>
-reinterpret() const
-----
-   a@ Creates and returns a reinterpreted SYCL [code]#buffer#
-      with the type specified by [code]#ReinterpretT# and
-      dimensions specified by [code]#ReinterpretDim#.
-      Only valid when [code]#(ReinterpretDim == 1)# or when
-      [code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) == sizeof(T)))#.
-      The buffer object being reinterpreted can be a SYCL sub-buffer
-      that was created from a SYCL [code]#buffer#.  The implementation must
-      throw an [code]#exception# with the [code]#errc::invalid# error code
-      if the total size in bytes represented by this SYCL [code]#buffer# (or
-      sub-buffer) is not evenly divisible by [code]#sizeof(ReinterpretT)#.
-      Reinterpreting a sub-buffer provides a reinterpreted view
-      of the sub-buffer only,
-      and does not change the offset or size of the sub-buffer view (in bytes)
-      relative to the parent [code]#buffer#.
+_Effects:_ Creates a reinterpreted SYCL [code]#buffer#. The buffer object being
+reinterpreted can be a SYCL sub-buffer that was created from a SYCL
+[code]#buffer#. Reinterpreting a sub-buffer provides a reinterpreted view of
+the sub-buffer only, and does not change the offset or size of the sub-buffer
+view (in bytes) relative to the parent [code]#buffer#.
 
-|====
+_Returns (1):_ A reinterpreted SYCL [code]#buffer# with the type specified by
+[code]#ReinterpretT#, dimensions specified by [code]#ReinterpretDim# and range
+specified by [code]#reinterpretRange#.
 
+_Returns (2):_ A reinterpreted SYCL [code]#buffer# with the type specified by
+[code]#ReinterpretT# and dimensions specified by [code]#ReinterpretDim#.
+
+_Throws (1):_ An [code]#exception# with the [code]#errc::invalid# error code if
+the total size in bytes represented by the type and range of the reinterpreted
+SYCL [code]#buffer# (or sub-buffer) does not equal the total size in bytes
+represented by the type and range of this SYCL [code]#buffer# (or sub-buffer).
+
+_Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
+the total size in bytes represented by this SYCL [code]#buffer# (or sub-buffer)
+is not evenly divisible by [code]#sizeof(ReinterpretT)#.
+'''
 
 
 [[sec:buffer-properties]]
 ==== Buffer properties
 
-The properties that can be provided when constructing the SYCL [code]#buffer#
-class are described in <<table.properties.buffer>>.
+This section describes the properties that can be passed in the [code]#propList#
+parameter of the <<sec:buffer-ctors, buffer constructors>>.
 
 
-[[table.properties.buffer]]
-.Properties supported by the SYCL [code]#buffer# class
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Property @ Description
-a@
-[source]
+'''
+
+.[apidef]#property::buffer::use_host_ptr#
+[source,role=synopsis,id=api:property-buffer-use-host-ptr]
 ----
-property::buffer::use_host_ptr
+namespace sycl::property::buffer {
+class use_host_ptr {
+  use_host_ptr();  (1)
+};
+} // namespace sycl::property::buffer
 ----
-   a@ The [code]#use_host_ptr# property adds the requirement that the <<sycl-runtime>> must not allocate any memory for the SYCL [code]#buffer# and instead uses the provided host pointer directly. This prevents the <<sycl-runtime>> from allocating additional temporary storage on the host.
+
+The [code]#use_host_ptr# property adds the requirement that the <<sycl-runtime>>
+must not allocate any memory for the SYCL [code]#buffer# and instead uses the
+provided host pointer directly. This prevents the <<sycl-runtime>> from
+allocating additional temporary storage on the host.
 
 This property has a special guarantee for buffers that are constructed from a
 [code]#hostData# pointer.  If a [code]#host_accessor# is constructed from such
@@ -5810,90 +5680,63 @@ a buffer, then the address of the [code]#reference# type returned from the
 accessor's member functions such as [code]#operator[](id<>)# will be the same
 as the corresponding [code]#hostData# address.
 
-a@
-[source]
+_Effects (1):_ Constructs an [code]#use_host_ptr# property object.
+
+'''
+
+.[apidef]#property::buffer::use_mutex#
+[source,role=synopsis,id=api:property-buffer-use-mutex]
 ----
-property::buffer::use_mutex
+namespace sycl::property::buffer {
+class use_mutex {
+  use_mutex(std::mutex& mutexRef);  (1)
+
+  std::mutex* get_mutex_ptr() const; (2)
+};
+} // namespace sycl::property::buffer
 ----
-   a@ The [code]#use_mutex# property is valid for the SYCL
-      [code]#buffer#, [code]#unsampled_image# and
-      [code]#sampled_image# classes. The property adds the
-      requirement that the memory which is owned by the SYCL
-      [code]#buffer# can be shared with the application via a
-      [code]#std::mutex# provided to the property. The mutex
-      [code]#m# is locked by the runtime whenever the data is in
-      use and unlocked otherwise. The contents of [code]#hostData# are
-      guaranteed to reflect the contents of the buffer when the
-      [code]#std::mutex# is unlocked by the runtime.
 
-a@
-[source]
+The [code]#use_mutex# property is valid for the SYCL [code]#buffer#,
+[code]#unsampled_image# and [code]#sampled_image# classes. The property adds the
+requirement that the memory which is owned by the SYCL [code]#buffer# can be
+shared with the application via a [code]#std::mutex# provided to the property.
+The mutex [code]#m# is locked by the runtime whenever the data is in use and
+unlocked otherwise. The contents of [code]#hostData# are guaranteed to reflect
+the contents of the buffer when the [code]#std::mutex# is unlocked by the
+runtime.
+
+_Effects (1):_ Constructs a SYCL [code]#use_mutex# property instance with a
+reference to [code]#mutexRef# parameter provided.
+
+_Returns (2):_ The [code]#std::mutex# which was specified when constructing this
+SYCL [code]#use_mutex# property.
+
+'''
+
+.[apidef]#property::buffer::context_bound#
+[source,role=synopsis,id=api:property-buffer-context-bound]
 ----
-property::buffer::context_bound
+namespace sycl::property::buffer {
+class context_bound {
+ public:
+  context_bound(context boundContext);
+
+  context get_context() const;
+};
+} // namespace sycl::property::buffer
 ----
-   a@ The [code]#context_bound# property adds the requirement that the SYCL [code]#buffer# can only be associated with a single SYCL [code]#context# that is provided to the property.
 
-|====
+The [code]#context_bound# property adds the requirement that the SYCL
+[code]#buffer# can only be associated with a single SYCL [code]#context# that is
+provided to the property.
 
+_Effects (1):_ Constructs a SYCL [code]#context_bound# property instance with a
+copy of a SYCL [code]#context#.
 
-The constructors and special member functions of the buffer property classes are
-listed in <<table.constructors.properties.buffer>> and
-<<table.members.properties.buffer>> respectively.
+_Returns (2):_ The [code]#context# which was specified when constructing this
+SYCL [code]#context_bound# property.
 
-
-[[table.constructors.properties.buffer]]
-.Constructors of the [code]#buffer# [code]#property# classes
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Constructor @ Description
-a@
-[source]
-----
-property::buffer::use_host_ptr::use_host_ptr()
-----
-   a@ Constructs a SYCL [code]#use_host_ptr# property instance.
-
-a@
-[source]
-----
-property::buffer::use_mutex::use_mutex(std::mutex& mutexRef)
-----
-   a@ Constructs a SYCL [code]#use_mutex# property instance with a reference to [code]#mutexRef# parameter provided.
-
-a@
-[source]
-----
-property::buffer::context_bound::context_bound(context boundContext)
-----
-   a@ Constructs a SYCL [code]#context_bound# property instance with a copy of a SYCL [code]#context#.
-
-|====
-
-
-
-[[table.members.properties.buffer]]
-.Member functions of the [code]#buffer# [code]#property# classes
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Member function @ Description
-a@
-[source]
-----
-std::mutex* property::buffer::use_mutex::get_mutex_ptr() const
-----
-   a@ Returns the [code]#std::mutex# which was specified when
-      constructing this SYCL [code]#use_mutex# property.
-
-a@
-[source]
-----
-context property::buffer::context_bound::get_context() const
-----
-   a@ Returns the [code]#context# which was specified when
-      constructing this SYCL [code]#context_bound# property.
-
-|====
-
+'''
 
 
 [[sec:buf-sync-rules]]

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5379,11 +5379,11 @@ propList)`.
 .[apititle]#Construct from iterators#
 [source,role=synopsis,id=api:buffer-ctor-iterator]
 ----
-template <class InputIterator>                                               (1)
+template <typename InputIterator>                                      (1)
 buffer(InputIterator first, InputIterator last, AllocatorT allocator,
        const property_list& propList = {});
 
-template <class InputIterator>                                               (2)
+template <typename InputIterator>                                      (2)
 buffer(InputIterator first, InputIterator last,
        const property_list& propList = {});
 ----

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5251,15 +5251,6 @@ lifetime.
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
 
-The host address is [code]#const T#, so the host accesses can be read-only.
-However, the [code]#typename T# is not const so the device accesses can be both
-read and write accesses.
-Since, the [code]#hostData# is const, this buffer is only initialized with this
-memory and there is no write back after its destruction, unless the
-[code]#buffer# has another valid non-null final data address specified via the
-member function [code]#set_final_data()# after construction of the
-[code]#buffer#.
-
 The range of the constructed SYCL [code]#buffer# is specified by the
 [code]#bufferRange# parameter provided.
 
@@ -5268,6 +5259,10 @@ via an instance of [code]#property_list#.
 
 _Effects (4):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
 propList)`.
+
+_Remarks:_ When [code]#hostData# is a pointer to a const-qualified type, the
+buffer will not write back to any host memory unless requested via the member
+function [code]#set_final_data()#.
 
 '''
 
@@ -5298,10 +5293,6 @@ elements starting at [code]#std::data(container)# and containing
 The buffer is initialized with the contents of [code]#container#, and the buffer
 assumes exclusive access to [code]#container# for the duration of its lifetime.
 
-Data is written back to [code]#container# before the completion of
-[code]#buffer# destruction if the return type of [code]#std::data(container)# is
-not [code]#const#.
-
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
 
@@ -5309,6 +5300,10 @@ Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
 _Effects (2):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
+
+_Remarks:_ Data is written back to [code]#container# before the completion of
+[code]#buffer# destruction if the return type of [code]#std::data(container)# is
+not [code]#const#.
 
 '''
 
@@ -5402,6 +5397,9 @@ via an instance of [code]#property_list#.
 
 _Effects (2):_ Equivalent to `buffer(first, last, AllocatorT{}, propList)`.
 
+_Remarks:_ The buffer will not write back to any host memory unless requested
+via the member function [code]#set_final_data()#.
+
 '''
 
 .[apititle]#Construct sub-buffer#
@@ -5453,8 +5451,7 @@ buffer [code]#b# size [code]#bufferRange# in that dimension.
 ----
 range<Dimensions> get_range() const;
 ----
-_Returns:_ A range object representing the size of the buffer in terms of number
-of elements in each dimension as passed to the constructor.
+_Returns:_ A [code]#range# representing the number of elements in the buffer.
 
 '''
 
@@ -5473,9 +5470,8 @@ Equal to [code]#size()*sizeof(T)#.
 ----
 size_t size() const noexcept;
 ----
-mode and target in the command group buffer.
-The value of target can be [code]#target::device#,
-[code]#target::constant_buffer# or [code]#target::host_task#.
+_Returns:_ The total number of elements in the buffer.
+Equal to [code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
 
 '''
 
@@ -5527,31 +5523,22 @@ template <typename... Ts> auto get_access(Ts...);                              (
 
 template <typename... Ts> auto get_host_access(Ts...);                         (4)
 ----
+_Constraints (1-2):_ Available only when [code]#Targ# is [code]#target::device#,
+[code]#target::constant_buffer# or [code]#target::host_task#.
+
 _Returns (1):_ A valid [code]#accessor# to the buffer with the specified access
 mode and target in the command group buffer.
-The value of target can be [code]#target::device#,
-[code]#target::constant_buffer# or [code]#target::host_task#.
 
 _Returns (2):_ A valid [code]#accessor# to the buffer with the specified access
 mode and target in the command group buffer.
 The accessor is a <<ranged-accessor>>, where the range starts at the given
 offset from the beginning of the buffer.
-The value of target can be [code]#target::device#,
-[code]#target::constant_buffer# or [code]#target::host_task#.
 
 _Returns (3):_ A valid [code]#accessor# as if constructed via passing the buffer
 and all provided arguments to the [code]#accessor# constructor.
 
-Possible implementation:
-
-[code]#+return accessor{*this, args...};+#
-
 _Returns (4):_ A valid [code]#host_accessor# as if constructed via passing the
 buffer and all provided arguments to the [code]#host_accessor# constructor.
-
-Possible implementation:
-
-[code]#+return host_accessor{*this, args...};+#
 
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
 the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
@@ -5579,7 +5566,6 @@ _Returns (2):_ A valid host [code]#accessor# to the buffer with the specified
 access mode and target.
 The accessor is a <<ranged-accessor>>, where the range starts at the given
 offset from the beginning of the buffer.
-The value of target can only be [code]#target::host_buffer#.
 
 _Throws (2):_ An [code]#exception# with the [code]#errc::invalid# error code if
 the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of the
@@ -5650,7 +5636,7 @@ buffer<ReinterpretT, ReinterpretDim,
            ReinterpretT>>
 reinterpret() const;
 ----
-_Preconditions (2):_ Available when [code]#(ReinterpretDim == 1)# or when
+_Constraints (2):_ Available when [code]#(ReinterpretDim == 1)# or when
 [code]#\((ReinterpretDim == Dimensions) && (sizeof(ReinterpretT) ==
 sizeof(T)))#.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5679,9 +5679,9 @@ _Effects (1):_ Constructs an [code]#use_host_ptr# property object.
 ----
 namespace sycl::property::buffer {
 class use_mutex {
-  use_mutex(std::mutex& mutexRef);  (1)
+  use_mutex(std::mutex& mutexRef);
 
-  std::mutex* get_mutex_ptr() const; (2)
+  std::mutex* get_mutex_ptr() const;
 };
 } // namespace sycl::property::buffer
 ----
@@ -5695,10 +5695,26 @@ unlocked otherwise. The contents of [code]#hostData# are guaranteed to reflect
 the contents of the buffer when the [code]#std::mutex# is unlocked by the
 runtime.
 
-_Effects (1):_ Constructs a SYCL [code]#use_mutex# property instance with a
+'''
+
+.[apidef]#property::buffer::use_mutex constructor#
+[source,role=synopsis,id=api:property-buffer-use-mutex-ctor]
+----
+use_mutex(std::mutex& mutexRef);
+----
+
+_Effects:_ Constructs a SYCL [code]#use_mutex# property instance with a
 reference to [code]#mutexRef# parameter provided.
 
-_Returns (2):_ The [code]#std::mutex# which was specified when constructing this
+'''
+
+.[apidef]#property::buffer::use_mutex::get_mutex_ptr#
+[source,role=synopsis,id=api:property-buffer-use-mutex-get-mutex-ptr]
+----
+std::mutex* get_mutex_ptr() const;
+----
+
+_Returns:_ The [code]#std::mutex# which was specified when constructing this
 SYCL [code]#use_mutex# property.
 
 '''
@@ -5720,11 +5736,27 @@ The [code]#context_bound# property adds the requirement that the SYCL
 [code]#buffer# can only be associated with a single SYCL [code]#context# that is
 provided to the property.
 
-_Effects (1):_ Constructs a SYCL [code]#context_bound# property instance with a
+'''
+
+.[apidef]#property::buffer::context_bound constructor#
+[source,role=synopsis,id=api:property-buffer-context-bound-ctor]
+----
+context_bound(context boundContext);
+----
+
+_Effects:_ Constructs a SYCL [code]#context_bound# property instance with a
 copy of a SYCL [code]#context#.
 
-_Returns (2):_ The [code]#context# which was specified when constructing this
-SYCL [code]#context_bound# property.
+'''
+
+.[apidef]#property::buffer::context_bound::get_context#
+[source,role=synopsis,id=api:property-buffer-context-bound-get-context]
+----
+context get_context() const;
+----
+
+_Returns:_ The [code]#context# which was specified when constructing this SYCL
+[code]#context_bound# property.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5524,8 +5524,9 @@ template <typename... Ts> auto get_access(Ts...);                              (
 
 template <typename... Ts> auto get_host_access(Ts...);                         (4)
 ----
-_Constraints (1)-(2):_ Available only when [code]#Targ# is [code]#target::device#,
-[code]#target::constant_buffer# or [code]#target::host_task#.
+_Constraints (1)-(2):_ Available only when [code]#Targ# is
+[code]#target::device#, [code]#target::constant_buffer# or
+[code]#target::host_task#.
 
 _Returns (1):_ A valid [code]#accessor# to the buffer with the specified access
 mode and target in the command group buffer.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5192,15 +5192,13 @@ See <<sec:buffer-properties>> for the buffer properties that are defined by the
 .[apititle]#Construct with uninitialized memory#
 [source,role=synopsis,id=api:buffer-ctor-uninit]
 ----
-buffer(const range<Dimensions>& bufferRange,                        (1)
+buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,  (1)
        const property_list& propList = {});
 
-buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,  (2)
+buffer(const range<Dimensions>& bufferRange,                        (2)
        const property_list& propList = {});
 ----
-_Effects (1):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
-
-_Effects (2):_ Construct a SYCL [code]#buffer# instance with uninitialized
+_Effects (1):_ Construct a SYCL [code]#buffer# instance with uninitialized
 memory.
 The constructed SYCL [code]#buffer# will use the [code]#allocator# parameter
 provided when allocating memory on the host.
@@ -5212,27 +5210,26 @@ function [code]#set_final_data()#.
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
+_Effects (2):_ Equivalent to `buffer(bufferRange, AllocatorT{}, propList)`.
+
 '''
 
 .[apititle]#Construct with host memory#
 [source,role=synopsis,id=api:buffer-ctor-host-mem]
 ----
-buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
-       const property_list& propList = {});
-
 buffer(T* hostData, const range<Dimensions>& bufferRange,          (2)
        AllocatorT allocator, const property_list& propList = {});
 
-buffer(const T* hostData, const range<Dimensions>& bufferRange,    (3)
+buffer(T* hostData, const range<Dimensions>& bufferRange,          (1)
        const property_list& propList = {});
 
-buffer(const T* hostData, const range<Dimensions>& bufferRange,    (4)
+buffer(const T* hostData, const range<Dimensions>& bufferRange,    (3)
        AllocatorT allocator, const property_list& propList = {});
-----
-_Effects (1):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
-propList)`.
 
-_Effects (2):_ Construct a SYCL [code]#buffer# instance with the
+buffer(const T* hostData, const range<Dimensions>& bufferRange,    (4)
+       const property_list& propList = {});
+----
+_Effects (1):_ Construct a SYCL [code]#buffer# instance with the
 [code]#hostData# parameter provided.
 The buffer is initialized with the memory specified by [code]#hostData#, and the
 buffer assumes exclusive access to this memory for the duration of its lifetime.
@@ -5243,10 +5240,10 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
-_Effects (3):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+_Effects (2):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
 propList)`.
 
-_Effects (4):_ Construct a SYCL [code]#buffer# instance with the
+_Effects (3):_ Construct a SYCL [code]#buffer# instance with the
 [code]#hostData# parameter provided.
 The buffer assumes exclusive access to this memory for the duration of its
 lifetime.
@@ -5269,17 +5266,20 @@ The range of the constructed SYCL [code]#buffer# is specified by the
 Zero or more properties can be provided to the constructed SYCL [code]#buffer#
 via an instance of [code]#property_list#.
 
+_Effects (4):_ Equivalent to `buffer(hostData, bufferRange, AllocatorT{},
+propList)`.
+
 '''
 
 .[apititle]#Construct from a container#
 [source,role=synopsis,id=api:buffer-ctor-container]
 ----
 template <typename Container>                                      (1)
-buffer(Container& container, const property_list& propList = {});
-
-template <typename Container>                                      (2)
 buffer(Container& container, AllocatorT allocator,
        const property_list& propList = {});
+
+template <typename Container>                                      (2)
+buffer(Container& container, const property_list& propList = {});
 ----
 _Constraints:_ Available only if [code]#Container# is a contiguous container,
 that is the following requirements must be met:
@@ -5315,19 +5315,19 @@ _Effects (2):_ Equivalent to `buffer(container, AllocatorT{}, propList)`.
 [source,role=synopsis,id=api:buffer-ctor-shared-ptr]
 ----
   buffer(const std::shared_ptr<T>& hostData,                          (1)
-         const range<Dimensions>& bufferRange,
+         const range<Dimensions>& bufferRange, AllocatorT allocator,
          const property_list& propList = {});
 
   buffer(const std::shared_ptr<T>& hostData,                          (2)
-         const range<Dimensions>& bufferRange, AllocatorT allocator,
-         const property_list& propList = {});
-
-  buffer(const std::shared_ptr<T[]>& hostData,                        (3)
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
-  buffer(const std::shared_ptr<T[]>& hostData,                        (4)
+  buffer(const std::shared_ptr<T[]>& hostData,                        (3)
          const range<Dimensions>& bufferRange, AllocatorT allocator,
+         const property_list& propList = {});
+
+  buffer(const std::shared_ptr<T[]>& hostData,                        (4)
+         const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 ----
 _Effects (1):_ When [code]#hostData# is not empty, construct a SYCL buffer with

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5279,8 +5279,8 @@ buffer(Container& container, AllocatorT allocator,
 template <typename Container>
 buffer(Container& container, const property_list& propList = {}); (2)
 ----
-Constraints:_ Available only if [code]#Container# must be a contiguous
-container, that is the following requirements must be met:
+Constraints:_ Available only if [code]#Container# is a contiguous container,
+that is the following requirements must be met:
 
 * [code]#std::data(container)# and [code]#std::size(container)# are well formed;
 
@@ -5397,16 +5397,6 @@ _Effects (2):_ Equivalent to `buffer(first, last, AllocatorT{}, propList)`.
 buffer(buffer& b, const id<Dimensions>& baseIndex,
        const range<Dimensions>& subRange);
 ----
-_Preconditions_:
-
-* The offset and range specified by [code]#baseIndex# and [code]#subRange#
-together must represent a contiguous region of the original SYCL [code]#buffer#.
-
-* The sum of [code]#baseIndex# and [code]#subRange# in any dimension must not
-exceed the parent buffer [code]#b# size [code]#bufferRange# in that dimension.
-
-* The parent buffer [code]#b# must not be a sub-buffer.
-
 _Effects:_ Create a new sub-buffer without allocation to have separate accessors
 later. [code]#b# is the buffer with the real data. [code]#baseIndex# specifies
 the origin of the sub-buffer inside the buffer [code]#b#. [code]#subRange#
@@ -5476,7 +5466,7 @@ size_t get_count() const;
 ----
 Deprecated by SYCL 2020.
 
-_Returns:_ The same value as [code]#size()#.
+_Effects:_ Equivalent to [code]#return size()#.
 '''
 
 .[apititle]#buffer::get_size#
@@ -5486,7 +5476,7 @@ size_t get_size() const;
 ----
 Deprecated by SYCL 2020.
 
-_Returns:_ The same value as [code]#byte_size()#.
+_Effects:_ Equivalent to [code]#return byte_size()#.
 '''
 
 .[apititle]#buffer::get_allocator#

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -588,7 +588,7 @@ A property may be applicable to more than one class, however some properties may
 not be compatible with each other.
 See the requirements for the properties of the SYCL [code]#buffer# class, SYCL
 [code]#unsampled_image# class and SYCL [code]#sampled_image# class in
-<<table.properties.buffer>> and <<table.properties.image>> respectively.
+<<sec:buffer-properties>> and <<table.properties.image>> respectively.
 
 Properties can be passed to a <<sycl-runtime>> class via an instance of
 [code]#property_list#.

--- a/adoc/headers/buffer.h
+++ b/adoc/headers/buffer.h
@@ -11,23 +11,23 @@ class buffer {
   using const_reference = const value_type&;
   using allocator_type = AllocatorT;
 
-  buffer(const range<Dimensions>& bufferRange,
-         const property_list& propList = {});
-
   buffer(const range<Dimensions>& bufferRange, AllocatorT allocator,
          const property_list& propList = {});
 
-  buffer(T* hostData, const range<Dimensions>& bufferRange,
+  buffer(const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
   buffer(T* hostData, const range<Dimensions>& bufferRange,
          AllocatorT allocator, const property_list& propList = {});
 
-  buffer(const T* hostData, const range<Dimensions>& bufferRange,
+  buffer(T* hostData, const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
   buffer(const T* hostData, const range<Dimensions>& bufferRange,
          AllocatorT allocator, const property_list& propList = {});
+
+  buffer(const T* hostData, const range<Dimensions>& bufferRange,
+         const property_list& propList = {});
 
   /* Available only if Container is a contiguous container:
        - std::data(container) and std::size(container) are well formed
@@ -60,13 +60,13 @@ class buffer {
          const range<Dimensions>& bufferRange,
          const property_list& propList = {});
 
-  template <class InputIterator>
-  buffer<T, 1>(InputIterator first, InputIterator last, AllocatorT allocator,
-               const property_list& propList = {});
+  template <typename InputIterator>
+  buffer(InputIterator first, InputIterator last, AllocatorT allocator,
+         const property_list& propList = {});
 
-  template <class InputIterator>
-  buffer<T, 1>(InputIterator first, InputIterator last,
-               const property_list& propList = {});
+  template <typename InputIterator>
+  buffer(InputIterator first, InputIterator last,
+         const property_list& propList = {});
 
   buffer(buffer& b, const id<Dimensions>& baseIndex,
          const range<Dimensions>& subRange);

--- a/adoc/headers/buffer.h
+++ b/adoc/headers/buffer.h
@@ -136,28 +136,28 @@ class buffer {
 };
 
 // Deduction guides
-template <class InputIterator, class AllocatorT>
+template <typename InputIterator, typename AllocatorT>
 buffer(InputIterator, InputIterator, AllocatorT, const property_list& = {})
     -> buffer<typename std::iterator_traits<InputIterator>::value_type, 1,
               AllocatorT>;
 
-template <class InputIterator>
+template <typename InputIterator>
 buffer(InputIterator, InputIterator, const property_list& = {})
     -> buffer<typename std::iterator_traits<InputIterator>::value_type, 1>;
 
-template <class T, int Dimensions, class AllocatorT>
+template <typename T, int Dimensions, typename AllocatorT>
 buffer(const T*, const range<Dimensions>&, AllocatorT,
        const property_list& = {}) -> buffer<T, Dimensions, AllocatorT>;
 
-template <class T, int Dimensions>
+template <typename T, int Dimensions>
 buffer(const T*, const range<Dimensions>&, const property_list& = {})
     -> buffer<T, Dimensions>;
 
-template <class Container, class AllocatorT>
+template <typename Container, typename AllocatorT>
 buffer(Container&, AllocatorT, const property_list& = {})
     -> buffer<typename Container::value_type, 1, AllocatorT>;
 
-template <class Container>
+template <typename Container>
 buffer(Container&, const property_list& = {})
     -> buffer<typename Container::value_type, 1>;
 

--- a/adoc/headers/buffer.h
+++ b/adoc/headers/buffer.h
@@ -2,29 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace sycl {
-namespace property {
-namespace buffer {
-class use_host_ptr {
- public:
-  use_host_ptr() = default;
-};
-
-class use_mutex {
- public:
-  use_mutex(std::mutex& mutexRef);
-
-  std::mutex* get_mutex_ptr() const;
-};
-
-class context_bound {
- public:
-  context_bound(context boundContext);
-
-  context get_context() const;
-};
-} // namespace buffer
-} // namespace property
-
 template <typename T, int Dimensions = 1,
           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 class buffer {


### PR DESCRIPTION
This commit changes the buffer API descriptions to use the new style of API documentation. This should break up some of the larger tables in the specification.