### PR TITLE
Clarify value of info::device::vendor_id

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1888,6 +1888,15 @@ _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ A unique vendor device identifier.
 
+If the vendor has a PCI vendor ID, the low 16 bits must contain that PCI vendor
+ID, and the remaining bits must be set to zero.
+Otherwise, the value returned must be a valid Khronos vendor ID.
+Khronos vendor IDs are allocated starting at 0x10000, to distinguish them from
+the PCI vendor ID namespace.
+
+{note}Khronos vendor IDs are synchronized across APIs by utilizing Vulkan’s
+vk.xml as the central Khronos vendor ID registry.{endnote}
+
 '''
 
 .[apidef]#info::device::max_compute_units#


### PR DESCRIPTION
This device descriptor corresponds to CL_DEVICE_VENDOR_ID. The description in OpenCL is clear that this must return a unique identifier for the device vendor, and also describes how these identifiers are synchronized across APIs.

Closes #166.

---

Although I usually argue in favor of removing functionality with ties to OpenCL, I think this is a special case. The vendor ID here is not unique to OpenCL, but is rather a Khronos-wide concept; since SYCL is a Khronos API, it would be weird for this vendor ID to mean anything other than what it means everywhere else.