### PR TITLE
Deprecate the `half_precision::` namespace

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -25784,7 +25784,7 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 '''
 
 
-=== Half precision math functions
+=== Half precision math functions (deprecated)
 
 This section describes the half precision math functions that are available in
 the [code]#sycl::half_precision# namespace in both host and device code.
@@ -25806,9 +25806,9 @@ description.
 .[apidef]#half_precision::cos#
 [source,role=synopsis,id=api:half-cos]
 ----
-float cos(float x)                (1)
+float cos(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ cos(NonScalar x)
 ----
 
@@ -25840,9 +25840,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::divide#
 [source,role=synopsis,id=api:half-divide]
 ----
-float divide(float x, float y)                      (1)
+float divide(float x, float y)                      (1) /* deprecated */
 
-template<typename NonScalar1, typename NonScalar2>  (2)
+template<typename NonScalar1, typename NonScalar2>  (2) /* deprecated */
 /*return-type*/ divide(NonScalar1 x, NonScalar2 y)
 ----
 
@@ -25870,9 +25870,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp#
 [source,role=synopsis,id=api:half-exp]
 ----
-float exp(float x)                (1)
+float exp(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ exp(NonScalar x)
 ----
 
@@ -25900,9 +25900,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp2#
 [source,role=synopsis,id=api:half-exp2]
 ----
-float exp2(float x)                (1)
+float exp2(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ exp2(NonScalar x)
 ----
 
@@ -25930,9 +25930,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp10#
 [source,role=synopsis,id=api:half-exp10]
 ----
-float exp10(float x)                (1)
+float exp10(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ exp10(NonScalar x)
 ----
 
@@ -25960,9 +25960,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log#
 [source,role=synopsis,id=api:half-log]
 ----
-float log(float x)                (1)
+float log(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ log(NonScalar x)
 ----
 
@@ -25989,9 +25989,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log2#
 [source,role=synopsis,id=api:half-log2]
 ----
-float log2(float x)                (1)
+float log2(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ log2(NonScalar x)
 ----
 
@@ -26018,9 +26018,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log10#
 [source,role=synopsis,id=api:half-log10]
 ----
-float log10(float x)                (1)
+float log10(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ log10(NonScalar x)
 ----
 
@@ -26047,9 +26047,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::powr#
 [source,role=synopsis,id=api:half-powr]
 ----
-float powr(float x, float y)                        (1)
+float powr(float x, float y)                        (1) /* deprecated */
 
-template<typename NonScalar1, typename NonScalar2>  (2)
+template<typename NonScalar1, typename NonScalar2>  (2) /* deprecated */
 /*return-type*/ powr(NonScalar1 x, NonScalar2 y)
 ----
 
@@ -26082,9 +26082,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::recip#
 [source,role=synopsis,id=api:half-recip]
 ----
-float recip(float x)                (1)
+float recip(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ recip(NonScalar x)
 ----
 
@@ -26111,9 +26111,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::rsqrt#
 [source,role=synopsis,id=api:half-rsqrt]
 ----
-float rsqrt(float x)                (1)
+float rsqrt(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ rsqrt(NonScalar x)
 ----
 
@@ -26141,9 +26141,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::sin#
 [source,role=synopsis,id=api:half-sin]
 ----
-float sin(float x)                (1)
+float sin(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ sin(NonScalar x)
 ----
 
@@ -26175,9 +26175,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::sqrt#
 [source,role=synopsis,id=api:half-sqrt]
 ----
-float sqrt(float x)                (1)
+float sqrt(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ sqrt(NonScalar x)
 ----
 
@@ -26204,9 +26204,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::tan#
 [source,role=synopsis,id=api:half-tan]
 ----
-float tan(float x)                (1)
+float tan(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ tan(NonScalar x)
 ----
 


### PR DESCRIPTION
The functions in the half_precision namespace correspond to math functions with the half_ prefix in OpenCL. In OpenCL (and SYCL 1.2.1), the functions have a guaranteed minimum precision, but in SYCL 2020 the precision is backend-specific and non-portable.

Deprecating these functions in favor of using real half precision (via `sycl::half` or `std::float16_t`) will make SYCL simpler.

---

I deliberately didn't update the "what changed" section or assign a milestone, because I wanted to collect some feedback first. 
There is a precedent for deprecating features in SYCL 2020 that should have been deprecated as part of the move away from OpenCL -- should we do that here, or can we only deprecate in SYCL-Next?

My personal opinion: we should deprecate in SYCL 2020, so we can remove in SYCL-Next.  As far as I can tell, these functions are basically pointless, and implementations are free to implement them by just using 32-bit precision.  If a developer violates the precondition (of being in the range of a `half`), many implementations will continue to work.  Getting people to use `float` or `half` depending on what the device actually supports would be a much better user experience.
