### PR TITLE
Add new requirements for sub-group sizes

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1248,10 +1248,9 @@ single sub-group of size 6.{endnote}
 
 The numbering of work-items in a sub-group reflects the linear numbering of the
 work-items in the work-group.
-Specifically, if a work-item has a linear ID latexmath:[i_s] in the sub-group
-and a linear ID latexmath:[i_w] in the work-group, the work-item with linear ID
-latexmath:[i_s+1] in the sub-group has linear ID latexmath:[i_w+1] in the
-work-group.
+Specifically, if a work-item has a linear ID i~s~ in the sub-group and a linear
+ID i~w~ in the work-group, the work-item with linear ID i~s~+1 in the sub-group
+has linear ID i~w~+1 in the work-group.
 
 Similarly to work-groups, the [code]#group_barrier# function can be used to
 block a work-item until all work-items in the same sub-group arrive at the


### PR DESCRIPTION
Since the introduction of SYCL 2020 there have been multiple requests from developers and implementers to provide more detail about how sub-groups are expected to work.

This change is a first step towards more portable sub-groups, by ensuring that sub-group behavior is well-defined in cases where the highest-numbered dimension of a work-group is divisible by the sub-group size. Dividing the highest-numbered dimension into sub-groups is the obvious thing to do in this case, and matches the behavior of existing implementations.

The way in which other work-groups are divided into sub-groups remains implementation-defined, but this change introduces a non-normative note to hint at possible implementation choices. Eventually we may want to consider exposing these choices via device queries or similar, and implementations are exploring this via extensions.

Closes #193.

---

Although I don't think this would break any implementations, I've positioned it as a SYCL-Next feature rather than a SYCL 2020 clarification to be on the safe side.  I think it's important that we do this, but I'm willing to wait for SYCL-Next.