### PR TITLE
Clarify accumulator type for reductions and scans

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -22371,6 +22371,10 @@ _Returns:_ The result of combining the values resulting from dereferencing all
 pointers in the range [code]#[first, last)# using the operator
 [code]#binary_op#, where the values are combined according to the generalized
 sum defined in standard {cpp}.
+
+_Remarks:_ Intermediate results are stored as objects of type
+[code]#std::iterator_traits<Ptr>::value_type#.
+
 --
 
   . _Constraints:_ Available only if
@@ -22398,6 +22402,8 @@ _Returns:_ The result of combining the values resulting from dereferencing all
 pointers in the range [code]#[first, last)# and the initial value [code]#init#
 using the operator [code]#binary_op#, where the values are combined according to
 the generalized sum defined in standard {cpp}.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22421,6 +22427,8 @@ same synchronization point is unblocked.
 _Returns:_ The result of combining all the values of [code]#x# specified by each
 work-item in group [code]#g# using the operator [code]#binary_op#, where the
 values are combined according to the generalized sum defined in standard {cpp}.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22446,6 +22454,8 @@ _Returns:_ The result of combining all the values of [code]#x# specified by each
 work-item in group [code]#g# and the initial value [code]#init# using the
 operator [code]#binary_op#, where the values are combined according to the
 generalized sum defined in standard {cpp}.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
 ==== [code]#exclusive_scan# and [code]#inclusive_scan#
@@ -22514,6 +22524,9 @@ The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
+
+_Remarks:_ Intermediate results are stored as objects of type
+[code]#std::iterator_traits<OutPtr>::value_type#.
 --
 
   . _Constraints:_ Available only if
@@ -22551,6 +22564,8 @@ The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22580,6 +22595,8 @@ The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 For multi-dimensional groups, the order of work-items in group [code]#g# is
 determined by their linear id.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22608,6 +22625,8 @@ The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 For multi-dimensional groups, the order of work-items in group [code]#g# is
 determined by their linear id.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
 [source,,linenums]
@@ -22648,6 +22667,9 @@ The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
+
+_Remarks:_ Intermediate results are stored as objects of type
+[code]#std::iterator_traits<OutPtr>::value_type#.
 --
 
   . _Constraints:_ Available only if
@@ -22685,6 +22707,8 @@ The completion of the algorithm happens before any work-item blocking on the
 same synchronization point is unblocked.
 
 _Returns:_ A pointer to the end of the output range.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22712,6 +22736,8 @@ The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 For multi-dimensional groups, the order of work-items in group [code]#g# is
 determined by their linear id.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
   . _Constraints:_ Available only if
@@ -22740,6 +22766,8 @@ The scan is computed using a generalized noncommutative sum as defined in
 standard {cpp}.
 For multi-dimensional groups, the order of work-items in group [code]#g# is
 determined by their linear id.
+
+_Remarks:_ Intermediate results are stored as objects of type [code]#T#.
 --
 
 


### PR DESCRIPTION
Previously we said that the binary operator must return a value of a specific type, but were not explicit that this type should also be used to accumulate partial results.

Closes #342.