### PR TITLE
Clarify dimension must be in range [0, Dimensions)

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12059,6 +12059,8 @@ size_t get(int dimension) const
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12067,6 +12069,8 @@ size_t& operator[](int dimension)
 ----
    a@ Return the l-value of the specified dimension of the
       [code]#range#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12075,6 +12079,8 @@ size_t operator[](int dimension) const
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12402,8 +12408,9 @@ a@
 ----
 size_t get(int dimension) const
 ----
-   a@ Return the value of the [code]#id# for dimension
-      [code]#Dimension#.
+   a@ Return the value of the requested dimension of this [code]#id# object.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12412,6 +12419,8 @@ size_t& operator[](int dimension)
 ----
    a@ Return a reference to the requested dimension of the [code]#id#
       object.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12420,6 +12429,8 @@ size_t operator[](int dimension) const
 ----
    a@ Return the value of the requested dimension of the [code]#id#
       object.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12604,14 +12615,14 @@ a@
 ----
 size_t get_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_id()[dimension]#.
+   a@ Equivalent to [code]#return get_id()[dimension]#.
 
 a@
 [source]
 ----
 size_t operator[](int dimension) const
 ----
-   a@ Return the same value as [code]#get_id(dimension)#.
+   a@ Equivalent to [code]#return get_id(dimension)#.
 
 a@
 [source]
@@ -12626,7 +12637,7 @@ a@
 ----
 size_t get_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_range().get(dimension)#.
+   a@ Equivalent to [code]#return get_range().get(dimension)#.
 
 a@
 [source]
@@ -12730,6 +12741,8 @@ size_t get_global_id(int dimension) const
    a@ Return the constituent element of the <<global-id>>
       representing the work-item's position in the <<nd-range>>
       in the given [code]#Dimension#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12757,6 +12770,8 @@ size_t get_local_id(int dimension) const
    a@ Return the constituent element of the <<local-id>> representing the
       work-item's position within the current <<work-group>> in the given
       [code]#Dimension#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12791,6 +12806,8 @@ size_t get_group(int dimension) const
    a@ Return the constituent element of the group [code]#id# representing
       the work-group's position within the overall [code]#nd_range# in the
       given [code]#Dimension#.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12814,6 +12831,8 @@ size_t get_group_range(int dimension) const
 ----
    a@ Return the number of <<work-group,work-groups>> for [code]#Dimension# in the
       iteration space.
+      Results in undefined behavior if [code]#dimension# is not in the range
+      [code]#[0, Dimensions)#.
 
 a@
 [source]
@@ -12828,7 +12847,7 @@ a@
 ----
 size_t get_global_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_global_range().get(dimension)#.
+   a@ Equivalent to [code]#return get_global_range().get(dimension)#.
 
 a@
 [source]
@@ -12843,7 +12862,7 @@ a@
 ----
 size_t get_local_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_local_range().get(dimension)#.
+   a@ Equivalent to [code]#return get_local_range().get(dimension)#.
 
 a@
 [source]
@@ -13079,112 +13098,112 @@ a@
 ----
 range<Dimensions> get_global_range() const
 ----
-   a@ Return the same value as [code]#get_global().get_range()#
+   a@ Equivalent to [code]#return get_global().get_range()#
 
 a@
 [source]
 ----
 size_t get_global_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_global().get_range(dimension)#
+   a@ Equivalent to [code]#return get_global().get_range(dimension)#
 
 a@
 [source]
 ----
 id<Dimensions> get_global_id() const
 ----
-   a@ Return the same value as [code]#get_global().get_id()#
+   a@ Equivalent to [code]#return get_global().get_id()#
 
 a@
 [source]
 ----
 size_t get_global_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_global().get_id(dimension)#
+   a@ Equivalent to [code]#return get_global().get_id(dimension)#
 
 a@
 [source]
 ----
 range<Dimensions> get_local_range() const
 ----
-   a@ Return the same value as [code]#get_local().get_range()#
+   a@ Equivalent to [code]#return get_local().get_range()#
 
 a@
 [source]
 ----
 size_t get_local_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_local().get_range(dimension)#
+   a@ Equivalent to [code]#return get_local().get_range(dimension)#
 
 a@
 [source]
 ----
 id<Dimensions> get_local_id() const
 ----
-   a@ Return the same value as [code]#get_local().get_id()#
+   a@ Equivalent to [code]#return get_local().get_id()#
 
 a@
 [source]
 ----
 size_t get_local_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_local().get_id(dimension)#
