### PR TITLE
[KHR] Adding command graph extension

### DIFF
--- a/adoc/extensions/index.adoc
+++ b/adoc/extensions/index.adoc
@@ -11,4 +11,5 @@ specification, but their design is subject to change.
 // include::sycl_khr_extension_name.adoc[leveloffset=2]
 
 include::sycl_khr_default_context.adoc[leveloffset=2]
+
 include::sycl_khr_command_graph.adoc[leveloffset=2]

--- a/adoc/extensions/index.adoc
+++ b/adoc/extensions/index.adoc
@@ -11,3 +11,4 @@ specification, but their design is subject to change.
 // include::sycl_khr_extension_name.adoc[leveloffset=2]
 
 include::sycl_khr_default_context.adoc[leveloffset=2]
+include::sycl_khr_command_graph.adoc[leveloffset=2]

--- a/adoc/extensions/sycl_khr_command_graph.adoc
+++ b/adoc/extensions/sycl_khr_command_graph.adoc
@@ -1,0 +1,41 @@
+= sycl_khr_command_graph
+
+== Dependencies
+
+This extension has no dependencies on other extensions.
+
+== Feature test macro
+
+An implementation supporting this extension must predefine the macro
+[code]#SYCL_KHR_COMMAND_GRAPH# to one of the values defined in the
+table below.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial version of this extension.
+|===
+
+== Usage example
+
+[source,role=synopsis]
+----
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+int main() {
+  // Create a queue to work on.
+  queue myQueue;
+  
+  khr::command_graph myGraph{myQueue};
+
+  // ...
+
+  std::cout << "Good computation!" << std::endl;
+  return 0;
+}
+
+----

--- a/adoc/extensions/sycl_khr_command_graph.adoc
+++ b/adoc/extensions/sycl_khr_command_graph.adoc
@@ -1,5 +1,16 @@
 = sycl_khr_command_graph
 
+The graph abstraction defines an explicitly lazy execution model by decoupling
+command creation from submission. These concepts are potentially tied together
+in SYCL implementations that eagerly submit work to a device when a
+command-group is submitted to a queue. By providing a prior construction stage
+before a workload of commands begins execution on the device, submission of
+multiple commands can happen in a single submission call instead of many,
+reducing the overhead of multiple independent command submissions. Deferral of
+command submission can also allow for the SYCL implementation to optimize
+dependencies within the user defined graph, which may improve concurrency
+and other performance metrics.
+
 == Dependencies
 
 This extension has no dependencies on other extensions.
