### PR TITLE
Add SYCL 2020 (Revision 10) to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,7 @@ body:
       description: |
         What version of the specification contains the bug?
       options:
+        - SYCL 2020 (Revision 10)
         - SYCL 2020 (Revision 9)
         - SYCL 2020 (Source)
         - SYCL Next (Source)

--- a/.github/ISSUE_TEMPLATE/clarification_request.yml
+++ b/.github/ISSUE_TEMPLATE/clarification_request.yml
@@ -14,6 +14,7 @@ body:
       description: |
         What version of the specification is unclear?
       options:
+        - SYCL 2020 (Revision 10)
         - SYCL 2020 (Revision 9)
         - SYCL 2020 (Source)
         - SYCL Next (Source)


### PR DESCRIPTION
We should have done this when Revision 10 was released, but missed it.

I left Revision 9 in place because there is a non-zero chance a reporter will be looking at a stale copy. This will give us a quick way to identify issues that may be stale for triage.

---

My recommendation here is that we keep two (at most three) revisions in the list.  If we just have one revision, reporters may not pick up on the fact that the revision has changed.  If we have 2-3 revisions, a reporter is more likely to realize their version is stale (especially if it is not in the list at all).

@gmlueck: Note that this doesn't need to be backported to SYCL-2020 (unless you really want to!), because GitHub only checks the `.github` folder in the `main` branch.