### PR TITLE
Update to the latest Docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,8 +28,8 @@ jobs:
     # Use the Khronos container with the asciidoctor toolchain preinstalled.  We
     # reference the image by its SHA rather than its tag because they sometimes
     # overwrite a tag with a different image (which has a different SHA).  This
-    # SHA corresponds to tag "asciidoctor-spec.20250210".
-    container: khronosgroup/docker-images@sha256:9f5add2758a383ba329bc8c4b819dea9fb695ee629b05b7da4739ddf81d39073
+    # SHA corresponds to tag "asciidoctor-spec.20250629".
+    container: khronosgroup/docker-images@sha256:0f91e60e1af2bdd889783af3907f63279c08f573f2eccbc31094e348d1a32a4f
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This docker image creates a slightly different HTML render vs. the previous one.  It appears that the rouge source code highligher styles floating point constants slightly differntly in source code listings. In a constant like "42.0f", the "f" is now in a different CSS class. Theoretically, that should cause it to have a different font or color or something, but I can't detect any difference from looking at the web page.

There is no difference in the PDF render.