### PR TITLE
Remove "default" from common by-value semantics

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -452,14 +452,14 @@ Each of the following <<sycl-runtime>> classes: [code]#id#, [code]#range#,
 and [code]#nd_range# must follow the following statements, where [code]#T# is
 the runtime class type:
 
-  * [code]#T# must be default copy constructible and copy assignable in the host
+  * [code]#T# must be copy constructible and copy assignable in the host
     application (in the case where [code]#T# is available on the host) and
     within SYCL kernel functions.
-  * [code]#T# must be default destructible in the host application (in the case
-    where [code]#T# is available on the host) and within SYCL kernel functions.
-  * [code]#T# must be default move constructible and default move assignable in
-    the host application (in the case where [code]#T# is available on the host)
-    and within SYCL kernel functions.
+  * [code]#T# must be destructible in the host application (in the case where
+    [code]#T# is available on the host) and within SYCL kernel functions.
+  * [code]#T# must be move constructible and move assignable in the host
+    application (in the case where [code]#T# is available on the host) and
+    within SYCL kernel functions.
   * [code]#T# must be equality comparable in the host application (in the case
     where [code]#T# is available on the host) and within SYCL kernel functions.
     Equality between two instances of [code]#T# (i.e. [code]#a == b#) must be


### PR DESCRIPTION
This wording was introduced alongside a version of common-byval.h that showed each of these member functions declared using "= default". A later change updated the declarations in the header but did not remove the word "default" from the corresponding descriptive text.

Closes #210.

---

The original wording was introduced in https://github.com/KhronosGroup/SYCL-Docs/commit/2e3b42c717a49595f5fbfecff07537d3bffc888e.  The "= default" was removed in fb07ac22.