### PR TITLE
Clarify `device_type` and `get_devices()` functions

### DIFF
--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -158,6 +158,22 @@ properties as described in the table below:
 | [code]#info::device::version#        | [code]#CL_DEVICE_VERSION#
 |====
 
+Additionally, several values of the [code]#device_type# enumeration map directly
+to OpenCL:
+
+[[table.opencl.device_type]]
+.Mapping of SYCL [code]#device_type# enumeration to OpenCL
+[width="40%",options="header",cols="50%,50%"]
+|====
+| SYCL | OpenCL
+| [code]#device_type::cpu#  | [code]#CL_DEVICE_TYPE_CPU#
+| [code]#device_type::gpu#  | [code]#CL_DEVICE_TYPE_GPU#
+| [code]#device_type::accelerator#  | [code]#CL_DEVICE_TYPE_ACCELERATOR#
+| [code]#device_type::custom#  | [code]#CL_DEVICE_TYPE_CUSTOM#
+| [code]#device_type::automatic#  | [code]#CL_DEVICE_TYPE_DEFAULT#
+| [code]#device_type::all#  | [code]#CL_DEVICE_TYPE_ALL#
+|====
+
 === OpenCL memory model
 
 The memory model for SYCL devices running on OpenCL platforms follows the memory

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3608,7 +3608,7 @@ enum class device_type : /* unspecified */ {
   accelerator,
   custom,
   automatic,
-  host,
+  host, // Deprecated
   all
 };
 } // namespace sycl::info

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1130,7 +1130,7 @@ devices>> associated with this platform which have the device type specified by
 [code]#type#.
 
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
-[code]#std::vector# contains all devices of any type.
+[code]#std::vector# contains all root devices in this platform.
 If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
 contains a single device corresponding to an implementation-defined default
 device for this platform.
@@ -1851,7 +1851,7 @@ devices>> from all <<backend, SYCL backends>> available in the system which have
 the device type [code]#type#.
 
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
-[code]#std::vector# contains all devices of any type.
+[code]#std::vector# contains all root devices in the system.
 If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
 contains one device from each platform, corresponding to the device returned by
 [code]#platform::get_devices(info::device_type::automatic)#.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1129,6 +1129,10 @@ _Returns:_ A [code]#std::vector# containing all of the <<root-device,root
 devices>> associated with this platform which have the device type specified by
 [code]#type#.
 
+{note}Since the concept of a "host device" does not exist in SYCL 2020, if
+[code]#type# is [code]#info::device_type::host# this function will always return
+an empty vector.{endnote}
+
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
 [code]#std::vector# contains all root devices in this platform.
 If [code]#type# is [code]#info::device_type::automatic# and the platform is not
@@ -1850,6 +1854,10 @@ get_devices(info::device_type type = info::device_type::all)
 _Returns:_ A [code]#std::vector# containing all the <<root-device, root
 devices>> from all <<backend, SYCL backends>> available in the system which have
 the device type [code]#type#.
+
+{note}Since the concept of a "host device" does not exist in SYCL 2020, if
+[code]#type# is [code]#info::device_type::host# this function will always return
+an empty vector.{endnote}
 
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
 [code]#std::vector# contains all root devices in the system.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1870,7 +1870,8 @@ struct device_type {
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ The device type associated with the device.
-May not return [api]#info::device_type::all#.
+May not return [code]#info::device_type::all# or
+[code]#info::device_type::automatic#.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3630,7 +3630,7 @@ enum class device_type : /* unspecified */ {
   accelerator,
   custom,
   automatic,
-  host, // Deprecated
+  host, // Deprecated by SYCL 2020
   all
 };
 } // namespace sycl::info

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1129,6 +1129,12 @@ _Returns:_ A [code]#std::vector# containing all of the <<root-device,root
 devices>> associated with this platform which have the device type specified by
 [code]#type#.
 
