### PR TITLE
Clarify availability of sycl::byte/half on host

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17876,6 +17876,7 @@ Note these types are fundamental and therefore do not exist within the
 
 Additional scalar data types which are supported by SYCL within the [code]#sycl#
 namespace are described in <<table.types.additional>>.
+These data types are available on the host and in device code.
 
 
 [[table.types.additional]]


### PR DESCRIPTION
Existing implementations already provide implementations of these classes, and developers probably rely on that. A std:: equivalent of byte is already available in C++17, and std::float16_t exists in C++23.

Closes #436. 