### PR TITLE
Clarify that the CL/sycl.hpp header is deprecated

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -91,6 +91,8 @@ For compatibility with SYCL 1.2.1, SYCL provides another standard header file:
 [code]#<sycl/sycl.hpp>#.
 In that case, all SYCL classes, constants, types and functions defined by this
 specification should exist within the [code]#::cl::sycl# {cpp} namespace.
+The [code]#<CL/sycl.hpp># header and all declarations within the
+[code]#::cl::sycl# namespace are deprecated.
 
 For consistency, the programming API will only refer to the
 [code]#<sycl/sycl.hpp># header and the [code]#::sycl# namespace, but this should


### PR DESCRIPTION
Cherry pick #852 from main
(cherry picked from commit 002f6058046197b61984761aca38a155156e4918)