@@ -35,11 +46,14 @@ int main() {
   queue myQueue;
   
   khr::command_graph myGraph{myQueue};
-  
+
   // Create some 2D buffers of float for our matrices
-  buffer<float, 2> a{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
-  buffer<float, 2> b{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
-  buffer<float, 2> c{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
+  buffer<float, 2> a{range<2>{N, M},
+                     khr::property::graph::assume_buffer_outlives_graph{}};
+  buffer<float, 2> b{range<2>{N, M},
+                     khr::property::graph::assume_buffer_outlives_graph{}};
+  buffer<float, 2> c{range<2>{N, M},
+                     khr::property::graph::assume_buffer_outlives_graph{}};
 
   myGraph.begin_recording(myQueue);
 

--- a/adoc/extensions/sycl_khr_command_graph.adoc
+++ b/adoc/extensions/sycl_khr_command_graph.adoc
@@ -21,21 +21,1167 @@ table below.
 
 == Usage example
 
+The example below rewrites the application from
+<<subsec:example.sycl.application>> to demonstrate the usage of this extension.
+
 [source,role=synopsis]
 ----
 #include <iostream>
 #include <sycl/sycl.hpp>
+using namespace sycl;  // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
   // Create a queue to work on.
   queue myQueue;
   
   khr::command_graph myGraph{myQueue};
+  
+  // Create some 2D buffers of float for our matrices
+  buffer<float, 2> a{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
+  buffer<float, 2> b{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
+  buffer<float, 2> c{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
 
-  // ...
+  myGraph.begin_recording(myQueue);
+
+  // Launch an asynchronous kernel to initialize a
+  myQueue.submit([&](handler& cgh) {
+    // The kernel writes a, so get a write accessor on it
+    accessor A{a, cgh, write_only};
+
+    // Enqueue a parallel kernel iterating on a N*M 2D iteration space
+    cgh.parallel_for(range<2>{N, M},
+                     [=](id<2> index) { A[index] = index[0] * 2 + index[1]; });
+  });
+
+  // Launch an asynchronous kernel to initialize b
+  myQueue.submit([&](handler& cgh) {
+    // The kernel writes b, so get a write accessor on it
+    accessor B{b, cgh, write_only};
+
+    // From the access pattern above, the SYCL runtime detects that this
+    // command_group is independent from the first one and can be
+    // scheduled independently
+
+    // Enqueue a parallel kernel iterating on a N*M 2D iteration space
+    cgh.parallel_for(range<2>{N, M}, [=](id<2> index) {
+      B[index] = index[0] * 2014 + index[1] * 42;
+    });
+  });
+
+  // Launch an asynchronous kernel to compute matrix addition c = a + b
+  myQueue.submit([&](handler& cgh) {
+    // In the kernel a and b are read, but c is written
+    accessor A{a, cgh, read_only};
+    accessor B{b, cgh, read_only};
+    accessor C{c, cgh, write_only};
+
+    // From these accessors, the SYCL runtime will ensure that when
+    // this kernel is run, the kernels computing a and b have completed
+
+    // Enqueue a parallel kernel iterating on a N*M 2D iteration space
+    cgh.parallel_for(range<2>{N, M},
+                     [=](id<2> index) { C[index] = A[index] + B[index]; });
+  });
+  
+  myGraph.end_recording();
+  
+  auto myExecGraph = myGraph.finalize();
+
+  myQueue.khr_graph(myExecGraph);
+  
+  // Ask for an accessor to read c from application scope.  The SYCL runtime
+  // waits for c to be ready before returning from the constructor
+  host_accessor C{c, read_only};
+  std::cout << std::endl << "Result:" << std::endl;
+  for (size_t i = 0; i < N; i++) {
+    for (size_t j = 0; j < M; j++) {
+      // Compare the result to the analytic value
+      if (C[i][j] != i * (2 + 2014) + j * (1 + 42)) {
+        std::cout << "Wrong value " << C[i][j] << " on element " << i << " "
+                  << j << std::endl;
+        exit(-1);
+      }
+    }
+  }
 
   std::cout << "Good computation!" << std::endl;
   return 0;
 }
 
 ----
+
+This extension adds new classes `command_graph` and `node` which follows the
+{crs}[common reference semantics] of other SYCL runtime classes.
+
+=== SYCL Graph Terminology [[terminology]]
+
+Table {counter: tableNumber}. Terminology.
+[%header,cols="1,3"]
+|===
+| Concept | Description
+
+| Graph
+| A directed and acyclic graph (DAG) of commands (nodes) and their dependencies
+(edges), represented by the `command_graph` class.
+
+| Node
+| A command, which can have different attributes, targeting a specific device.
+
+| Edge
+| Dependency between commands as a happens-before relationship.
+
+|===
+
+==== Explicit Graph Building API
+
+When using the explicit graph building API to construct a graph, nodes and
+edges are captured as follows.
+
+Table {counter: tableNumber}. Explicit Graph Definition.
+[%header,cols="1,3"]
+|===
+| Concept | Description
+
+| Node
+| In the explicit graph building API nodes are created by the user invoking
+methods on a modifiable graph passing a command-group function (CGF). Each node
+represents either a command-group or an empty operation.
+
+| Edge
+| In the explicit graph building API edges are primarily defined by the user
+through newly added interfaces. This is either using the `make_edge()` function
+to define an edge between existing nodes, or using a
+`property::node::depends_on` property list when adding a new node to the graph.
+
+Edges can also be created when explicitly adding nodes to the graph through
+existing SYCL mechanisms for expressing dependencies. Data dependencies from
+accessors to existing nodes in the graph are captured as an edge. Using
+`handler::depends_on()` will also create a graph edge when passed an event
+returned from a queue submission captured by a queue recording to the same
+graph.
+|===
+
+==== Queue Recording API
+
+When using the record & replay API to construct a graph by recording a queue,
+nodes and edges are captured as follows.
+
+Table {counter: tableNumber}. Recorded Graph Definition.
+[%header,cols="1,3"]
+|===
+| Concept | Description
+
+| Node
+| A node in a queue recorded graph represents a command-group submission to the
+device associated with the queue being recorded. Nodes are constructed from
+the command-group functions (CGF) passed to `queue::submit()`, or from the queue
+shortcut equivalents for the defined handler command types. Each submission
+encompasses either one or both of a.) some data movement, b.) a single
+asynchronous command launch. Nodes cannot define forward edges, only backwards.
+That is, nodes can only create dependencies on command-groups that have already
+been submitted.
+
+| Edge
+| An edge in a queue recorded graph is expressed through command group
+dependencies in one of three ways. Firstly, through buffer accessors that
+represent data dependencies between two command groups captured as nodes.
+Secondly, by using the `handler::depends_on()` mechanism inside a command group
+captured as a node. However, for an event passed to `handler::depends_on()` to
+create an edge, it must be an event returned from a queue
+submission captured by the same graph. Otherwise, a synchronous error will be
+thrown with error code `invalid`. `handler::depends_on()` can be
+used to express edges when a user is working with USM memory rather than SYCL
+buffers. Thirdly, for a graph recorded with an in-order queue, an edge is added
+automatically between two sequential command groups submitted to the in-order queue.
+|===
+
+==== Sub-Graph
+
+A node in a graph can take the form of a nested sub-graph. This occurs when
+a command-group submission that invokes `handler::khr_graph()` with an
+executable graph object is added to the graph as a node. The child graph node is
+scheduled in the parent graph as-if edges are created to connect the root nodes
+of the child graph with the dependent nodes of the parent graph.
+
+Adding an executable graph as a sub-graph does not affect its existing node
+dependencies, such that it could be submitted in future without any side
+effects of prior uses as a sub-graph.
+
+=== Node
+
+[source, c++]
+----
+namespace sycl::khr {
+enum class node_type {
+  empty,
+  subgraph,
+  kernel,
+  memcpy,
+  memset,
+  memfill,
+  prefetch,
+  memadvise,
+  host_task,
+};
+
+class node {
+public:
+  node() = delete;
+
+  node_type get_type() const;
+
+  std::vector<node> get_predecessors() const;
+
+  std::vector<node> get_successors() const;
+
+  static node get_node_from_event(event nodeEvent);
+};
+
+}  // sycl::khr
+----
+
+:crs: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:reference-semantics
+
+Node is a class that encapsulates tasks like SYCL kernel functions, or memory
+operations for deferred execution. A graph must
+be created first, the structure of a graph is defined second by adding nodes and
+edges.
+
+The `node` class provides the {crs}[common reference semantics].
+
+==== Node Member Functions
+
+[source, c++]
+----
+node_type get_type() const;
+----
+
+_Returns:_ A value representing the type of command this node represents.
+
+[source, c++]
+----
+std::vector<node> get_predecessors() const;
+----
+
+_Returns:_ A list of the predecessor nodes which this node directly depends on.
+
+[source, c++]
+----
+std::vector<node> get_successors() const;
+----
+
+_Returns:_ A list of the successor nodes which directly depend on this node.
+
+[source, c++]
+----
+static node get_node_from_event(event nodeEvent);
+----
+
+_Effects:_ Finds the node associated with an event `nodeEvent` created from
+a submission to a queue in the recording state.
+
+_Returns:_ Graph node that was created when the command that returned
+`nodeEvent` was submitted.
+
+_Throws:_ An `exception` with error code `invalid` if `nodeEvent` is not
+associated with a graph node.
+
+==== Depends-On Property
+
+[source,c++]
+----
+namespace sycl::khr::property::node {
+class depends_on {
+  public:
+    template<typename... NodeTN>
+    depends_on(NodeTN... nodes);
+};
+}
+----
+
+The API for explicitly adding nodes to a `command_graph` includes a
+`property_list` parameter. This extension defines the `depends_on` property to
+be passed here. `depends_on` defines any `node` objects for the created node to
+be dependent on, and therefore form an edge with. These nodes are in addition to
+the dependent nodes identified from the command-group requisites of the created
+node.
+
+==== Depends-On-All-Leaves Property
+[source,c++]
+----
+namespace sycl::khr::property::node {
+class depends_on_all_leaves {
+  public:
+    depends_on_all_leaves() = default;
+};
+}
+----
+
+The API for explicitly adding nodes to a `command_graph` includes a
+`property_list` parameter. This extension defines the `depends_on_all_leaves`
+property to be passed here. `depends_on_all_leaves` provides a shortcut for
+adding all the current leaves of a graph as dependencies.
+
+=== Graph
+
+[source, c++]
+----
+namespace sycl::khr {
+// State of a graph
+enum class graph_state {
+  modifiable,
+  executable
+};
+
+// New object representing graph
+template<graph_state State = graph_state::modifiable>
+class command_graph {};
+
+template<>
+class command_graph<graph_state::modifiable> {
+public:
+  command_graph(const context& syclContext, const device& syclDevice,
+                const property_list& propList = {});
+
+  command_graph(const queue& syclQueue,
+                const property_list& propList = {});
+
+  command_graph<graph_state::executable>
+  finalize(const property_list& propList = {}) const;
+
+  void begin_recording(queue& recordingQueue, const property_list& propList = {});
+  void begin_recording(const std::vector<queue>& recordingQueues, const property_list& propList = {});
+
+  void end_recording();
+  void end_recording(queue& recordingQueue);
+  void end_recording(const std::vector<queue>& recordingQueues);
+
+  node add(const property_list& propList = {});
+
+  template<typename T>
+  node add(T cgf, const property_list& propList = {});
+
+  node add(dynamic_command_group& dynamicCG, const property_list& propList = {});
+
+  void make_edge(node& src, node& dest);
+
+  void print_graph(std::string path, bool verbose = false) const;
+
+  std::vector<node> get_nodes() const;
+  std::vector<node> get_root_nodes() const;
+};
+
+template<>
+class command_graph<graph_state::executable> {
+public:
+    command_graph() = delete;
+};
+
+}  // namespace sycl::khr
+----
+
+This extension adds a new `command_graph` object which follows the
+{crs}[common reference semantics] of other SYCL runtime objects.
+
+A `command_graph` represents a directed acyclic graph of nodes, where each node
+represents a single command for a specific device or a sub-graph. The execution
+of a graph completes when all its nodes have completed.
+
+A `command_graph` is built up by either recording queue submissions or
+explicitly adding nodes, then once the user is happy that the graph is complete,
+the graph instance is finalized into an executable variant which can have no
+more nodes added to it. Finalization may be a computationally expensive
+operation as the runtime can perform optimizations based on the graph
+structure. After finalization the graph can be submitted for execution on a
+queue one or more times with reduced overhead.
+
+A `command_graph` can be submitted to both in-order and out-of-order queues. Any
+dependencies between the graph and other command-groups submitted to the same
+queue will be respected. However, the in-order and out-of-order properties of the
+queue have no effect on how the nodes within the graph are executed (e.g. the graph
+nodes without dependency edges may execute out-of-order even when using an in-order
+queue). For further information about how the properties of a queue affect graphs
+<<Queue Properties, see the section on Queue Properties>>
+
+==== Graph State
+
+An instance of a `command_graph` object can be in one of two states:
+
+* **Modifiable** - Graph is under construction and new nodes may be added to it.
+* **Executable** - Graph topology is fixed after finalization and graph is ready to
+  be submitted for execution.
+
+A `command_graph` object is constructed in the _modifiable_ state and is made
+_executable_ by the user invoking `command_graph::finalize()` to create a
+new executable instance of the graph. An executable graph cannot be converted
+to a modifiable graph. After finalizing a graph in the modifiable state, it is
+valid for a user to add additional nodes and finalize again to create subsequent
+executable graphs. The state of a `command_graph` object is made explicit by
+templating on state to make the class strongly typed, with the default template
+argument being `graph_state::modifiable` to reduce code verbosity on
+construction.
+
+.Graph State Diagram
+[source, mermaid]
+....
+graph LR
+    Modifiable -->|Finalize| Executable
+....
+
+==== Graph Properties [[graph-properties]]
+
+===== No-Cycle-Check Property
+
+[source,c++]
+----
+namespace sycl::khr::property::graph {
+class no_cycle_check {
+  public:
+    no_cycle_check() = default;
+};
+}
+----
+
+The `property::graph::no_cycle_check` property disables any checks if a newly
+added dependency will lead to a cycle in a specific `command_graph` and can be
+passed to a `command_graph` on construction via the property list parameter.
+As a result, no errors are reported when a function tries to create a cyclic
+dependency. Thus, it's the user's responsibility to create an acyclic graph
+for execution when this property is set. Creating a cycle in a `command_graph`
+puts that `command_graph` into an undefined state. Any further operations
+performed on a `command_graph` in this state will result in undefined
+behavior.
+
+===== Assume-Buffer-Outlives-Graph Property [[assume-buffer-outlives-graph-property]]
+
+[source,c++]
+----
+namespace sycl::khr::property::graph {
+class assume_buffer_outlives_graph {
+  public:
+    assume_buffer_outlives_graph() = default;
+};
+}
+----
+
+The `property::graph::assume_buffer_outlives_graph` property disables
+<<buffer-limitations, restrictions on using buffers>> in a `command_graph` and
+can be passed to a `command_graph` on construction via the property list
+parameter. This property represents a promise from the user that any buffer
+which is used in a graph will be kept alive on the host for the lifetime of the
+graph. Destroying that buffer during the lifetime of a `command_graph`
+constructed with this property results in undefined behavior.
+
+==== Enable-Profiling Property [[enable-profiling]]
+
+[source,c++]
+----
+namespace sycl::khr::graph {
+class enable_profiling {
+  public:
+    enable_profiling() = default;
+};
+}
+----
+
+The `property::graph::enable_profiling` property enables profiling events
+returned from submissions of the executable graph. Passing this property
+implies disabling certain optimizations. As a result, the execution time of a
+graph finalized with profiling enabled is longer than that of a graph without
+profiling capability. An error will be thrown when attempting to profile an
+event from a graph submission that was created without this property.
+
+==== Graph Member Functions
+
+===== Constructor of the `command_graph` class
+
+[source,c++]
+----
+command_graph(const context& syclContext,
+              const device& syclDevice,
+              const property_list& propList = {});
+----
+
+_Effects:_ Creates a SYCL `command_graph` object in the modifiable state for context
+`syclContext` and device `syclDevice`. Zero or more properties can be provided
+to the constructed SYCL `command_graph` via an instance of `property_list`.
+`syclContext` is an immutable characteristic of the graph.
+
+_Constraints:_ This constructor is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Preconditions:_ Valid `command_graph` constructor properties are listed in
+Section <<graph-properties, Graph Properties>>.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if `syclDevice` is not
+associated with `syclContext`.
+
+* Synchronously `exception` with error code `invalid` if `syclDevice`
+  <<device-info-query, reports this extension as unsupported>>.
+
+[source,c++]
+----
+command_graph(const queue& syclQueue,
+              const property_list& propList = {});
+----
+
+_Effects:_ Simplified constructor form where `syclQueue` provides only
+the device and context which become immutable characteristics of the graph.
+Zero or more properties can be provided to the constructed SYCL `command_graph`
+via an instance of `property_list`. All other properties of the queue are
+ignored for the purposes of graph creation. See the
+<<Queue Properties, Queue Properties>> section for more general information
+about how queue properties interact with command_graph objects.
+
+_Constraints:_ This constructor is only available when the `command_graph` state is
+`graph_state::modifiable`.
+
+_Preconditions:_ Valid `command_graph` constructor properties are listed in
+Section <<graph-properties, Graph Properties>>.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if the device
+associated with
+`syclQueue` <<device-info-query, reports this extension as unsupported>>.
+
+===== Member functions of the `command_graph` class
+
+[source,c++]
+----
+node add(const property_list& propList = {});
+----
+
+_Effects:_ This creates an empty node which contains no command. Its intended use is
+to make a connection point inside a graph between groups of nodes, and can
+significantly reduce the number of edges ( O(n) vs. O(n^2^) ).
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Returns:_ The empty node which has been added to the graph.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if a queue is
+recording commands to the graph.
+
+[source,c++]
+----
+template<typename T>
+node add(T cgf, const property_list& propList = {});
+----
+
+_Effects:_ The `cgf` command group function behaves in much the same way as the command
+group function passed to `queue::submit` unless explicitly stated otherwise in
+<<extension-interaction, Interaction With Other Extensions>>. Code in the
+function is executed synchronously, before the function returns back to
+`command_graph::add`, with the exception of any SYCL commands (e.g. kernels,
+or explicit memory copy operations). These commands are captured
+into the graph and executed asynchronously when the graph is submitted to a
+queue. The requisites of `cgf` will be used to identify any dependent nodes in
+the graph to form edges with.
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Returns:_ The command-group function object node which has been added to the graph.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if a queue is recording
+  commands to the graph.
+* Synchronously `exception` with error code `invalid` if the graph wasn't
+  created with the `property::graph::assume_buffer_outlives_graph` property
+  and this command uses a buffer. See the
+  <<assume-buffer-outlives-graph-property, Assume-Buffer-Outlives-Graph>>
+  property for more information.
+* An `exception` with error code `invalid` if the type of the command-group is
+  not a kernel execution and a `dynamic_parameter` was registered inside `cgf`.
+
+[source,c++]
+----
+node add(dynamic_command_group& dynamicCG, const property_list& propList = {});
+----
+
+_Effects:_ Adds the dynamic command-group `dynamicCG` as a node to the graph and sets the
+current active command-group function in `dynamicCG` as the executable for future
+executions of this graph node.
+The current active command-group function in `dynamicCG` will be executed asynchronously
+when the graph is submitted to a queue. The requisites of this command-group
+function will be used to identify any dependent nodes in the graph
+to form edges with. The other command-group functions in `dynamicCG` will be captured
+into the graph but will not be executed in a graph submission unless they are
+set to active.
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Returns:_ The dynamic command-group object node which has been added to the graph.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if a queue is recording
+  commands to the graph.
+
+* Synchronously `exception` with error code `invalid` if the graph does not match
+  the graph used on construction of `dynamicCG`.
+
+* An `exception` with error code `invalid` if the command-group functions in
+  `cgfList` have event or accessor dependencies that are incompatible with
+  each other and would result in different graph topologies when set to active.
+
+[source,c++]
+----
+void make_edge(node& src, node& dest);
+----
+
+_Effects:_ Creates a dependency between two nodes representing a happens-before
+relationship. Node `dest` will be dependent on `src`.
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if a queue is recording
+  commands to the graph object.
+
+* Synchronously `exception` with error code `invalid` if `src` or `dest`
+  are not valid nodes assigned to the graph object.
+
+* Synchronously `exception` with error code `invalid` if `src` and `dest`
+  are the same node.
+
+* Synchronously `exception` with error code `invalid` if the resulting
+  dependency would lead to a cycle. This error is omitted when
+  `property::graph::no_cycle_check` is set.
+
+[source,c++]
+----
+command_graph<graph_state::executable>
+finalize(const property_list& propList = {}) const;
+----
+
+_Effects:_ Synchronous operation that creates a new graph in the executable state with a
+fixed topology that can be submitted for execution on any queue sharing the
+context associated with the graph. It is valid to call this method multiple times
+to create subsequent executable graphs. It is also valid to continue to add new
+nodes to the modifiable graph instance after calling this function. It is valid
+to finalize an empty graph instance with no recorded commands.
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
+
+_Returns:_ A new executable graph object which can be submitted to a queue.
+
+_Throws:_ Synchronously `exception` with error code `feature_not_supported` if
+the graph contains a command that is not supported by the device.
+
+[source,c++]
+----
+void
+print_graph(std::string path, bool verbose = false) const;
+----
+
+_Effects:_ Synchronous operation that writes a DOT formatted description of the graph to the
+provided `path`. By default, this includes the graph topology, node types, node id,
+and kernel names.
+`verbose` can be set to true to write more detailed information about each node type
+such as kernel arguments, copy source, and destination addresses.
+At the moment DOT format is the only supported format. The name of the output file
+must therefore match this extension, i.e. "<filename>.dot".
+
+_Throws:_ Synchronously `exception` with error code `invalid` if the path is
+invalid or the file extension is not supported or if the write operation failed.
+
+[source,c++]
+----
+std::vector<node> get_nodes() const;
+----
+
+_Returns:_ A list of all the nodes present in the graph in the order that they
+were added.
+
+[source,c++]
+----
+std::vector<node> get_root_nodes() const;
+----
+
+_Returns:_ A list of all nodes in the graph which have no dependencies.
+
+===== Member functions of the `command_graph` class for queue recording
+
+[source, c++]
+----
+void
+begin_recording(queue& recordingQueue,
+                const property_list& propList = {})
+----
+
+_Effects:_ Synchronously changes the state of `recordingQueue` to the
+`queue_state::recording` state. This operation is an error if `recordingQueue`
+is already in the `queue_state::recording` state.
+
+_Preconditions:_
+`propList` is an optional parameter for passing properties.
+Properties for the `command_graph` class are defined in
+<<graph-properties, Graph Properties>>.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if `recordingQueue` is
+  already recording to a graph.
+
+* Synchronously `exception` with error code `invalid` if `recordingQueue` is
+  associated with a device or context that is different from the device
+  and context used on creation of the graph.
+
+[source, c++]
+----
+void
+begin_recording(const std::vector<queue>& recordingQueues,
+                const property_list& propList = {})
+----
+
+_Effects:_ Synchronously changes the state of each queue in `recordingQueues`
+to the `queue_state::recording` state and start recording commands to the graph
+instance. This operation is an error for any queue in `recordingQueues` that
+is already in the `queue_state::recording` state.
+
+_Preconditions:_
+`propList` is an optional parameter for passing properties.
+Properties for the `command_graph` class are defined in
+<<graph-properties, Graph Properties>>.
+
+_Throws:_
+
+* Synchronously `exception` with error code `invalid` if any queue in
+  `recordingQueues` is already recording to a graph.
+
+* Synchronously `exception` with error code `invalid` if any of `recordingQueues`
+  is associated with a device or context that is different from the device
+  and context used on creation of the graph.
+
+[source, c++]
+----
+void end_recording()
+----
+
+_Effects:_ Synchronously finishes recording on all queues that are recording
+to the graph and sets their state to `queue_state::executing`. This operation
+is a no-op for any queue in the graph that is already in the
+`queue_state::executing` state.
+
+[source, c++]
+----
+void end_recording(queue& recordingQueue)
+----
+
+_Effects:_ Synchronously changes the state of `recordingQueue` to the
+`queue_state::executing` state. This operation is a no-op if `recordingQueue`
+is already in the `queue_state::executing` state.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if
+`recordingQueue` is recording to a different graph.
+
+[source, c++]
+----
+void end_recording(const std::vector<queue>& recordingQueues)
+----
+
+_Effects:_ Synchronously changes the state of each queue in `recordingQueues` to the
+`queue_state::executing` state. This operation is a no-op for any queue in
+`recordingQueues` that is already in the `queue_state::executing` state.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if any queue in
+`recordingQueues` is recording to a different graph.
+
+=== Queue Class Modifications
+
+[source, c++]
+----
+namespace sycl {
+namespace khr {
+enum class queue_state {
+  executing,
+  recording
+};
+
+} // namespace khr
+
+// New methods added to the sycl::queue class
+using namespace khr;
+class queue {
+public:
+
+  khr::queue_state
+  khr_get_state() const;
+
+  khr::command_graph<graph_state::modifiable>
+  khr_get_graph() const;
+
+  /* -- graph convenience shortcuts -- */
+
+  event khr_graph(command_graph<graph_state::executable>& graph);
+  event khr_graph(command_graph<graph_state::executable>& graph,
+                   event depEvent);
+  event khr_graph(command_graph<graph_state::executable>& graph,
+                   const std::vector<event>& depEvents);
+};
+} // namespace sycl
+----
+
+:queue-class: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interface.queue.class
+
+This extension modifies the {queue-class}[SYCL queue class] such that
+<<queue-state, state>> is introduced to queue objects, allowing an instance to be
+put into a mode where command-groups are recorded to a graph rather than
+submitted immediately for execution.
+
+<<new-queue-member-functions, Three new member functions>> are also added to the
+`sycl::queue` class in this extension as queue shortcuts for `handler::graph()`.
+
+==== Queue State
+
+The `sycl::queue` object can be in either of two states. The default
+`queue_state::executing` state is where the queue has its normal semantics of
+submitted command-groups being immediately scheduled for asynchronous execution.
+
+The alternative `queue_state::recording` state is used for graph construction.
+Instead of being scheduled for execution, command-groups submitted to the queue
+are recorded to a graph object as new nodes for each submission. After recording
+has finished and the queue returns to the executing state, the recorded commands are
+not executed, they are transparent to any following queue operations. The state
+of a queue can be queried with `queue::khr_get_state()`.
+
+.Queue State Diagram
+[source, mermaid]
+....
+graph LR
+    Executing -->|Begin Recording| Recording
+    Recording -->|End Recording| Executing
+....
+
+==== Transitive Queue Recording
+
+Submitting a command-group to a queue in the executable state can implicitly
+change its state to `queue_state::recording`. This will occur when the
+command-group depends on an event that has been returned by a queue in the
+recording state. The change of state happens before the command-group is
+submitted to the device (i.e. a new graph node will be created for that command-group).
+
+A queue whose state has been set to `queue_state::recording` using this
+mechanism, will behave as if it had been passed as an argument to
+`command_graph::begin_recording()`. In particular, its state will not change
+again until `command_graph::end_recording()` is called.
+
+The recording properties of the queue whose event triggered the state change
+will also be inherited (i.e. any properties passed to the original call of
+`command_graph::begin_recording()` will be inherited by the queue whose state
+is being transitioned).
+
+===== Example
+
+[source,c++]
+----
+// q1 state is set to recording.
+graph.begin_recording(q1);
+
+// Node is added to the graph by submitting to a recording queue.
+auto e1 = q1.single_task(...);
+
+// Since there is a dependency on e1 which was created by a queue being
+// recorded, q2 immediately enters record mode, and a new node is created
+// with an edge between e1 and e2.
+auto e2 = q2.single_task(e1, ...);
+
+// Ends recording on q1 and q2.
+graph.end_recording();
+----
+
+==== Queue Properties
+
+:queue-properties: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:queue-properties
+
+There are {queue-properties}[two properties] defined by the core SYCL
+specification that can be passed to a `sycl::queue` on construction via the
+property list parameter. They interact with this extension in the following
+ways:
+
+1. `property::queue::in_order` - When a queue is created with the in-order
+   property, recording its operations results in a straight-line graph, as each
+   operation has an implicit dependency on the previous operation. However,
+   a graph submitted to an in-order queue will keep its existing structure such
+   that the complete graph executes in-order with respect to the other
+   command-groups submitted to the queue. The SYCL runtime automatically adds
+   an implicit dependency before and after the graph execution, as if the graph
+   execution is one command-group submitted to the in-order queue.
+
+2. `property::queue::enable_profiling` - This property has no effect on graph
+   recording. When set on the queue a graph is submitted to however, it allows
+   profiling information to be obtained from the event returned by a graph
+   submission. The executable graph used for this submission must have been
+   created with the `enable_profiling` property, see
+   <<enable-profiling, Enable-Profiling>> for more details. As it is not
+   defined how a submitted graph will be split up for scheduling at runtime,
+   the `uint64_t` timestamp reported from a profiling query on a graph
+   execution event has the following semantics, which may be
+   pessimistic about execution time on device.
+
+   * `info::event_profiling::command_submit` - Timestamp when the graph is
+      submitted to the queue.
+   * `info::event_profiling::command_start` - Timestamp when the first
+      command-group node begins running.
+   * `info::event_profiling::command_end` - Timestamp when the last
+      command-group node completes execution.
+      
+==== New Queue Member Functions
+
+===== Additional member functions of the `sycl::queue` class
+
+[source,c++]
+----
+queue_state
+queue::khr_get_state() const;
+----
+
+_Effects:_ Query the <<queue-state, recording state>> of the queue.
+
+_Returns:_ If the queue is in the default state where commands are scheduled
+immediately for execution, `queue_state::executing` is returned. Otherwise,
+`queue_state::recording` is returned where commands are redirected to a `command_graph`
+object.
+
+[source,c++]
+----
+command_graph<graph_state::modifiable>
+queue::khr_get_graph() const;
+----
+
+_Effects:_ Query the underlying command graph of a queue when recording.
+
+_Returns:_ The graph object that the queue is recording commands into.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if the queue is
+not in `queue_state::recording` state.
+
+[source,c++]
+----
+event
+queue::khr_graph(command_graph<graph_state::executable>& graph)
+----
+
+_Effects:_ Queue shortcut function that is equivalent to submitting a command-group
+containing `handler::khr_graph(graph)`.
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
+
+_Preconditions:_ The queue should be associated with a device and context that are the same
+as the device and context used on creation of the graph.
+
+_Returns:_ An event which represents the command which is submitted to the queue.
+
+[source,c++]
+----
+event
+queue::khr_graph(command_graph<graph_state::executable>& graph,
+                 event depEvent);
+----
+
+_Effects:_ Queue shortcut function that is equivalent to submitting a command-group
+containing `handler::depends_on(depEvent)` and
+`handler::khr_graph(graph)`.
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
+
+_Preconditions:_ The queue should be associated with a device and context that
+are the same as the device and context used on creation of the graph.
+
+_Returns:_ An event which represents the command which is submitted to the queue.
+
+[source,c++]
+----
+event
+queue::khr_graph(command_graph<graph_state::executable>& graph,
+                 const std::vector<event>& depEvents);
+----
+
+_Effects:_ Queue shortcut function that is equivalent to submitting a command-group
+containing `handler::depends_on(depEvents)` and
+`handler::khr_graph(graph)`.
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
+
+_Preconditions:_ The queue should be associated with a device and context that
+are the same as the device and context used on creation of the graph.
+
+_Returns:_ An event which represents the command which is submitted to the queue.
+
+==== New Handler Member Functions
+
+===== Additional member functions of the `sycl::handler` class
+
+[source,c++]
+----
+void
+handler::khr_graph(command_graph<graph_state::executable>& graph)
+----
+
+_Effects:_ Invokes the execution of a graph. Only one instance of `graph` will
+execute at any time. If `graph` is submitted multiple times, dependencies
+are automatically added by the runtime to prevent concurrent executions of
+an identical graph.
+
+_Throws:_ Synchronously `exception` with error code `invalid` if the handler
+is submitted to a queue which is associated with a device or context that is
+different from the device and context used on creation of the graph.
+
+=== Thread Safety
+
+The new functions in this extension are thread-safe, the same as member
+functions of classes in the base SYCL specification. If user code does
+not perform synchronization between two threads accessing the same queue,
+there is no strong ordering between events on that queue, and the kernel
+submissions, recording and finalization will happen in an undefined order.
+
+When one thread ends recording on a queue while another
+thread is submitting work, which kernels will be part of the subsequent
+graph is undefined. If user code enforces a total order on the queue
+events, then the behavior is well-defined, and will match the observable
+total order.
+
+The returned value from the `queue::khr_get_state()` should be
+considered immediately stale in multi-threaded usage, as another thread could
+have preemptively changed the state of the queue.
+
+=== Exception Safety
+
+In addition to the destruction semantics provided by the SYCL
+{crs}[common reference semantics], when the last copy of a modifiable
+`command_graph` is destroyed recording is ended on any queues that are recording
+to that graph, equivalent to `+this->end_recording()+`.
+
+As a result, users don't need to manually wrap queue recording code in a
+`try` / `catch` block to reset the state of recording queues on an exception
+back to the executing state. Instead, an uncaught exception destroying the
+modifiable graph will perform this action, useful in RAII pattern usage.
+
+=== Command-Group Function Limitations
+
+While not disallowed by the SYCL specification it should be noted that it is not
+possible to capture arbitrary C++ code which is inside a CGF (Command-Group
+Function) used to create a graph node. This code will be evaluated once during
+the call to `queue::submit()` or `command_graph::add()` along with the calls to
+handler functions and this will not be reflected on future executions of the
+graph.
+
+Similarly, any command-group function inside a `dynamic_command_group` will be
+evaluated once, in index order, when submitted to the graph using
+`command_graph::add()`.
+
+Any code like this should be moved to a separate host-task and added to the
+graph via the recording or explicit APIs in order to be compatible with this
+extension.
+
+=== Host Tasks [[host-tasks]]
+
+:host-task: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:interfaces.hosttasks
+
+A {host-task}[host task] is a native C++ callable, scheduled according to SYCL
+dependency rules. It is valid to record a host task as part of a graph, though it
+may lead to sub-optimal graph performance because a host task node may prevent
+the SYCL runtime from submitting the entire executable `command_graph` to the
+device at once.
+
+[source,c++]
+----
+auto node = graph.add([&](sycl::handler& cgh){
+  // Host code here is evaluated during the call to add()
+  cgh.host_task([=](){
+    // Code here is evaluated as part of executing the command graph node
+  });
+});
+----
+
+=== Queue Behavior In Recording Mode
+
+When a queue is placed in recording mode via a call to `command_graph::begin_recording`,
+some features of the queue are no longer available because the commands are not
+executed during this mode. The general philosophy is to throw an exception at
+runtime when a feature is not available, so that there is an obvious indication
+of failure. The following list describes the behavior that changes during
+recording mode. Features not listed below behave the same in recording mode as
+they do in non-recording mode.
+
+==== Event Limitations
+
+For queue submissions that are being recorded to a modifiable `command_graph`,
+the only events that can be used as parameters to `handler::depends_on()`, or
+as dependent events for queue shortcuts like `queue::parallel_for()`, are events
+that have been returned from queue submissions recorded to the same modifiable
+`command_graph`.
+
+Other limitations on the events returned from a submission to a queue in the
+recording state are:
+
+- Calling `event::get_info<info::event::command_execution_status>()` or
+`event::get_profiling_info()` will throw synchronously with error code `invalid`.
+
+- A host-side wait on the event will throw synchronously with error
+code `invalid`.
+
+- Using the event outside of the recording scope will throw synchronously with error code
+`invalid`.
+
+==== Queue Limitations
+
+A host-side wait on a queue in the recording state is an error and will
+throw synchronously with error code `invalid`.
+
+==== Buffer Limitations
+
+The use of buffers inside a `command_graph` is restricted unless the user
+creates the graph with the <<assume-buffer-outlives-graph-property, Assume-Buffer-Outlives-Graph>>
+property. Buffer lifetimes are not extended by a `command_graph` in which they
+are used and so the user must ensure that their lifetimes exceed that of the
+`command_graph`. Attempting to use a buffer in a `command_graph` without this
+property will result in a synchronous error being throw with error code
+`invalid`.
+
+There are also restrictions on using a buffer which has been created with a
+host data pointer in commands recorded to a `command_graph`. Because of the
+delayed execution of a `command_graph`, data may not be copied to the device
+immediately when commands using these buffers are submitted to the graph,
+therefore the host data must also outlive the graph to ensure correct behavior.
+
+Because of the delayed execution of a recorded graph, it is not possible to support
+captured code which relies on the copy-back on destruction behavior of buffers.
+Typically, applications would rely on this behavior to do work on the host which
+cannot inherently be captured inside a command graph.
+
+- Thus, when recording to a graph it is an error to submit a command which has
+an accessor on a buffer which would cause a write-back to happen. Using an
+incompatible buffer in this case will result in a synchronous error being
+thrown with error code `invalid`.
+
+- The copy-back mechanism can be disabled explicitly for buffers with attached host
+storage using either `buffer::set_final_data(nullptr)` or
+`buffer::set_write_back(false)`.
+
+- It is also an error to create a host accessor to a buffer which is used in
+commands which are currently being recorded to a command graph. Attempting to
+construct a host accessor to an incompatible buffer will result in a
+synchronous error being thrown with error code `invalid`.
+
+==== Error Handling
+
+When a queue is in recording mode asynchronous exceptions will not be
+generated, as no device execution is occurring. Synchronous errors specified as
+being thrown in the default queue executing state, will still be thrown when a
+queue is in the recording state. Queue query methods operate as usual in
+recording mode, as opposed to throwing.

--- a/adoc/extensions/sycl_khr_command_graph.adoc
+++ b/adoc/extensions/sycl_khr_command_graph.adoc
@@ -37,9 +37,9 @@ int main() {
   khr::command_graph myGraph{myQueue};
   
   // Create some 2D buffers of float for our matrices
-  buffer<float, 2> a{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
-  buffer<float, 2> b{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
-  buffer<float, 2> c{range<2>{N, M}, khr::property::graph::assume_buffer_outlives_graph{}};
+  buffer<float, 2> a{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
+  buffer<float, 2> b{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
+  buffer<float, 2> c{range<2>{N, M}, {khr::property::graph::assume_buffer_outlives_graph{}}};
 
   myGraph.begin_recording(myQueue);
 


### PR DESCRIPTION
Implementation is available in the [oneAPI DPC++ Compiler](https://github.com/intel/llvm) for a vendor extension `sycl_ext_oneapi_graph` which is a superset of this proposed KHR extension.

Projects that are currently using the command graph vendor extension include:
- GROMACS https://gitlab.com/gromacs/gromacs/-/merge_requests/4604
- Kokkos https://github.com/kokkos/kokkos/pull/6912
- Llama.cpp https://github.com/ggml-org/llama.cpp/pull/12371
