### PR TITLE
Fix `compare_exchange_*` with only one `memory_order`

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20587,7 +20587,20 @@ bool compare_exchange_weak(T& expected, T desired,
                            memory_order order = default_read_modify_write_order,
                            memory_scope scope = default_scope) const
 ----
-   a@ Equivalent to [code]#compare_exchange_weak(expected, desired, order, order, scope)#.
+   a@ Equivalent to:
+[source, c++]
+----
+memory_order success = order;
+memory_order failure;
+if (order == memory_order::acq_rel) {
+  failure = memory_order::acquire;
+} else if (order == memory_order::release) {
+  failure = memory_order::relaxed;
+} else {
+  failure = order;
+}
+return compare_exchange_weak(expected, desired, success, failure, scope);
+----
 
 a@
 [source]
@@ -20617,7 +20630,20 @@ bool compare_exchange_strong(
     T& expected, T desired,
     memory_order order = default_read_modify_write_order) const
 ----
-   a@ Equivalent to [code]#compare_exchange_strong(expected, desired, order, order, scope)#.
+   a@ Equivalent to:
+[source, c++]
+----
+memory_order success = order;
+memory_order failure;
+if (order == memory_order::acq_rel) {
+  failure = memory_order::acquire;
+} else if (order == memory_order::release) {
+  failure = memory_order::relaxed;
+} else {
+  failure = order;
+}
+return compare_exchange_strong(expected, desired, success, failure, scope);
+----
 
 |====
 


### PR DESCRIPTION
Previously, `compare_exchange_weak` and `compare_exchange_strong` with only one `memory_order` were defined as being equivalent to passing that value as both the `success` and `failure` arguments of the overload accepting two `memory_order`s. This is a bug, because the overload accepting two `memory_order`s clearly states that `failure` does not accept certain values of `memory_order`.

The definitions of the equivalent functions in ISO C++ do not have this issue, and so this commit aligns the behavior of these functions with ISO C++.

---

The equivalent wording in ISO C++, from [here](https://eel.is/c++draft/atomics#types.operations-23) is:

> When only one `memory_order` argument is supplied, the value of `success` is `order`, and the value of `failure` is `order` except that a value of `memory_order​::​acq_rel` shall be replaced by the value `memory_order​::​acquire` and a value of `memory_order​::​release` shall be replaced by the value `memory_order​::​relaxed`.

I didn't adopt this wording directly, because the SYCL specification currently has separate descriptions for all of the `compare_exchange_*` variants. Describing this behavior in code was the simplest way to modify the existing "Equivalent to" statement, fixing the bug without having to duplicate the description of the _Effects_/_Preconditions_/etc.