### PR TITLE
Add `noexcept` to index space classes

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12012,14 +12012,14 @@ include::{header_dir}/range.h[lines=4..-1]
 a@
 [source]
 ----
-range()
+range() noexcept;
 ----
    a@ Construct a SYCL [code]#range# with the value [code]#0# for each dimension.
 
 a@
 [source]
 ----
-range(size_t dim0)
+range(size_t dim0) noexcept;
 ----
    a@ Construct a 1D range with value dim0.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12028,7 +12028,7 @@ range(size_t dim0)
 a@
 [source]
 ----
-range(size_t dim0, size_t dim1)
+range(size_t dim0, size_t dim1) noexcept;
 ----
    a@ Construct a 2D range with values dim0 and dim1.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12037,7 +12037,7 @@ range(size_t dim0, size_t dim1)
 a@
 [source]
 ----
-range(size_t dim0, size_t dim1, size_t dim2)
+range(size_t dim0, size_t dim1, size_t dim2) noexcept;
 ----
    a@ Construct a 3D range with values dim0, dim1 and dim2.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12055,7 +12055,7 @@ range(size_t dim0, size_t dim1, size_t dim2)
 a@
 [source]
 ----
-size_t get(int dimension) const
+size_t get(int dimension) const noexcept;
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
@@ -12063,7 +12063,7 @@ size_t get(int dimension) const
 a@
 [source]
 ----
-size_t& operator[](int dimension)
+size_t& operator[](int dimension) noexcept;
 ----
    a@ Return the l-value of the specified dimension of the
       [code]#range#.
@@ -12071,7 +12071,7 @@ size_t& operator[](int dimension)
 a@
 [source]
 ----
-size_t operator[](int dimension) const
+size_t operator[](int dimension) const noexcept;
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
@@ -12079,7 +12079,7 @@ size_t operator[](int dimension) const
 a@
 [source]
 ----
-size_t size() const
+size_t size() const noexcept;
 ----
    a@ Return the size of the range computed as dimension0*...*dimensionN.
 
@@ -12095,7 +12095,7 @@ size_t size() const
 a@
 [source]
 ----
