### PR TITLE
Clarify that fp16 and fp64 aspects affect pointers

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3388,7 +3388,7 @@ The precise definition of this aspect is left open to the SYCL implementation.
 [role=synopsis,id=api:aspect-fp16]
 --
 Indicates that kernels submitted to the device may use the [code]#sycl::half#
-data type.
+data type and pointers to [code]#sycl::half#.
 --
 
 '''
@@ -3397,7 +3397,7 @@ data type.
 [role=synopsis,id=api:aspect-fp64]
 --
 Indicates that kernels submitted to the device may use the [code]#double# data
-type.
+type and pointers to [code]#double#.
 --
 
 '''


### PR DESCRIPTION
The SYCL-CTS was previously modified to run tests requiring `double*` (and `atomic_ref<double*>`) only on devices with the `fp64` aspect. This change updates the specification to reflect the WG's decision.

Closes #526.