### PR TITLE
Clarify that the CL/sycl.hpp header is deprecated

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -91,6 +91,7 @@ For compatibility with SYCL 1.2.1, SYCL provides another standard header file:
 [code]#<sycl/sycl.hpp>#.
 In that case, all SYCL classes, constants, types and functions defined by this
 specification should exist within the [code]#::cl::sycl# {cpp} namespace.
+The [code]#<CL/sycl.hpp># header is deprecated.
 
 For consistency, the programming API will only refer to the
 [code]#<sycl/sycl.hpp># header and the [code]#::sycl# namespace, but this should


### PR DESCRIPTION
This header was retained only for backwards compatibility.

Other backwards-compatibility-only interfaces in the specification are deprecated, and this one was missed.

Closes #137.

---

@gmlueck - I've marked this editorial because it obviously won't require CTS changes. I defer to you regarding whether it requires discussion in a WG meeting, or if the discussion in #137 is sufficient.

FWIW, DPC++ already says this header is deprecated. AdaptiveCpp does not (as far as I can tell).