-range operatorOP(const range& lhs, const range& rhs)
+range operatorOP(const range& lhs, const range& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12115,7 +12115,7 @@ is the cast to [code]#size_t#.
 a@
 [source]
 ----
-range operatorOP(const range& lhs, const size_t& rhs)
+range operatorOP(const range& lhs, const size_t& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12135,7 +12135,7 @@ the operator returns a [code]#bool#, the result is the cast to
 a@
 [source]
 ----
-range& operatorOP(range& lhs, const range& rhs)
+range& operatorOP(range& lhs, const range& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
@@ -12148,7 +12148,7 @@ to [code]#size_t#.
 a@
 [source]
 ----
-range& operatorOP(range& lhs, const size_t& rhs)
+range& operatorOP(range& lhs, const size_t& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
@@ -12161,7 +12161,7 @@ operator returns a [code]#bool#, the result is the cast to
 a@
 [source]
 ----
-range operatorOP(const size_t& lhs, const range& rhs)
+range operatorOP(const size_t& lhs, const range& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12181,7 +12181,7 @@ the [code]#lhs# [code]#size_t# and each element of the
 a@
 [source]
 ----
-range operatorOP(const range& rhs)
+range operatorOP(const range& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: unary [code]#pass:[+]#, unary [code]#-#.
 
@@ -12194,7 +12194,7 @@ the [code]#rhs# SYCL [code]#range#.
 a@
 [source]
 ----
-range& operatorOP(range& rhs)
+range& operatorOP(range& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: prefix [code]#pass:[++]#, prefix [code]#--#.
 
@@ -12205,7 +12205,7 @@ of an element-wise [code]#OP# operator on each element of the [code]#rhs#
 a@
 [source]
 ----
-range operatorOP(range& lhs, int)
+range operatorOP(range& lhs, int) noexcept;
 ----
    a@ Where [code]#OP# is: postfix [code]#pass:[++]#, postfix [code]#--#.
 
@@ -12257,7 +12257,7 @@ a@
 nd_range<Dimensions>(
 range<Dimensions> globalSize,
     range<Dimensions> localSize,
-    id<Dimensions> offset = id<Dimensions>())
+    id<Dimensions> offset = id<Dimensions>()) noexcept;
 ----
    a@ Construct an [code]#nd_range# from the local and global
       constituent ranges. Supplying the option offset is
@@ -12276,21 +12276,21 @@ range<Dimensions> globalSize,
 a@
 [source]
 ----
-range<Dimensions> get_global_range() const
+range<Dimensions> get_global_range() const noexcept;
 ----
    a@ Return the constituent global range.
 
 a@
 [source]
 ----
-range<Dimensions> get_local_range() const
+range<Dimensions> get_local_range() const noexcept;
 ----
    a@ Return the constituent local range.
 
 a@
 [source]
 ----
-range<Dimensions> get_group_range() const
+range<Dimensions> get_group_range() const noexcept;
 ----
    a@ Return a range representing the number of groups in each
       dimension.  This range would result from
@@ -12299,7 +12299,7 @@ range<Dimensions> get_group_range() const
 a@
 [source]
 ----
-id<Dimensions> get_offset() const
+id<Dimensions> get_offset() const noexcept;
     // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
@@ -12343,14 +12343,14 @@ include::{header_dir}/id.h[lines=4..-1]
 a@
 [source]
 ----
-id()
+id() noexcept;
 ----
    a@ Construct a SYCL [code]#id# with the value [code]#0# for each dimension.
 
 a@
 [source]
 ----
-id(size_t dim0)
+id(size_t dim0) noexcept;
 ----
    a@ Construct a 1D [code]#id# with value dim0.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12359,7 +12359,7 @@ id(size_t dim0)
 a@
 [source]
 ----
-id(size_t dim0, size_t dim1)
+id(size_t dim0, size_t dim1) noexcept;
 ----
    a@ Construct a 2D [code]#id# with values dim0, dim1.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12368,7 +12368,7 @@ id(size_t dim0, size_t dim1)
 a@
 [source]
 ----
-id(size_t dim0, size_t dim1, size_t dim2)
+id(size_t dim0, size_t dim1, size_t dim2) noexcept;
 ----
    a@ Construct a 3D [code]#id# with values dim0, dim1, dim2.
       Only valid when the template parameter [code]#Dimensions# is equal
@@ -12377,14 +12377,14 @@ id(size_t dim0, size_t dim1, size_t dim2)
 a@
 [source]
 ----
-id(const range<Dimensions>& range)
+id(const range<Dimensions>& range) noexcept;
 ----
    a@ Construct an [code]#id# from the dimensions of [code]#range#.
 
 a@
 [source]
 ----
-id(const item<Dimensions>& item)
+id(const item<Dimensions>& item) noexcept;
 ----
    a@ Construct an [code]#id# from [code]#item.get_id()#.
 
@@ -12400,7 +12400,7 @@ id(const item<Dimensions>& item)
 a@
 [source]
 ----
-size_t get(int dimension) const
+size_t get(int dimension) const noexcept;
 ----
    a@ Return the value of the [code]#id# for dimension
       [code]#Dimension#.
@@ -12408,7 +12408,7 @@ size_t get(int dimension) const
 a@
 [source]
 ----
-size_t& operator[](int dimension)
+size_t& operator[](int dimension) noexcept;
 ----
    a@ Return a reference to the requested dimension of the [code]#id#
       object.
@@ -12416,7 +12416,7 @@ size_t& operator[](int dimension)
 a@
 [source]
 ----
-size_t operator[](int dimension) const
+size_t operator[](int dimension) const noexcept;
 ----
    a@ Return the value of the requested dimension of the [code]#id#
       object.
@@ -12424,7 +12424,7 @@ size_t operator[](int dimension) const
 a@
 [source]
 ----
-operator size_t() const
+operator size_t() const noexcept;
 ----
    a@ Available only when: [code]#Dimensions == 1#
 
@@ -12440,7 +12440,7 @@ Returns the same value as [code]#get(0)#.
 a@
 [source]
 ----
-id operatorOP(const id& lhs, const id& rhs)
+id operatorOP(const id& lhs, const id& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12456,7 +12456,7 @@ If the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id operatorOP(const id& lhs, const size_t& rhs)
+id operatorOP(const id& lhs, const size_t& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12472,7 +12472,7 @@ operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id& operatorOP(id& lhs, const id& rhs)
+id& operatorOP(id& lhs, const id& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -12487,7 +12487,7 @@ the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id& operatorOP(id& lhs, const size_t& rhs)
+id& operatorOP(id& lhs, const size_t& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
@@ -12501,7 +12501,7 @@ returns a [code]#bool# the result is the cast to [code]#size_t#.
 a@
 [source]
 ----
-id operatorOP(const size_t& lhs, const id& rhs)
+id operatorOP(const size_t& lhs, const id& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12517,7 +12517,7 @@ the [code]#lhs# [code]#size_t# and each element of the
 a@
 [source]
 ----
-id operatorOP(const id& rhs)
+id operatorOP(const id& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: unary [code]#pass:[+]#, unary [code]#-#.
 
@@ -12530,7 +12530,7 @@ the [code]#rhs# SYCL [code]#id#.
 a@
 [source]
 ----
-id& operatorOP(id& rhs)
+id& operatorOP(id& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: prefix [code]#pass:[++]#, prefix [code]#--#.
 
@@ -12541,7 +12541,7 @@ of an element-wise [code]#OP# operator on each element of the [code]#rhs#
 a@
 [source]
 ----
-id operatorOP(id& lhs, int)
+id operatorOP(id& lhs, int) noexcept;
 ----
    a@ Where [code]#OP# is: postfix [code]#pass:[++]#, postfix [code]#--#.
 
@@ -12594,7 +12594,7 @@ include::{header_dir}/item.h[lines=4..-1]
 a@
 [source]
 ----
-id<Dimensions> get_id() const
+id<Dimensions> get_id() const noexcept;
 ----
    a@ Return the constituent [code]#id#
       representing the work-item's position in the iteration space.
@@ -12602,21 +12602,21 @@ id<Dimensions> get_id() const
 a@
 [source]
 ----
-size_t get_id(int dimension) const
+size_t get_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_id()[dimension]#.
 
 a@
 [source]
 ----
-size_t operator[](int dimension) const
+size_t operator[](int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_id(dimension)#.
 
 a@
 [source]
 ----
-range<Dimensions> get_range() const
+range<Dimensions> get_range() const noexcept;
 ----
    a@ Returns a [code]#range# representing the dimensions of the
       range of possible values of the [code]#item#.
@@ -12624,14 +12624,14 @@ range<Dimensions> get_range() const
 a@
 [source]
 ----
-size_t get_range(int dimension) const
+size_t get_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_range().get(dimension)#.
 
 a@
 [source]
 ----
-id<Dimensions> get_offset() const
+id<Dimensions> get_offset() const noexcept;
     // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
@@ -12646,7 +12646,7 @@ This member function is only available if [code]#WithOffset# is [code]#true#.
 a@
 [source]
 ----
-operator item<Dimensions, true>() const
+operator item<Dimensions, true>() const noexcept;
     // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
@@ -12660,7 +12660,7 @@ write code that assumes an offset and still provides an offset-less [code]#item#
 a@
 [source]
 ----
-operator size_t() const
+operator size_t() const noexcept;
 ----
    a@ Available only when: [code]#Dimensions == 1#
 
@@ -12669,7 +12669,7 @@ Returns the same value as [code]#get_id(0)#.
 a@
 [source]
 ----
-size_t get_linear_id() const
+size_t get_linear_id() const noexcept;
 ----
    a@ Return the id as a linear index value. Calculating a linear
       address from the multi-dimensional index follows
@@ -12717,7 +12717,7 @@ include::{header_dir}/nditem.h[lines=4..-1]
 a@
 [source]
 ----
-id<Dimensions> get_global_id() const
+id<Dimensions> get_global_id() const noexcept;
 ----
    a@ Return the constituent <<global-id>> representing the
       work-item's position in the global iteration space.
@@ -12725,7 +12725,7 @@ id<Dimensions> get_global_id() const
 a@
 [source]
 ----
-size_t get_global_id(int dimension) const
+size_t get_global_id(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the <<global-id>>
       representing the work-item's position in the <<nd-range>>
@@ -12734,7 +12734,7 @@ size_t get_global_id(int dimension) const
 a@
 [source]
 ----
-size_t get_global_linear_id() const
+size_t get_global_linear_id() const noexcept;
 ----
    a@ Return the constituent <<global-id>> as a linear index value, representing the work-item's
    position in the global iteration space.  The linear address is calculated from the
@@ -12744,7 +12744,7 @@ size_t get_global_linear_id() const
 a@
 [source]
 ----
-id<Dimensions> get_local_id() const
+id<Dimensions> get_local_id() const noexcept;
 ----
    a@ Return the constituent <<local-id>> representing the
       work-item's position within the current <<work-group>>.
@@ -12752,7 +12752,7 @@ id<Dimensions> get_local_id() const
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const
+size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the <<local-id>> representing the
       work-item's position within the current <<work-group>> in the given
@@ -12761,7 +12761,7 @@ size_t get_local_id(int dimension) const
 a@
 [source]
 ----
-size_t get_local_linear_id() const
+size_t get_local_linear_id() const noexcept;
 ----
    a@ Return the constituent <<local-id>> as a linear index value, representing the work-item's
    position within the current <<work-group>>.  The linear address is calculated from the
@@ -12770,7 +12770,7 @@ size_t get_local_linear_id() const
 a@
 [source]
 ----
-group<Dimensions> get_group() const
+group<Dimensions> get_group() const noexcept;
 ----
    a@ Return the constituent <<work-group>>, [code]#group#
       representing the <<work-group>>'s position within the overall
@@ -12779,14 +12779,14 @@ group<Dimensions> get_group() const
 a@
 [source]
 ----
-sub_group get_sub_group() const
+sub_group get_sub_group() const noexcept;
 ----
    a@ Return a [code]#sub_group# representing the <<sub-group>> to which the work-item belongs.
 
 a@
 [source]
 ----
-size_t get_group(int dimension) const
+size_t get_group(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the group [code]#id# representing
       the work-group's position within the overall [code]#nd_range# in the
@@ -12795,7 +12795,7 @@ size_t get_group(int dimension) const
 a@
 [source]
 ----
-size_t get_group_linear_id() const
+size_t get_group_linear_id() const noexcept;
 ----
    a@ Return the group id as a linear index value. Calculating a linear address
       from a multi-dimensional index follows <<sec:multi-dim-linearization>>.
@@ -12803,14 +12803,14 @@ size_t get_group_linear_id() const
 a@
 [source]
 ----
-range<Dimensions> get_group_range() const
+range<Dimensions> get_group_range() const noexcept;
 ----
    a@ Returns the number of <<work-group,work-groups>> in the iteration space.
 
 a@
 [source]
 ----
-size_t get_group_range(int dimension) const
+size_t get_group_range(int dimension) const noexcept;
 ----
    a@ Return the number of <<work-group,work-groups>> for [code]#Dimension# in the
       iteration space.
@@ -12818,7 +12818,7 @@ size_t get_group_range(int dimension) const
 a@
 [source]
 ----
-range<Dimensions> get_global_range() const
+range<Dimensions> get_global_range() const noexcept;
 ----
    a@ Returns a [code]#range# representing the dimensions of the
       global iteration space.
@@ -12826,14 +12826,14 @@ range<Dimensions> get_global_range() const
 a@
 [source]
 ----
-size_t get_global_range(int dimension) const
+size_t get_global_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_global_range().get(dimension)#.
 
 a@
 [source]
 ----
-range<Dimensions> get_local_range() const
+range<Dimensions> get_local_range() const noexcept;
 ----
    a@ Returns a [code]#range# representing the dimensions of the current
       work-group.
@@ -12841,14 +12841,14 @@ range<Dimensions> get_local_range() const
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const
+size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_local_range().get(dimension)#.
 
 a@
 [source]
 ----
-id<Dimensions> get_offset() const
+id<Dimensions> get_offset() const noexcept;
     // Deprecated in SYCL 2020.
 ----
    a@ Deprecated in SYCL 2020.
@@ -12859,7 +12859,7 @@ id<Dimensions> get_offset() const
 a@
 [source]
 ----
-nd_range<Dimensions> get_nd_range() const
+nd_range<Dimensions> get_nd_range() const noexcept;
 ----
    a@ Returns the [code]#nd_range# of the current execution.
 
@@ -12869,7 +12869,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
                                    global_ptr<DataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -12882,7 +12882,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
                                    local_ptr<DataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -12895,7 +12895,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
                                    global_ptr<DataT> src,
-                                   size_t numElements, size_t srcStride) const
+                                   size_t numElements, size_t srcStride) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -12908,7 +12908,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
                                    local_ptr<DataT> src,
-                                   size_t numElements, size_t destStride) const
+                                   size_t numElements, size_t destStride) const noexcept;
 ----
     a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -12921,7 +12921,7 @@ a@
 template <typename DestDataT, typename SrcDataT>
 device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                    decorated_global_ptr<SrcDataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -12938,7 +12938,7 @@ a@
 template <typename DestDataT, typename SrcDataT>
 device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                    decorated_local_ptr<SrcDataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -12955,7 +12955,7 @@ a@
 template <typename DestDataT, typename SrcDataT>
 device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                    decorated_global_ptr<SrcDataT> src,
-                                   size_t numElements, size_t srcStride) const
+                                   size_t numElements, size_t srcStride) const noexcept;
 ----
    a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -12972,7 +12972,7 @@ a@
 template <typename DestDataT, SrcDataT>
 device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                    decorated_local_ptr<SrcDataT> src,
-                                   size_t numElements, size_t destStride) const
+                                   size_t numElements, size_t destStride) const noexcept;
 ----
     a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -12986,7 +12986,7 @@ destination stride specified by [code]#destStride# and returns a SYCL
 a@
 [source]
 ----
-template <typename... EventTN> void wait_for(EventTN... events) const
+template <typename... EventTN> void wait_for(EventTN... events) const noexcept;
 ----
    a@ Permitted type for [code]#EventTN# is [code]#device_event#.
       Waits for the asynchronous operations associated with each [code]#device_event# to complete.
@@ -13037,7 +13037,7 @@ include::{header_dir}/hitem.h[lines=4..-1]
 a@
 [source]
 ----
-item<Dimensions, false> get_global() const
+item<Dimensions, false> get_global() const noexcept;
 ----
    a@ Return the constituent global <<item>> representing the
       work-item's position in the global iteration space as provided upon kernel invocation.
@@ -13045,14 +13045,14 @@ item<Dimensions, false> get_global() const
 a@
 [source]
 ----
-item<Dimensions, false> get_local() const
+item<Dimensions, false> get_local() const noexcept;
 ----
    a@ Return the same value as [code]#get_logical_local()#.
 
 a@
 [source]
 ----
-item<Dimensions, false> get_logical_local() const
+item<Dimensions, false> get_logical_local() const noexcept;
 ----
    a@ Return the constituent element of the logical local <<item>>
       work-item's position in the local iteration space as provided upon the invocation of the
@@ -13068,7 +13068,7 @@ of the logical id and the physical range:
 a@
 [source]
 ----
-item<Dimensions, false> get_physical_local() const
+item<Dimensions, false> get_physical_local() const noexcept;
 ----
    a@ Return the constituent element of the physical local <<item>>
       work-item's position in the local iteration space as provided (by the user or the runtime)
@@ -13077,112 +13077,112 @@ item<Dimensions, false> get_physical_local() const
 a@
 [source]
 ----
-range<Dimensions> get_global_range() const
+range<Dimensions> get_global_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_global().get_range()#
 
 a@
 [source]
 ----
-size_t get_global_range(int dimension) const
+size_t get_global_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_global().get_range(dimension)#
 
 a@
 [source]
 ----
-id<Dimensions> get_global_id() const
+id<Dimensions> get_global_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_global().get_id()#
 
 a@
 [source]
 ----
-size_t get_global_id(int dimension) const
+size_t get_global_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_global().get_id(dimension)#
 
 a@
 [source]
 ----
-range<Dimensions> get_local_range() const
+range<Dimensions> get_local_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_local().get_range()#
 
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const
+size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_local().get_range(dimension)#
 
 a@
 [source]
 ----
-id<Dimensions> get_local_id() const
+id<Dimensions> get_local_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_local().get_id()#
 
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const
+size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_local().get_id(dimension)#
 
 a@
 [source]
 ----
-range<Dimensions> get_logical_local_range() const
+range<Dimensions> get_logical_local_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_logical_local().get_range()#
 
 a@
 [source]
 ----
-size_t get_logical_local_range(int dimension) const
+size_t get_logical_local_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_logical_local().get_range(dimension)#
 
 a@
 [source]
 ----
-id<Dimensions> get_logical_local_id() const
+id<Dimensions> get_logical_local_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_logical_local().get_id()#
 
 a@
 [source]
 ----
-size_t get_logical_local_id(int dimension) const
+size_t get_logical_local_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_logical_local().get_id(dimension)#
 
 a@
 [source]
 ----
-range<Dimensions> get_physical_local_range() const
+range<Dimensions> get_physical_local_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_physical_local().get_range()#
 
 a@
 [source]
 ----
-size_t get_physical_local_range(int dimension) const
+size_t get_physical_local_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_physical_local().get_range(dimension)#
 
 a@
 [source]
 ----
-id<Dimensions> get_physical_local_id() const
+id<Dimensions> get_physical_local_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_physical_local().get_id()#
 
 a@
 [source]
 ----
-size_t get_physical_local_id(int dimension) const
+size_t get_physical_local_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_physical_local().get_id(dimension)#
 
@@ -13228,7 +13228,7 @@ include::{header_dir}/group.h[lines=4..-1]
 a@
 [source]
 ----
-id<Dimensions> get_group_id() const
+id<Dimensions> get_group_id() const noexcept;
 ----
    a@ Return an <<id>> representing the index of the work-group within the
       global <<nd-range>> for every dimension.  Since the work-items in a
@@ -13239,14 +13239,14 @@ id<Dimensions> get_group_id() const
 a@
 [source]
 ----
-size_t get_group_id(int dimension) const
+size_t get_group_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_group_id()[dimension]#.
 
 a@
 [source]
 ----
-id<Dimensions> get_local_id() const
+id<Dimensions> get_local_id() const noexcept;
 ----
    a@ Return a SYCL [code]#id# representing the calling work-item's position
       within the <<work-group>>.
@@ -13257,7 +13257,7 @@ a [code]#parallel_for_work_item# context.
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const
+size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_local_id()[dimension]#.
 
@@ -13267,7 +13267,7 @@ a [code]#parallel_for_work_item# context.
 a@
 [source]
 ----
-range<Dimensions> get_local_range() const
+range<Dimensions> get_local_range() const noexcept;
 ----
    a@ Return a SYCL [code]#range# representing all dimensions of the local range.
       This local range may have been provided by the programmer, or chosen by the <<sycl-runtime>>.
@@ -13275,35 +13275,35 @@ range<Dimensions> get_local_range() const
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const
+size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_local_range()[dimension]#.
 
 a@
 [source]
 ----
-range<Dimensions> get_group_range() const
+range<Dimensions> get_group_range() const noexcept;
 ----
    a@ Return a [code]#range# representing the number of <<work-group,work-groups>> in the [code]#nd_range#.
 
 a@
 [source]
 ----
-size_t get_group_range(int dimension) const
+size_t get_group_range(int dimension) const noexcept;
 ----
    a@ Return the same value as [code]#get_group_range()[dimension]#.
 
 a@
 [source]
 ----
-size_t operator[](int dimension) const
+size_t operator[](int dimension) const noexecpt;
 ----
    a@ Return the same value as [code]#get_group_id(dimension)#.
 
 a@
 [source]
 ----
-range<Dimensions> get_max_local_range() const
+range<Dimensions> get_max_local_range() const noexcept;
 ----
    a@ Return a [code]#range# representing the maximum number of work-items in any <<work-group>>
       in the [code]#nd_range#.
@@ -13311,7 +13311,7 @@ range<Dimensions> get_max_local_range() const
 a@
 [source]
 ----
-size_t get_group_linear_id() const
+size_t get_group_linear_id() const noexcept;
 ----
    a@ Get a linearized version of the <<work-group-id>>.
       Calculating a linear <<work-group-id>>
@@ -13320,14 +13320,14 @@ size_t get_group_linear_id() const
 a@
 [source]
 ----
-size_t get_group_linear_range() const
+size_t get_group_linear_range() const noexcept;
 ----
    a@ Return the total number of <<work-group,work-groups>> in the [code]#nd_range#.
 
 a@
 [source]
 ----
-size_t get_local_linear_id() const
+size_t get_local_linear_id() const noexcept;
 ----
    a@ Get a linearized version of the calling work-item's <<local-id>>.
       Calculating a linear <<local-id>>
@@ -13339,14 +13339,14 @@ a [code]#parallel_for_work_item# context.
 a@
 [source]
 ----
-size_t get_local_linear_range() const
+size_t get_local_linear_range() const noexcept;
 ----
    a@ Return the total number of work-items in the <<work-group>>.
 
 a@
 [source]
 ----
-bool leader() const
+bool leader() const noexcept;
 ----
    a@ Return true for exactly one work-item in the <<work-group>>, if the
       calling work-item is the leader of the work-group, and false for all
@@ -13361,7 +13361,7 @@ a@
 [source]
 ----
 template <typename WorkItemFunctionT>
-void parallel_for_work_item(const WorkItemFunctionT& func) const
+void parallel_for_work_item(const WorkItemFunctionT& func) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Launch the work-items for this work-group.
@@ -13385,7 +13385,7 @@ a@
 ----
 template <typename WorkItemFunctionT>
 void parallel_for_work_item(range<Dimensions> logicalRange,
-                            const WorkItemFunctionT& func) const
+                            const WorkItemFunctionT& func) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Launch the work-items for this work-group using a logical local range.
@@ -13414,7 +13414,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
                                    global_ptr<DataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -13427,7 +13427,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
                                    local_ptr<DataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -13440,7 +13440,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(local_ptr<DataT> dest,
                                    global_ptr<DataT> src,
-                                   size_t numElements, size_t srcStride) const
+                                   size_t numElements, size_t srcStride) const noexcept;
 ----
    a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -13453,7 +13453,7 @@ a@
 template <typename DataT>
 device_event async_work_group_copy(global_ptr<DataT> dest,
                                    local_ptr<DataT> src,
-                                   size_t numElements, size_t destStride) const
+                                   size_t numElements, size_t destStride) const noexcept;
 ----
     a@ Deprecated in SYCL 2020.
       Has the same effect as the overload taking [code]#decorated_local_ptr#
@@ -13466,7 +13466,7 @@ a@
 template <typename DestDataT, typename SrcDataT>
 device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                    decorated_local_ptr<SrcDataT> src,
-                                   size_t numElements) const
+                                   size_t numElements) const noexcept;
 ----
    a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -13483,7 +13483,7 @@ a@
 template <typename DestDataT, typename SrcDataT>
 device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                    decorated_global_ptr<SrcDataT> src,
-                                   size_t numElements, size_t srcStride) const
+                                   size_t numElements, size_t srcStride) const noexcept;
 ----
    a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -13500,7 +13500,7 @@ a@
 template <typename DestDataT, SrcDataT>
 device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                    decorated_local_ptr<SrcDataT> src,
-                                   size_t numElements, size_t destStride) const
+                                   size_t numElements, size_t destStride) const noexcept;
 ----
     a@ Available only when: (std::is_same_v<DestDataT,
         std::remove_const_t<SrcDataT>> == true)
