### PR TITLE
Clarify work-item scope atomics (and memory model in general)

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1096,14 +1096,23 @@ programming and to provide a meaningful way to describe the behavior of
 <<group,groups>> containing a single work-item.
 {endnote}
 
-Potentially concurrent conflicting actions with different memory scopes are
-considered a data race, resulting in undefined behavior.
+Potentially concurrent conflicting actions with different memory scopes may lead
+to a data race, resulting in undefined behavior.
+An atomic operation _A_ with scope _S~1~_ operating on the same memory location
+as atomic operation _B_ with scope _S~2~_ is a data race if:
+
+* The work-items which executed _A_ and _B_ are not both in the same group of
+ work-items associated with scope _S~1~_; or
+* The work-items which executed _A_ and _B_ are not both in the same group of
+ work-items associated with scope _S~2~_.
 
 An atomic operation _A_ with scope _S~1~_ can only synchronize with another
 atomic operation _B_ with scope _S~2~_ if:
 
-* The work-item which executed _A_ is in both _S~1~_ and _S~2~_; and
-* The work-item which executed _B_ is in both _S~1~_ and _S~2~_.
+* The work-items which executed _A_ and _B_ are both in the same group of
+  work-items associated with scope _S~1~_; and
+* The work-items which executed _A_ and _B_ are both in the same group of
+  work-items associated with scope _S~2~_.
 
 The memory scopes are listed above from narrowest
 ([code]#memory_scope::work_item#) to widest ([code]#memory_scope::system#).

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1099,6 +1099,12 @@ programming and to provide a meaningful way to describe the behavior of
 Potentially concurrent conflicting actions with different memory scopes are
 considered a data race, resulting in undefined behavior.
 
+An atomic operation _A_ with scope _S~1~_ can only synchronize with another
+atomic operation _B_ with scope _S~2~_ if:
+
+* The work-item which executed _A_ is in both _S~1~_ and _S~2~_; and
+* The work-item which executed _B_ is in both _S~1~_ and _S~2~_.
+
 The memory scopes are listed above from narrowest
 ([code]#memory_scope::work_item#) to widest ([code]#memory_scope::system#).
 
@@ -1119,10 +1125,9 @@ supplied.
 ====
 The addition of memory scopes to the {cpp} memory model modifies the definition
 of some concepts from the {cpp} core language.
-For example: the synchronizes-with relationship and sequential consistency must
-be defined in a way that accounts for atomic operations with differing (but
-compatible) scopes, in a manner similar to the <<opencl20, OpenCL 2.0
-specification>>.
+For example: sequential consistency must be defined in a way that accounts for
+atomic operations with differing (but compatible) scopes, in a manner similar to
+the <<opencl20, OpenCL 2.0 specification>>.
 Efforts to formalize the memory model of SYCL are ongoing, and a formal memory
 model will be included in a future version of the SYCL specification.
 ====

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1096,6 +1096,9 @@ programming and to provide a meaningful way to describe the behavior of
 <<group,groups>> containing a single work-item.
 {endnote}
 
+Potentially concurrent conflicting actions with different memory scopes are
+considered a data race, resulting in undefined behavior.
+
 The memory scopes are listed above from narrowest
 ([code]#memory_scope::work_item#) to widest ([code]#memory_scope::system#).
 
@@ -1116,10 +1119,10 @@ supplied.
 ====
 The addition of memory scopes to the {cpp} memory model modifies the definition
 of some concepts from the {cpp} core language.
-For example: data races, the synchronizes-with relationship and sequential
-consistency must be defined in a way that accounts for atomic operations with
-differing (but compatible) scopes, in a manner similar to the <<opencl20, OpenCL
-2.0 specification>>.
+For example: the synchronizes-with relationship and sequential consistency must
+be defined in a way that accounts for atomic operations with differing (but
+compatible) scopes, in a manner similar to the <<opencl20, OpenCL 2.0
+specification>>.
 Efforts to formalize the memory model of SYCL are ongoing, and a formal memory
 model will be included in a future version of the SYCL specification.
 ====

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1089,6 +1089,13 @@ values:
     the memory allocation containing the referenced object, as defined by the
     capabilities of <<buffer,buffers>> and <<usm>>.
 
+{note}An atomic operation with work-item scope is effectively the same as a
+non-atomic operation.
+[code]#sycl::memory_scope::work_item# is primarily intended to simplify generic
+programming and to provide a meaningful way to describe the behavior of
+<<group,groups>> containing a single work-item.
+{endnote}
+
 The memory scopes are listed above from narrowest
 ([code]#memory_scope::work_item#) to widest ([code]#memory_scope::system#).
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20340,6 +20340,10 @@ scope for the atomic operations.
 Most member functions also provide an optional parameter that allows the
 application to override this default.
 
+All accesses to an object referenced by an [code]#sycl::atomic_ref# must
+exclusively occur through instances of an [code]#sycl::atomic_ref# with the same
+[code]#DefaultScope#.
+
 The [code]#sycl::atomic_ref# class also has a template parameter
 [code]#AddressSpace#, which allows the application to make an assertion about
 the address space of the object of type [code]#T# that it references.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20340,10 +20340,6 @@ scope for the atomic operations.
 Most member functions also provide an optional parameter that allows the
 application to override this default.
 
-All accesses to an object referenced by an [code]#sycl::atomic_ref# must
-exclusively occur through instances of an [code]#sycl::atomic_ref# with the same
-[code]#DefaultScope#.
-
 The [code]#sycl::atomic_ref# class also has a template parameter
 [code]#AddressSpace#, which allows the application to make an assertion about
 the address space of the object of type [code]#T# that it references.


### PR DESCRIPTION
This started as an attempt just to clarify work-item scope atomics, but I think the fix has ended up addressing some broader long-standing issues with the memory model.

I think figuring out the steps that a SYCL application needs to take to guarantee "sequential consistency" is the only remaining open in the memory model, and I'm afraid to touch it. 😆 

Closes #665.