+_Remarks_: If [code]#type# is [code]#info::device_type::all#, the
+[code]#std::vector# contains all devices of any type.
+If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
+contains a single device corresponding to an implementation-defined default
+device for this platform.
+
 '''
 
 [[sec:platform-static-member-funcs]]
@@ -1843,6 +1849,12 @@ get_devices(info::device_type type = info::device_type::all)
 _Returns:_ A [code]#std::vector# containing all the <<root-device, root
 devices>> from all <<backend, SYCL backends>> available in the system which have
 the device type [code]#type#.
+
+_Remarks_: If [code]#type# is [code]#info::device_type::all#, the
+[code]#std::vector# contains all devices of any type.
+If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
+contains one device from each platform, corresponding to the device returned by
+[code]#platform::get_devices(info::device_type::automatic)#.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1131,9 +1131,10 @@ devices>> associated with this platform which have the device type specified by
 
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
 [code]#std::vector# contains all root devices in this platform.
-If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
-contains a single device corresponding to an implementation-defined default
-device for this platform.
+If [code]#type# is [code]#info::device_type::automatic# and the platform is not
+empty, the [code]#std::vector# contains a single root device corresponding to an
+implementation-defined default device for this platform.
+If the platform is empty, any call to this function returns an empty vector.
 
 '''
 
@@ -1853,8 +1854,8 @@ the device type [code]#type#.
 _Remarks_: If [code]#type# is [code]#info::device_type::all#, the
 [code]#std::vector# contains all root devices in the system.
 If [code]#type# is [code]#info::device_type::automatic#, the [code]#std::vector#
-contains one device from each platform, corresponding to the device returned by
-[code]#platform::get_devices(info::device_type::automatic)#.
+contains one root device from each non-empty platform, corresponding to the
+device returned by [code]#platform::get_devices(info::device_type::automatic)#.
 
 '''
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -3603,13 +3603,13 @@ application will not be able to submit kernels to that device _D_.
 ----
 namespace sycl::info {
 enum class device_type : /* unspecified */ {
-  cpu,         // Maps to OpenCL CL_DEVICE_TYPE_CPU
-  gpu,         // Maps to OpenCL CL_DEVICE_TYPE_GPU
-  accelerator, // Maps to OpenCL CL_DEVICE_TYPE_ACCELERATOR
-  custom,      // Maps to OpenCL CL_DEVICE_TYPE_CUSTOM
-  automatic,   // Maps to OpenCL CL_DEVICE_TYPE_DEFAULT
+  cpu,
+  gpu,
+  accelerator,
+  custom,
+  automatic,
   host,
-  all // Maps to OpenCL CL_DEVICE_TYPE_ALL
+  all
 };
 } // namespace sycl::info
 ----

--- a/adoc/headers/deviceInfo.h
+++ b/adoc/headers/deviceInfo.h
@@ -94,7 +94,7 @@ enum class device_type : /* unspecified */ {
   accelerator,
   custom,
   automatic,
-  host,
+  host, // Deprecated
   all
 };
 

--- a/adoc/headers/deviceInfo.h
+++ b/adoc/headers/deviceInfo.h
@@ -89,13 +89,13 @@ struct partition_type_affinity_domain;
 } // namespace device
 
 enum class device_type : /* unspecified */ {
-  cpu,         // Maps to OpenCL CL_DEVICE_TYPE_CPU
-  gpu,         // Maps to OpenCL CL_DEVICE_TYPE_GPU
-  accelerator, // Maps to OpenCL CL_DEVICE_TYPE_ACCELERATOR
-  custom,      // Maps to OpenCL CL_DEVICE_TYPE_CUSTOM
-  automatic,   // Maps to OpenCL CL_DEVICE_TYPE_DEFAULT
+  cpu,
+  gpu,
+  accelerator,
+  custom,
+  automatic,
   host,
-  all // Maps to OpenCL CL_DEVICE_TYPE_ALL
+  all
 };
 
 enum class partition_property : /* unspecified */ {


### PR DESCRIPTION
This pull request makes a couple of changes, all related to clarifying `device_type` and the `device::get_devices()` and `platform::get_devices()` functions.  Specifically:

- Move the mapping between `device_type` and `CL_DEVICE_TYPE` into the OpenCL backend specification.
- Deprecate `device_type::host`, because it has no meaning in SYCL 2020.
- Clarify that a device cannot identify itself as an "automatic" device, just like how it cannot be an "all" device.
- Clarify that `get_devices(automatic)` is intended to return some sort of "default" device.

Closes #771. 

---

It wasn't clear what the difference between `platform::get_devices(device_type::automatic)` and `devices::get_devices(device_type::automatic)` should be from the original wording, but I think what I've proposed here makes sense.

In OpenCL, `clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, ...)` returns a per-platform default device, and so it seems pretty likely that the original intent was for `platform::get_devices(device_type::automatic)` to have equivalent behavior.

Given that per-platform behavior, it seems logical that `devices::get_devices(device_type::automatic)` should return the list of all per-platform default devices, instead of just a single device.