@@ -13514,7 +13514,7 @@ destination stride specified by [code]#destStride# and returns a SYCL
 a@
 [source]
 ----
-template <typename... EventTN> void wait_for(EventTN... events) const
+template <typename... EventTN> void wait_for(EventTN... events) const noexcept;
 ----
    a@ Permitted type for [code]#EventTN# is [code]#device_event#.
       Waits for the asynchronous operations associated with each [code]#device_event# to complete.
@@ -13555,7 +13555,7 @@ include::{header_dir}/subgroup.h[lines=4..-1]
 a@
 [source]
 ----
-id<1> get_group_id() const
+id<1> get_group_id() const noexcept;
 ----
    a@ Return an <<id>> representing the index of the sub-group within the
       <<work-group>>.  Since the work-items that compose a sub-group are chosen
@@ -13567,7 +13567,7 @@ id<1> get_group_id() const
 a@
 [source]
 ----
-id<1> get_local_id() const
+id<1> get_local_id() const noexcept;
 ----
    a@ Return a SYCL [code]#id# representing the calling work-item's position
       within the <<sub-group>>.
@@ -13575,7 +13575,7 @@ id<1> get_local_id() const
 a@
 [source]
 ----
-range<1> get_local_range() const
+range<1> get_local_range() const noexcept;
 ----
    a@ Return a [code]#range# representing the size of the <<sub-group>>.
       This size may be less than the value returned by
