### PR TITLE
Add `host_task` to handler synopsis

### DIFF
--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -130,5 +130,9 @@ class handler {
   template <auto& SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant();
+
+  template <typename T>
+  void host_task(T&& hostTaskCallable);
+
 };
 } // namespace sycl


### PR DESCRIPTION
`host_task` is unconditionally available via `handler` and should be listed in the handler synopsis.

Rewriting the specification such that `host_task` is described alongside other handler functions would be a large change that would renumber sections, and should be postponed until SYCL-Next.

Closes #843.