### PR TITLE
Deprecate the `half_precision::` namespace

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -25804,7 +25804,7 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 '''
 
 
-=== Half precision math functions
+=== Half precision math functions (deprecated)
 
 This section describes the half precision math functions that are available in
 the [code]#sycl::half_precision# namespace in both host and device code.
@@ -25826,9 +25826,9 @@ description.
 .[apidef]#half_precision::cos#
 [source,role=synopsis,id=api:half-cos]
 ----
-float cos(float x)                (1)
+float cos(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ cos(NonScalar x)
 ----
 
@@ -25860,9 +25860,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::divide#
 [source,role=synopsis,id=api:half-divide]
 ----
-float divide(float x, float y)                      (1)
+float divide(float x, float y)                      (1) /* deprecated */
 
-template<typename NonScalar1, typename NonScalar2>  (2)
+template<typename NonScalar1, typename NonScalar2>  (2) /* deprecated */
 /*return-type*/ divide(NonScalar1 x, NonScalar2 y)
 ----
 
@@ -25890,9 +25890,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp#
 [source,role=synopsis,id=api:half-exp]
 ----
-float exp(float x)                (1)
+float exp(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ exp(NonScalar x)
 ----
 
@@ -25920,9 +25920,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp2#
 [source,role=synopsis,id=api:half-exp2]
 ----
-float exp2(float x)                (1)
+float exp2(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ exp2(NonScalar x)
 ----
 
@@ -25950,9 +25950,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::exp10#
 [source,role=synopsis,id=api:half-exp10]
 ----
-float exp10(float x)                (1)
+float exp10(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ exp10(NonScalar x)
 ----
 
@@ -25980,9 +25980,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log#
 [source,role=synopsis,id=api:half-log]
 ----
-float log(float x)                (1)
+float log(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ log(NonScalar x)
 ----
 
@@ -26009,9 +26009,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log2#
 [source,role=synopsis,id=api:half-log2]
 ----
-float log2(float x)                (1)
+float log2(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ log2(NonScalar x)
 ----
 
@@ -26038,9 +26038,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::log10#
 [source,role=synopsis,id=api:half-log10]
 ----
-float log10(float x)                (1)
+float log10(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ log10(NonScalar x)
 ----
 
@@ -26067,9 +26067,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::powr#
 [source,role=synopsis,id=api:half-powr]
 ----
-float powr(float x, float y)                        (1)
+float powr(float x, float y)                        (1) /* deprecated */
 
-template<typename NonScalar1, typename NonScalar2>  (2)
+template<typename NonScalar1, typename NonScalar2>  (2) /* deprecated */
 /*return-type*/ powr(NonScalar1 x, NonScalar2 y)
 ----
 
@@ -26102,9 +26102,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::recip#
 [source,role=synopsis,id=api:half-recip]
 ----
-float recip(float x)                (1)
+float recip(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ recip(NonScalar x)
 ----
 
@@ -26131,9 +26131,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::rsqrt#
 [source,role=synopsis,id=api:half-rsqrt]
 ----
-float rsqrt(float x)                (1)
+float rsqrt(float x)                (1) /* deprecated */
 
-template<typename NonScalar>        (2)
+template<typename NonScalar>        (2) /* deprecated */
 /*return-type*/ rsqrt(NonScalar x)
 ----
 
@@ -26161,9 +26161,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::sin#
 [source,role=synopsis,id=api:half-sin]
 ----
-float sin(float x)                (1)
+float sin(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ sin(NonScalar x)
 ----
 
@@ -26195,9 +26195,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::sqrt#
 [source,role=synopsis,id=api:half-sqrt]
 ----
-float sqrt(float x)                (1)
+float sqrt(float x)                (1) /* deprecated */
 
-template<typename NonScalar>       (2)
+template<typename NonScalar>       (2) /* deprecated */
 /*return-type*/ sqrt(NonScalar x)
 ----
 
@@ -26224,9 +26224,9 @@ The return type is [code]#NonScalar# unless [code]#NonScalar# is the
 .[apidef]#half_precision::tan#
 [source,role=synopsis,id=api:half-tan]
 ----
-float tan(float x)                (1)
+float tan(float x)                (1) /* deprecated */
 
-template<typename NonScalar>      (2)
+template<typename NonScalar>      (2) /* deprecated */
 /*return-type*/ tan(NonScalar x)
 ----
 


### PR DESCRIPTION
Cherry pick #833 from main
(cherry picked from commit 4b0fe9410413166ac5014f09d4eb764e0c11a741)