### PR TITLE
Explicitly delete handler move/copy constructors

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -14355,9 +14355,6 @@ All of the accessors defined in <<command-group-scope>> take as a parameter an
 instance of the <<handler>>, and all the kernel invocation functions are member
 functions of this class.
 
-The constructors of the SYCL [code]#handler# class are described in
-<<table.constructors.handler>>.
-
 It is disallowed for an instance of the SYCL [code]#handler# class to be moved
 or copied.
 
@@ -14366,21 +14363,6 @@ or copied.
 ----
 include::{header_dir}/commandGroupHandler.h[lines=4..-1]
 ----
-
-
-[[table.constructors.handler]]
-.Constructors of the [code]#handler# class
-[width="100%",options="header",separator="@",cols="65%,35%"]
-|====
-@ Constructor @ Description
-a@
-[source]
-----
-handler(___unspecified___)
-----
-   a@ Unspecified implementation-defined constructor.
-
-|====
 
 
 [[sub.section.requirement]]

--- a/adoc/headers/commandGroupHandler.h
+++ b/adoc/headers/commandGroupHandler.h
@@ -4,11 +4,15 @@
 namespace sycl {
 
 class handler {
- private:
-  // implementation defined constructor
-  handler(___unspecified___);
-
  public:
+  handler() = delete;
+
+  // A handler cannot be moved or copied.
+  handler(const handler&) = delete;
+  handler(handler&&) = delete;
+  handler& operator=(const handler&) = delete;
+  handler& operator=(handler&&) = delete;
+
   template <typename DataT, int Dimensions, access_mode AccessMode,
             target AccessTarget, access::placeholder IsPlaceholder>
   void require(


### PR DESCRIPTION
Cherry pick #837 from main
(cherry picked from commit 9e31f3a9e488e76a5e8b44af4d12aeb54ec2a7e4)