@@ -13586,7 +13586,7 @@ range<1> get_local_range() const
 a@
 [source]
 ----
-range<1> get_group_range() const
+range<1> get_group_range() const noexcept;
 ----
    a@ Return a [code]#range# representing the number of
       <<sub-group,sub-groups>> in the <<work-group>>.
@@ -13594,7 +13594,7 @@ range<1> get_group_range() const
 a@
 [source]
 ----
-range<1> get_max_local_range() const
+range<1> get_max_local_range() const noexcept;
 ----
    a@ Return a [code]#range# representing the maximum number of work-items
       permitted in a <<sub-group>> for the executing kernel.  This value may
@@ -13604,35 +13604,35 @@ range<1> get_max_local_range() const
 a@
 [source]
 ----
-uint32_t get_group_linear_id() const
+uint32_t get_group_linear_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_group_id()[0]#.
 
 a@
 [source]
 ----
-uint32_t get_group_linear_range() const
+uint32_t get_group_linear_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_group_range()[0]#.
 
 a@
 [source]
 ----
-uint32_t get_local_linear_id() const
+uint32_t get_local_linear_id() const noexcept;
 ----
    a@ Return the same value as [code]#get_local_id()[0]#.
 
 a@
 [source]
 ----
-uint32_t get_local_linear_range() const
+uint32_t get_local_linear_range() const noexcept;
 ----
    a@ Return the same value as [code]#get_local_range()[0]#.
 
 a@
 [source]
 ----
