### PR TITLE
Deprecate `accessor::max_size()`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9447,8 +9447,10 @@ a@
 ----
 size_type max_size() const noexcept
 ----
-   a@ Returns the maximum number of elements any accessor of this type would be
-      able to access.
+   a@ Deprecated by SYCL 2020.
+
+Returns the maximum number of elements any accessor of this type would be able
+to access.
 
 a@
 [source]

--- a/adoc/headers/accessorBuffer.h
+++ b/adoc/headers/accessorBuffer.h
@@ -137,6 +137,7 @@ class accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   // Deprecated

--- a/adoc/headers/accessorHost.h
+++ b/adoc/headers/accessorHost.h
@@ -69,6 +69,7 @@ class host_accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   bool empty() const noexcept;

--- a/adoc/headers/accessorLocal.h
+++ b/adoc/headers/accessorLocal.h
@@ -37,6 +37,7 @@ template <typename DataT, int Dimensions = 1> class local_accessor {
 
   size_type size() const noexcept;
 
+  // Deprecated
   size_type max_size() const noexcept;
 
   bool empty() const noexcept;


### PR DESCRIPTION
Cherry pick #879 from main
(cherry picked from commit cd4523989a5d87d073bab61b5d203e62e7f5b240)