### PR TITLE
Deprecate `accessor::max_size()`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9453,7 +9453,7 @@ a@
 ----
 size_type max_size() const noexcept
 ----
-   a@ Deprecated.
+   a@ Deprecated by SYCL 2020.
 
 Returns the maximum number of elements any accessor of this type would be able
 to access.

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9453,8 +9453,10 @@ a@
 ----
 size_type max_size() const noexcept
 ----
-   a@ Returns the maximum number of elements any accessor of this type would be
-      able to access.
+   a@ Deprecated.
+
+Returns the maximum number of elements any accessor of this type would be able
+to access.
 
 a@
 [source]

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -137,6 +137,7 @@ class accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   // Deprecated

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -69,6 +69,7 @@ class host_accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   bool empty() const noexcept;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -37,6 +37,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   bool empty() const noexcept;


### PR DESCRIPTION
This function was added only to align accessor with the container interface. However, an accessor is not a container, and this has led to confusion regarding what this function should return.

---

As per discussion in last week's SYCL WG call, I've targeted this at SYCL 2020 instead of SYCL-Next, despite it being a feature that was introduced in SYCL 2020.  Whether or not this function will be removed in SYCL-Next is to be determined later, but the WG decided it is useful to signal to developers that a function should not be used as early as possible.