### PR TITLE
Explicitly delete handler move/copy constructors

### DIFF
--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -9,6 +9,12 @@ class handler {
   handler(___unspecified___);
 
  public:
+  // A handler cannot be moved or copied.
+  handler(const handler&) = delete;
+  handler(handler&&) = delete;
+  handler& operator=(const handler&) = delete;
+  handler& operator=(handler&&) = delete;
+
   template <typename DataT, int Dimensions, access_mode AccessMode,
             target AccessTarget, access::placeholder IsPlaceholder>
   void require(


### PR DESCRIPTION
Previously we said in words that a handler could not be moved or copied, but it was unclear whether this meant that it should be forbidden by the class implementation or simply resulted in undefined behavior.

This change explicitly deletes the handler move and copy constructors, making it clear that it is the implementation's responsibility to prevent a handler from being moved or copied.

Closes #807.