### PR TITLE
Add note about vec behavior in relational funcs

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -27777,6 +27777,13 @@ The term _vector element type_ represents these types:
 * [code]#double#
 * [code]#half#
 
+{note}The behavior of these functions for [code]#vec# input parameter types
+follows the OpenCL C behavior where the value -1 represents "true" and the value
+0 represents "false".
+Functions that check the truthiness of a [code]#vec# element check whether the
+high bit of the element is set, which again aligns with OpenCL C.
+{endnote}
+
 '''
 
 .[apidef]#isequal#

--- a/adoc/scripts/reflow.py
+++ b/adoc/scripts/reflow.py
@@ -96,7 +96,7 @@ class ReflowCallbacks:
         """True if justification should break to a new line after the end of a
         sentence."""
 
-        self.breakInitial = True
+        self.breakInitial = False
         """True if justification should break to a new line after something
         that appears to be an initial in someone's name. **TBD**"""
 


### PR DESCRIPTION
Add a non-normative note which draws attention to the fact that the relational functions taking `vec` inputs have "truthiness" semantics that differ from from most other C++ functions.

The semantic of these functions is inherited from the SYCL 1.2.1 specification, and it aligns with the OpenCL C semantics of vectors.

Note: The change to "reflow.py" is necessary to make the script realize that the period ending a sentence like "Blah blah OpenCL C." really is the period at the end of a sentence.  Without this change, the script thinks the "C." is a middle initial in someone's name, so it doesn't interpret the period as an end-of-sentence marker.

Closes #902