-bool leader() const
+bool leader() const noexcept;
 ----
    a@ Return true for exactly one work-item in the <<sub-group>>, if the
       calling work-item is the leader of the sub-group, and false for all

--- a/adoc/headers/group.h
+++ b/adoc/headers/group.h
@@ -12,101 +12,101 @@ template <int Dimensions = 1> class group {
 
   /* -- common interface members -- */
 
-  id<Dimensions> get_group_id() const;
+  id<Dimensions> get_group_id() const noexcept;
 
-  size_t get_group_id(int dimension) const;
+  size_t get_group_id(int dimension) const noexcept;
 
-  id<Dimensions> get_local_id() const;
+  id<Dimensions> get_local_id() const noexcept;
 
-  size_t get_local_id(int dimension) const;
+  size_t get_local_id(int dimension) const noexcept;
 
-  range<Dimensions> get_local_range() const;
+  range<Dimensions> get_local_range() const noexcept;
 
-  size_t get_local_range(int dimension) const;
+  size_t get_local_range(int dimension) const noexcept;
 
-  range<Dimensions> get_group_range() const;
+  range<Dimensions> get_group_range() const noexcept;
 
-  size_t get_group_range(int dimension) const;
+  size_t get_group_range(int dimension) const noexcept;
 
-  range<Dimensions> get_max_local_range() const;
+  range<Dimensions> get_max_local_range() const noexcept;
 
-  size_t operator[](int dimension) const;
+  size_t operator[](int dimension) const noexcept;
 
-  size_t get_group_linear_id() const;
+  size_t get_group_linear_id() const noexcept;
 
-  size_t get_local_linear_id() const;
+  size_t get_local_linear_id() const noexcept;
 
-  size_t get_group_linear_range() const;
+  size_t get_group_linear_range() const noexcept;
 
-  size_t get_local_linear_range() const;
+  size_t get_local_linear_range() const noexcept;
 
-  bool leader() const;
+  bool leader() const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename WorkItemFunctionT>
-  void parallel_for_work_item(const WorkItemFunctionT& func) const;
+  void parallel_for_work_item(const noexcept WorkItemFunctionT& func) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename WorkItemFunctionT>
   void parallel_for_work_item(range<Dimensions> logicalRange,
-                              const WorkItemFunctionT& func) const;
+                              const noexcept WorkItemFunctionT& func) const noexcept;
 
   // Deprecated in SYCL 2020. 
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
                                      global_ptr<DataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
                                      local_ptr<DataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
                                      global_ptr<DataT> src,
                                      size_t numElements,
