### PR TITLE
Clarify thread-safety guarantees

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11,8 +11,11 @@ available for any <<backend, SYCL backends>>, with the exception of the
 interoperability interface, which is described in general terms in this
 document, not pertaining to any particular <<backend>>.
 
-SYCL guarantees that all the member functions and special member functions of
-the SYCL classes described are thread safe.
+All functions defined in this specification are thread-safe, unless otherwise
+specified.
+{note}If a function returns a pointer or reference, potentially concurrent
+conflicting actions via that pointer or reference still constitute a data
+race.{endnote}
 
 The underlying types for all enumerations defined in this specification are
 implementation-defined.


### PR DESCRIPTION
Previously, the thread-safety guarantee only applied to member functions of SYCL classes and did not apply to free functions, function templates, etc. This change clarifies that the thread-safety guarantee applies to all functions.

A new non-normative note further clarifies that this guarantee is not intended to eliminate data races from SYCL programs entirely.

Closes #415.