+   a@ Equivalent to [code]#return get_local().get_id(dimension)#
 
 a@
 [source]
 ----
 range<Dimensions> get_logical_local_range() const
 ----
-   a@ Return the same value as [code]#get_logical_local().get_range()#
+   a@ Equivalent to [code]#return get_logical_local().get_range()#
 
 a@
 [source]
 ----
 size_t get_logical_local_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_logical_local().get_range(dimension)#
+   a@ Equivalent to [code]#return get_logical_local().get_range(dimension)#
 
 a@
 [source]
 ----
 id<Dimensions> get_logical_local_id() const
 ----
-   a@ Return the same value as [code]#get_logical_local().get_id()#
+   a@ Equivalent to [code]#return get_logical_local().get_id()#
 
 a@
 [source]
 ----
 size_t get_logical_local_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_logical_local().get_id(dimension)#
+   a@ Equivalent to [code]#return get_logical_local().get_id(dimension)#
 
 a@
 [source]
 ----
 range<Dimensions> get_physical_local_range() const
 ----
-   a@ Return the same value as [code]#get_physical_local().get_range()#
+   a@ Equivalent to [code]#return get_physical_local().get_range()#
 
 a@
 [source]
 ----
 size_t get_physical_local_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_physical_local().get_range(dimension)#
+   a@ Equivalent to [code]#return get_physical_local().get_range(dimension)#
 
 a@
 [source]
 ----
 id<Dimensions> get_physical_local_id() const
 ----
-   a@ Return the same value as [code]#get_physical_local().get_id()#
+   a@ Equivalent to [code]#return get_physical_local().get_id()#
 
 a@
 [source]
 ----
 size_t get_physical_local_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_physical_local().get_id(dimension)#
+   a@ Equivalent to [code]#return get_physical_local().get_id(dimension)#
 
 |====
 
@@ -13241,7 +13260,7 @@ a@
 ----
 size_t get_group_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_group_id()[dimension]#.
+   a@ Equivalent to [code]#return get_group_id()[dimension]#.
 
 a@
 [source]
@@ -13259,7 +13278,7 @@ a@
 ----
 size_t get_local_id(int dimension) const
 ----
-   a@ Return the same value as [code]#get_local_id()[dimension]#.
+   a@ Equivalent to [code]#return get_local_id()[dimension]#.
 
 It is undefined behavior for this member function to be invoked from within
 a [code]#parallel_for_work_item# context.
@@ -13277,7 +13296,7 @@ a@
 ----
 size_t get_local_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_local_range()[dimension]#.
+   a@ Equivalent to [code]#return get_local_range()[dimension]#.
 
 a@
 [source]
@@ -13291,14 +13310,14 @@ a@
 ----
 size_t get_group_range(int dimension) const
 ----
-   a@ Return the same value as [code]#get_group_range()[dimension]#.
+   a@ Equivalent to [code]#return get_group_range()[dimension]#.
 
 a@
 [source]
 ----
 size_t operator[](int dimension) const
 ----
-   a@ Return the same value as [code]#get_group_id(dimension)#.
+   a@ Equivalent to [code]#return get_group_id(dimension)#.
 
 a@
 [source]
@@ -13606,28 +13625,28 @@ a@
 ----
 uint32_t get_group_linear_id() const
 ----
-   a@ Return the same value as [code]#get_group_id()[0]#.
+   a@ Equivalent to [code]#return get_group_id()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_group_linear_range() const
 ----
-   a@ Return the same value as [code]#get_group_range()[0]#.
+   a@ Equivalent to [code]#return get_group_range()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_local_linear_id() const
 ----
-   a@ Return the same value as [code]#get_local_id()[0]#.
+   a@ Equivalent to [code]#return get_local_id()[0]#.
 
 a@
 [source]
 ----
 uint32_t get_local_linear_range() const
 ----
-   a@ Return the same value as [code]#get_local_range()[0]#.
+   a@ Equivalent to [code]#return get_local_range()[0]#.
 
 a@
 [source]


### PR DESCRIPTION
Accessing a dimension outside of the range supported by a class should result in undefined behavior. This clarification impacts all classes that are used to describe the kernel index space (e.g., id, item, group).

Closes #551.

---

Note that I changed some of the wording from "Returns" to "Equivalent to".  This was deliberate, because "Equivalent to" inherits preconditions, whereas "Returns" does not.