-                                     size_t srcStride) const;
+                                     size_t srcStride) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
                                      local_ptr<DataT> src,
                                      size_t numElements,
-                                     size_t destStride) const;
+                                     size_t destStride) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
-       std::remove_const_t<SrcDataT>> == true) */
+       std::remove_const noexcept_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                      decorated_global_ptr<SrcDataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
-       std::remove_const_t<SrcDataT>> == true) */
+       std::remove_const noexcept_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                      decorated_local_ptr<SrcDataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
-       std::remove_const_t<SrcDataT>> == true) */
+       std::remove_const noexcept_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                      decorated_global_ptr<SrcDataT> src,
                                      size_t numElements,
-                                     size_t srcStride) const;
+                                     size_t srcStride) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
-       std::remove_const_t<SrcDataT>> == true) */
+       std::remove_const noexcept_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                      decorated_local_ptr<SrcDataT> src,
                                      size_t numElements,
-                                     size_t destStride) const;
+                                     size_t destStride) const noexcept;
 
-  template <typename... EventTN> void wait_for(EventTN... events) const;
+  template <typename... EventTN> void wait_for(EventTN... events) const noexcept;
 };
 } // namespace sycl

--- a/adoc/headers/hitem.h
+++ b/adoc/headers/hitem.h
@@ -11,44 +11,44 @@ template <int Dimensions> class h_item {
 
   /* -- common interface members -- */
 
-  item<Dimensions, false> get_global() const;
+  item<Dimensions, false> get_global() const noexcept;
 
-  item<Dimensions, false> get_local() const;
+  item<Dimensions, false> get_local() const noexcept;
 
-  item<Dimensions, false> get_logical_local() const;
+  item<Dimensions, false> get_logical_local() const noexcept;
 
-  item<Dimensions, false> get_physical_local() const;
+  item<Dimensions, false> get_physical_local() const noexcept;
 
-  range<Dimensions> get_global_range() const;
+  range<Dimensions> get_global_range() const noexcept;
 
-  size_t get_global_range(int dimension) const;
+  size_t get_global_range(int dimension) const noexcept;
 
-  id<Dimensions> get_global_id() const;
+  id<Dimensions> get_global_id() const noexcept;
 
-  size_t get_global_id(int dimension) const;
+  size_t get_global_id(int dimension) const noexcept;
 
-  range<Dimensions> get_local_range() const;
+  range<Dimensions> get_local_range() const noexcept;
 
-  size_t get_local_range(int dimension) const;
+  size_t get_local_range(int dimension) const noexcept;
 
-  id<Dimensions> get_local_id() const;
+  id<Dimensions> get_local_id() const noexcept;
 
-  size_t get_local_id(int dimension) const;
+  size_t get_local_id(int dimension) const noexcept;
 
-  range<Dimensions> get_logical_local_range() const;
+  range<Dimensions> get_logical_local_range() const noexcept;
 
-  size_t get_logical_local_range(int dimension) const;
+  size_t get_logical_local_range(int dimension) const noexcept;
 
-  id<Dimensions> get_logical_local_id() const;
+  id<Dimensions> get_logical_local_id() const noexcept;
 
-  size_t get_logical_local_id(int dimension) const;
+  size_t get_logical_local_id(int dimension) const noexcept;
 
-  range<Dimensions> get_physical_local_range() const;
+  range<Dimensions> get_physical_local_range() const noexcept;
 
-  size_t get_physical_local_range(int dimension) const;
+  size_t get_physical_local_range(int dimension) const noexcept;
 
-  id<Dimensions> get_physical_local_id() const;
+  id<Dimensions> get_physical_local_id() const noexcept;
 
-  size_t get_physical_local_id(int dimension) const;
+  size_t get_physical_local_id(int dimension) const noexcept;
 };
 } // namespace sycl

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -6,56 +6,56 @@ template <int Dimensions = 1> class id {
  public:
   static constexpr int dimensions = Dimensions;
 
-  id();
+  id() noexcept;
 
   /* The following constructor is only available in the id class
    * specialization where: Dimensions==1 */
-  id(size_t dim0);
+  id(size_t dim0) noexcept;
   /* The following constructor is only available in the id class
    * specialization where: Dimensions==2 */
-  id(size_t dim0, size_t dim1);
+  id(size_t dim0, size_t dim1) noexcept;
   /* The following constructor is only available in the id class
    * specialization where: Dimensions==3 */
-  id(size_t dim0, size_t dim1, size_t dim2);
+  id(size_t dim0, size_t dim1, size_t dim2) noexcept;
 
   /* -- common interface members -- */
 
-  id(const range<Dimensions>& range);
-  id(const item<Dimensions>& item);
+  id(const range<Dimensions>& range) noexcept;
+  id(const item<Dimensions>& item) noexcept;
 
-  size_t get(int dimension) const;
-  size_t& operator[](int dimension);
-  size_t operator[](int dimension) const;
+  size_t get(int dimension) const noexcept;
+  size_t& operator[](int dimension) noexcept;
+  size_t operator[](int dimension) const noexcept;
 
   // only available if Dimensions == 1
-  operator size_t() const;
+  operator size_t() const noexcept;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend id operatorOP(const id& lhs, const id& rhs) { /* ... */
+  friend id operatorOP(const id& lhs, const id& rhs) noexcept { /* ... */
   }
-  friend id operatorOP(const id& lhs, const size_t& rhs) { /* ... */
+  friend id operatorOP(const id& lhs, const size_t& rhs) noexcept { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-  friend id& operatorOP(id& lhs, const id& rhs) { /* ... */
+  friend id& operatorOP(id& lhs, const id& rhs) noexcept { /* ... */
   }
-  friend id& operatorOP(id& lhs, const size_t& rhs) { /* ... */
+  friend id& operatorOP(id& lhs, const size_t& rhs) noexcept { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend id operatorOP(const size_t& lhs, const id& rhs) { /* ... */
+  friend id operatorOP(const size_t& lhs, const id& rhs) noexcept { /* ... */
   }
 
   // OP is unary +, -
-  friend id operatorOP(const id& rhs) { /* ... */
+  friend id operatorOP(const id& rhs) noexcept { /* ... */
   }
 
   // OP is prefix ++, --
-  friend id& operatorOP(id& rhs) { /* ... */
+  friend id& operatorOP(id& rhs) noexcept { /* ... */
   }
 
   // OP is postfix ++, --
-  friend id operatorOP(id& lhs, int) { /* ... */
+  friend id operatorOP(id& lhs, int) noexcept { /* ... */
   }
 };
 

--- a/adoc/headers/item.h
+++ b/adoc/headers/item.h
@@ -10,27 +10,27 @@ template <int Dimensions = 1, bool WithOffset = true> class item {
 
   /* -- common interface members -- */
 
-  id<Dimensions> get_id() const;
+  id<Dimensions> get_id() const noexcept;
 
-  size_t get_id(int dimension) const;
+  size_t get_id(int dimension) const noexcept;
 
-  size_t operator[](int dimension) const;
+  size_t operator[](int dimension) const noexcept;
 
-  range<Dimensions> get_range() const;
+  range<Dimensions> get_range() const noexcept;
 
-  size_t get_range(int dimension) const;
+  size_t get_range(int dimension) const noexcept;
 
   // Deprecated in SYCL 2020.
   // only available if WithOffset is true
-  id<Dimensions> get_offset() const;
+  id<Dimensions> get_offset() const noexcept;
 
   // Deprecated in SYCL 2020.
   // only available if WithOffset is false
-  operator item<Dimensions, true>() const;
+  operator item<Dimensions, true>() const noexcept;
 
   // only available if Dimensions == 1
-  operator size_t() const;
+  operator size_t() const noexcept;
 
-  size_t get_linear_id() const;
+  size_t get_linear_id() const noexcept;
 };
 } // namespace sycl

--- a/adoc/headers/ndRange.h
+++ b/adoc/headers/ndRange.h
@@ -10,11 +10,11 @@ template <int Dimensions = 1> class nd_range {
 
   // The offset is deprecated in SYCL 2020.
   nd_range(range<Dimensions> globalSize, range<Dimensions> localSize,
-           id<Dimensions> offset = id<Dimensions>());
+           id<Dimensions> offset = id<Dimensions>()) noexcept;
 
-  range<Dimensions> get_global_range() const;
-  range<Dimensions> get_local_range() const;
-  range<Dimensions> get_group_range() const;
-  id<Dimensions> get_offset() const; // Deprecated in SYCL 2020.
+  range<Dimensions> get_global_range() const noexcept;
+  range<Dimensions> get_local_range() const noexcept;
+  range<Dimensions> get_group_range() const noexcept;
+  id<Dimensions> get_offset() const noexcept; // Deprecated in SYCL 2020.
 };
 } // namespace sycl

--- a/adoc/headers/nditem.h
+++ b/adoc/headers/nditem.h
@@ -10,82 +10,82 @@ template <int Dimensions = 1> class nd_item {
 
   /* -- common interface members -- */
 
-  id<Dimensions> get_global_id() const;
+  id<Dimensions> get_global_id() const noexcept;
 
-  size_t get_global_id(int dimension) const;
+  size_t get_global_id(int dimension) const noexcept;
 
-  size_t get_global_linear_id() const;
+  size_t get_global_linear_id() const noexcept;
 
-  id<Dimensions> get_local_id() const;
+  id<Dimensions> get_local_id() const noexcept;
 
-  size_t get_local_id(int dimension) const;
+  size_t get_local_id(int dimension) const noexcept;
 
-  size_t get_local_linear_id() const;
+  size_t get_local_linear_id() const noexcept;
 
-  group<Dimensions> get_group() const;
+  group<Dimensions> get_group() const noexcept;
 
-  sub_group get_sub_group() const;
+  sub_group get_sub_group() const noexcept;
 
-  size_t get_group(int dimension) const;
+  size_t get_group(int dimension) const noexcept;
 
-  size_t get_group_linear_id() const;
+  size_t get_group_linear_id() const noexcept;
 
-  range<Dimensions> get_group_range() const;
+  range<Dimensions> get_group_range() const noexcept;
 
-  size_t get_group_range(int dimension) const;
+  size_t get_group_range(int dimension) const noexcept;
 
-  range<Dimensions> get_global_range() const;
+  range<Dimensions> get_global_range() const noexcept;
 
-  size_t get_global_range(int dimension) const;
+  size_t get_global_range(int dimension) const noexcept;
 
-  range<Dimensions> get_local_range() const;
+  range<Dimensions> get_local_range() const noexcept;
 
-  size_t get_local_range(int dimension) const;
+  size_t get_local_range(int dimension) const noexcept;
 
   // Deprecated in SYCL 2020.
-  id<Dimensions> get_offset() const;
+  id<Dimensions> get_offset() const noexcept;
 
-  nd_range<Dimensions> get_nd_range() const;
+  nd_range<Dimensions> get_nd_range() const noexcept;
 
   // Deprecated in SYCL 2020. 
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
                                      global_ptr<DataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
                                      local_ptr<DataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(local_ptr<DataT> dest,
                                      global_ptr<DataT> src,
                                      size_t numElements,
-                                     size_t srcStride) const;
+                                     size_t srcStride) const noexcept;
 
   // Deprecated in SYCL 2020.
   template <typename DataT>
   device_event async_work_group_copy(global_ptr<DataT> dest,
                                      local_ptr<DataT> src,
                                      size_t numElements,
-                                     size_t destStride) const;
+                                     size_t destStride) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
        std::remove_const_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                      decorated_global_ptr<SrcDataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
        std::remove_const_t<SrcDataT>> == true) */
   template <typename DestDataT, typename SrcDataT>
   device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                      decorated_local_ptr<SrcDataT> src,
-                                     size_t numElements) const;
+                                     size_t numElements) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
        std::remove_const_t<SrcDataT>> == true) */
@@ -93,7 +93,7 @@ template <int Dimensions = 1> class nd_item {
   device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
                                      decorated_global_ptr<SrcDataT> src,
                                      size_t numElements,
-                                     size_t srcStride) const;
+                                     size_t srcStride) const noexcept;
 
   /* Available only when: (std::is_same_v<DestDataT,
        std::remove_const_t<SrcDataT>> == true) */
@@ -101,8 +101,8 @@ template <int Dimensions = 1> class nd_item {
   device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
                                      decorated_local_ptr<SrcDataT> src,
                                      size_t numElements,
-                                     size_t destStride) const;
+                                     size_t destStride) const noexcept;
 
