### PR TITLE
Clarify effect of using accessors outside commands

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -7890,7 +7890,7 @@ even if this is a <<ranged-accessor>> whose range does not start at the
 beginning of the buffer.  The return value is unspecified if the accessor is
 empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 Deprecated in SYCL 2020.  Use [code]#get_multi_ptr# instead.
 
@@ -7905,7 +7905,7 @@ Returns a pointer to the start of this accessor's underlying buffer, even if
 this is a <<ranged-accessor>> whose range does not start at the beginning of
 the buffer.  The return value is unspecified if the accessor is empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -7920,7 +7920,7 @@ even if this is a <<ranged-accessor>> whose range does not start at the
 beginning of the buffer.  The return value is unspecified if the accessor is
 empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -7933,7 +7933,7 @@ const accessor& operator=(const value_type& other) const
 
 Assignment to the single element that is accessed by this accessor.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -7946,7 +7946,7 @@ const accessor& operator=(value_type&& other) const
 
 Assignment to the single element that is accessed by this accessor.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 |====
 
@@ -8303,7 +8303,7 @@ constant_ptr<DataT> get_pointer() const noexcept
       at the beginning of the buffer.  The return value is unspecified if the
       accessor is empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 |====
 
@@ -8538,7 +8538,7 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -8553,7 +8553,7 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing, at the index specified by [code]#index#.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -8567,7 +8567,7 @@ Returns an instance of [code]#atomic# of type [code]#DataT# providing atomic
 access to the element stored within the work-group's local memory allocation
 that this accessor is accessing, at the index specified by [code]#index#.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -8578,7 +8578,7 @@ local_ptr<DataT> get_pointer() const noexcept
       that this accessor is accessing.  The return value is unspecified if the
       accessor is empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 |====
 
@@ -9259,7 +9259,7 @@ local_ptr<value_type> get_pointer() const noexcept
       region which corresponds to the calling work-group. The return value is
       unspecified if the accessor is empty.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 Deprecated in SYCL 2020.  Use [code]#get_multi_ptr# instead.
 
@@ -9285,7 +9285,7 @@ const local_accessor& operator=(const value_type& other) const
 
 Assignment to the single element that is accessed by this accessor.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 a@
 [source]
@@ -9296,7 +9296,7 @@ const local_accessor& operator=(const value_type&& other) const
 
 Assignment to the single element that is accessed by this accessor.
 
-This function may only be called from within a <<command>>.
+_Preconditions_: Must be called within a <<command>>.
 
 |====
 


### PR DESCRIPTION
The previous wording said that certain accessor member functions may only be called from within a command, but did not say what should happen if this condition was violated.

The new wording clarifies that this results in undefined behavior, giving different implementations the freedom to decide how to diagnose this error.

Closes #580.

---

Note that #580 was originally focused on just `accessor::get_pointer()` and `accessor::get_multi_ptr()`. While working on the new wording, I realized that the same problem existed for multiple `accessor` member functions, and applied the same fix everywhere.