### PR TITLE
Clarify synchronization behavior of sycl::free

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11838,6 +11838,10 @@ _Effects_: Causes the memory pointed to by [code]#ptr# to be deallocated.
 Applications should not rely on [code]#free# for synchronization, nor assume
 that [code]#free# cannot cause deadlocks.{endnote}
 
+_Synchronization_: A call to [code]#free# that deallocates a region of memory
+synchronizes with any allocation call that allocates all or part of the same
+region of memory.
+
 _Remarks_: If [code]#ptr# is null, this function has no effect.
 
 *Overload (2):*


### PR DESCRIPTION
`sycl::free` should have the same synchronization behavior as `std::free`, which
is defined in C99 as synchronizing with any allocation function that allocates
the same memory region.

Closes #687. 