-  template <typename... EventTN> void wait_for(EventTN... events) const;
+  template <typename... EventTN> void wait_for(EventTN... events) const noexcept;
 };
 } // namespace sycl

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -6,52 +6,52 @@ template <int Dimensions = 1> class range {
  public:
   static constexpr int dimensions = Dimensions;
 
-  range();
+  range() noexcept;
 
   /* The following constructor is only available in the range class
    * specialization where: Dimensions==1 */
-  range(size_t dim0);
+  range(size_t dim0) noexcept;
   /* The following constructor is only available in the range class
    * specialization where: Dimensions==2 */
-  range(size_t dim0, size_t dim1);
+  range(size_t dim0, size_t dim1) noexcept;
   /* The following constructor is only available in the range class
    * specialization where: Dimensions==3 */
-  range(size_t dim0, size_t dim1, size_t dim2);
+  range(size_t dim0, size_t dim1, size_t dim2) noexcept;
 
   /* -- common interface members -- */
 
-  size_t get(int dimension) const;
-  size_t& operator[](int dimension);
-  size_t operator[](int dimension) const;
+  size_t get(int dimension) const noexcept;
+  size_t& operator[](int dimension) noexcept;
+  size_t operator[](int dimension) const noexcept;
 
-  size_t size() const;
+  size_t size() const noexcept;
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const range& lhs, const range& rhs) { /* ... */
+  friend range operatorOP(const range& lhs, const range& rhs) noexcept { /* ... */
   }
-  friend range operatorOP(const range& lhs, const size_t& rhs) { /* ... */
+  friend range operatorOP(const range& lhs, const size_t& rhs) noexcept { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-  friend range& operatorOP(range& lhs, const range& rhs) { /* ... */
+  friend range& operatorOP(range& lhs, const range& rhs) noexcept { /* ... */
   }
-  friend range& operatorOP(range& lhs, const size_t& rhs) { /* ... */
+  friend range& operatorOP(range& lhs, const size_t& rhs) noexcept { /* ... */
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const size_t& lhs, const range& rhs) { /* ... */
+  friend range operatorOP(const size_t& lhs, const range& rhs) noexcept { /* ... */
   }
 
   // OP is unary +, -
-  friend range operatorOP(const range& rhs) { /* ... */
+  friend range operatorOP(const range& rhs) noexcept { /* ... */
   }
 
   // OP is prefix ++, --
-  friend range& operatorOP(range& rhs) { /* ... */
+  friend range& operatorOP(range& rhs) noexcept { /* ... */
   }
 
   // OP is postfix ++, --
-  friend range operatorOP(range& lhs, int) { /* ... */
+  friend range operatorOP(range& lhs, int) noexcept { /* ... */
   }
 };
 

--- a/adoc/headers/subgroup.h
+++ b/adoc/headers/subgroup.h
@@ -12,24 +12,24 @@ class sub_group {
 
   /* -- common interface members -- */
 
-  id<1> get_group_id() const;
+  id<1> get_group_id() const noexcept;
 
-  id<1> get_local_id() const;
+  id<1> get_local_id() const noexcept;
 
-  range<1> get_local_range() const;
+  range<1> get_local_range() const noexcept;
 
-  range<1> get_group_range() const;
+  range<1> get_group_range() const noexcept;
 
-  range<1> get_max_local_range() const;
+  range<1> get_max_local_range() const noexcept;
 
-  uint32_t get_group_linear_id() const;
+  uint32_t get_group_linear_id() const noexcept;
 
-  uint32_t get_local_linear_id() const;
+  uint32_t get_local_linear_id() const noexcept;
 
-  uint32_t get_group_linear_range() const;
+  uint32_t get_group_linear_range() const noexcept;
 
-  uint32_t get_local_linear_range() const;
+  uint32_t get_local_linear_range() const noexcept;
 
-  bool leader() const;
+  bool leader() const noexcept;
 };
 } // namespace sycl


### PR DESCRIPTION
Classes like `id`, `range`, `group` and `sub_group` are used predominantly inside of device code where exceptions are not supported. Over time we have slowly gotten better at marking functions like these `noexcept`, and the equivalents of these functions are already marked `noexcept` in various places (e.g., KHR extensions).

Closes #626.