### PR TITLE
Add "std::" to more "size_t"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5567,7 +5567,7 @@ _Returns:_ A [code]#range# representing the number of elements in the buffer.
 .[apititle]#buffer::byte_size#
 [source,role=synopsis,id=api:buffer-byte-size]
 ----
-size_t byte_size() const noexcept;
+std::size_t byte_size() const noexcept;
 ----
 _Returns:_ The size of the buffer storage in bytes.
 Equal to [code]#size()*sizeof(T)#.
@@ -5577,7 +5577,7 @@ Equal to [code]#size()*sizeof(T)#.
 .[apititle]#buffer::size#
 [source,role=synopsis,id=api:buffer-size]
 ----
-size_t size() const noexcept;
+std::size_t size() const noexcept;
 ----
 _Returns:_ The total number of elements in the buffer.
 Equal to [code]#+get_range()[0] * ...
@@ -5588,7 +5588,7 @@ Equal to [code]#+get_range()[0] * ...
 .[apititle]#buffer::get_count#
 [source,role=synopsis,id=api:buffer-get-count]
 ----
-size_t get_count() const;
+std::size_t get_count() const;
 ----
 Deprecated by SYCL 2020.
 
@@ -5599,7 +5599,7 @@ _Effects:_ Equivalent to [code]#return size()#.
 .[apititle]#buffer::get_size#
 [source,role=synopsis,id=api:buffer-get-size]
 ----
-size_t get_size() const;
+std::size_t get_size() const;
 ----
 Deprecated by SYCL 2020.
 
@@ -6484,7 +6484,7 @@ pitch of the image in bytes.
 a@
 [source]
 ----
-size_t size() const noexcept
+std::size_t size() const noexcept
 ----
    a@ Returns the total number of elements in the image.
       Equal to [code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
@@ -6492,7 +6492,7 @@ size_t size() const noexcept
 a@
 [source]
 ----
-size_t byte_size() const noexcept
+std::size_t byte_size() const noexcept
 ----
    a@ Returns the size of the image storage in bytes.  The number of
       bytes may be greater than [code]#size()*element size#
@@ -6758,7 +6758,7 @@ pitch of the image in bytes.
 a@
 [source]
 ----
-size_t size() const noexcept
+std::size_t size() const noexcept
 ----
    a@ Returns the total number of elements in the image.
       Equal to [code]#+get_range()[0] * ... * get_range()[Dimensions-1]+#.
@@ -6766,7 +6766,7 @@ size_t size() const noexcept
 a@
 [source]
 ----
-size_t byte_size() const noexcept
+std::size_t byte_size() const noexcept
 ----
    a@ Returns the size of the image storage in bytes.  The number of
       bytes may be greater than [code]#size()*element size#
@@ -8058,13 +8058,13 @@ the additional member functions described in
 a@
 [source]
 ----
-size_t get_size() const
+std::size_t get_size() const
 ----
    a@ Returns the same value as [code]#byte_size()#.
 a@
 [source]
 ----
-size_t get_count() const
+std::size_t get_count() const
 ----
    a@ Returns the same value as [code]#size()#.
 
@@ -8620,7 +8620,7 @@ const_reference
 a@
 [source]
 ----
-size_t get_size() const noexcept
+std::size_t get_size() const noexcept
 ----
    a@ Returns the size in bytes of the memory region this accessor may access.
 
@@ -8635,7 +8635,7 @@ size in bytes of the accessor's local memory allocation, per work-group.
 a@
 [source]
 ----
-size_t get_count() const noexcept
+std::size_t get_count() const noexcept
 ----
    a@ Returns the number of [code]#DataT# elements of the memory region this
       accessor may access.
@@ -9800,7 +9800,7 @@ host_unsampled_image_accessor(unsampled_image<Dimensions, AllocatorT>& imageRef,
 a@
 [source]
 ----
-size_t size() const noexcept
+std::size_t size() const noexcept
 ----
    a@ Returns the number of elements of the underlying [code]#unsampled_image#
       that this accessor is accessing.
@@ -9988,7 +9988,7 @@ host_sampled_image_accessor(sampled_image<Dimensions, AllocatorT>& imageRef,
 a@
 [source]
 ----
-size_t size() const noexcept
+std::size_t size() const noexcept
 ----
    a@ Returns the number of elements of the underlying [code]#sampled_image#
       that this accessor is accessing.
@@ -12058,7 +12058,7 @@ range(std::size_t dim0, std::size_t dim1, std::size_t dim2) noexcept;
 a@
 [source]
 ----
-size_t get(int dimension) const noexcept;
+std::size_t get(int dimension) const noexcept;
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
@@ -12068,7 +12068,7 @@ size_t get(int dimension) const noexcept;
 a@
 [source]
 ----
-size_t& operator[](int dimension) noexcept;
+std::size_t& operator[](int dimension) noexcept;
 ----
    a@ Return the l-value of the specified dimension of the
       [code]#range#.
@@ -12078,7 +12078,7 @@ size_t& operator[](int dimension) noexcept;
 a@
 [source]
 ----
-size_t operator[](int dimension) const noexcept;
+std::size_t operator[](int dimension) const noexcept;
 ----
    a@ Return the value of the specified dimension of the
       [code]#range#.
@@ -12088,7 +12088,7 @@ size_t operator[](int dimension) const noexcept;
 a@
 [source]
 ----
-size_t size() const noexcept;
+std::size_t size() const noexcept;
 ----
    a@ Return the size of the range computed as dimension0*...*dimensionN.
 
@@ -12415,7 +12415,7 @@ id(const item<Dimensions>& item) noexcept;
 a@
 [source]
 ----
-size_t get(int dimension) const noexcept;
+std::size_t get(int dimension) const noexcept;
 ----
    a@ Return the value of the requested dimension of this [code]#id# object.
       Results in undefined behavior if [code]#dimension# is not in the range
@@ -12424,7 +12424,7 @@ size_t get(int dimension) const noexcept;
 a@
 [source]
 ----
-size_t& operator[](int dimension) noexcept;
+std::size_t& operator[](int dimension) noexcept;
 ----
    a@ Return a reference to the requested dimension of the [code]#id#
       object.
@@ -12434,7 +12434,7 @@ size_t& operator[](int dimension) noexcept;
 a@
 [source]
 ----
-size_t operator[](int dimension) const noexcept;
+std::size_t operator[](int dimension) const noexcept;
 ----
    a@ Return the value of the requested dimension of the [code]#id#
       object.
@@ -12627,14 +12627,14 @@ id<Dimensions> get_id() const noexcept;
 a@
 [source]
 ----
-size_t get_id(int dimension) const noexcept;
+std::size_t get_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_id()[dimension]#.
 
 a@
 [source]
 ----
-size_t operator[](int dimension) const noexcept;
+std::size_t operator[](int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_id(dimension)#.
 
@@ -12649,7 +12649,7 @@ range<Dimensions> get_range() const noexcept;
 a@
 [source]
 ----
-size_t get_range(int dimension) const noexcept;
+std::size_t get_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_range().get(dimension)#.
 
@@ -12694,7 +12694,7 @@ Returns the same value as [code]#get_id(0)#.
 a@
 [source]
 ----
-size_t get_linear_id() const noexcept;
+std::size_t get_linear_id() const noexcept;
 ----
    a@ Return the id as a linear index value. Calculating a linear
       address from the multi-dimensional index follows
@@ -12750,7 +12750,7 @@ id<Dimensions> get_global_id() const noexcept;
 a@
 [source]
 ----
-size_t get_global_id(int dimension) const noexcept;
+std::size_t get_global_id(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the <<global-id>>
       representing the work-item's position in the <<nd-range>>
@@ -12761,7 +12761,7 @@ size_t get_global_id(int dimension) const noexcept;
 a@
 [source]
 ----
-size_t get_global_linear_id() const noexcept;
+std::size_t get_global_linear_id() const noexcept;
 ----
    a@ Return the constituent <<global-id>> as a linear index value, representing the work-item's
    position in the global iteration space.  The linear address is calculated from the
@@ -12779,7 +12779,7 @@ id<Dimensions> get_local_id() const noexcept;
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const noexcept;
+std::size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the <<local-id>> representing the
       work-item's position within the current <<work-group>> in the given
@@ -12790,7 +12790,7 @@ size_t get_local_id(int dimension) const noexcept;
 a@
 [source]
 ----
-size_t get_local_linear_id() const noexcept;
+std::size_t get_local_linear_id() const noexcept;
 ----
    a@ Return the constituent <<local-id>> as a linear index value, representing the work-item's
    position within the current <<work-group>>.  The linear address is calculated from the
@@ -12815,7 +12815,7 @@ sub_group get_sub_group() const noexcept;
 a@
 [source]
 ----
-size_t get_group(int dimension) const noexcept;
+std::size_t get_group(int dimension) const noexcept;
 ----
    a@ Return the constituent element of the group [code]#id# representing
       the work-group's position within the overall [code]#nd_range# in the
@@ -12826,7 +12826,7 @@ size_t get_group(int dimension) const noexcept;
 a@
 [source]
 ----
-size_t get_group_linear_id() const noexcept;
+std::size_t get_group_linear_id() const noexcept;
 ----
    a@ Return the group id as a linear index value. Calculating a linear address
       from a multi-dimensional index follows <<sec:multi-dim-linearization>>.
@@ -12841,7 +12841,7 @@ range<Dimensions> get_group_range() const noexcept;
 a@
 [source]
 ----
-size_t get_group_range(int dimension) const noexcept;
+std::size_t get_group_range(int dimension) const noexcept;
 ----
    a@ Return the number of <<work-group,work-groups>> for [code]#Dimension# in the
       iteration space.
@@ -12859,7 +12859,7 @@ range<Dimensions> get_global_range() const noexcept;
 a@
 [source]
 ----
-size_t get_global_range(int dimension) const noexcept;
+std::size_t get_global_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_global_range().get(dimension)#.
 
@@ -12874,7 +12874,7 @@ range<Dimensions> get_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const noexcept;
+std::size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_local_range().get(dimension)#.
 
@@ -13117,7 +13117,7 @@ range<Dimensions> get_global_range() const noexcept;
 a@
 [source]
 ----
-size_t get_global_range(int dimension) const noexcept;
+std::size_t get_global_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_global().get_range(dimension)#
 
@@ -13131,7 +13131,7 @@ id<Dimensions> get_global_id() const noexcept;
 a@
 [source]
 ----
-size_t get_global_id(int dimension) const noexcept;
+std::size_t get_global_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_global().get_id(dimension)#
 
@@ -13145,7 +13145,7 @@ range<Dimensions> get_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const noexcept;
+std::size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_local().get_range(dimension)#
 
@@ -13159,7 +13159,7 @@ id<Dimensions> get_local_id() const noexcept;
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const noexcept;
+std::size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_local().get_id(dimension)#
 
@@ -13173,7 +13173,7 @@ range<Dimensions> get_logical_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_logical_local_range(int dimension) const noexcept;
+std::size_t get_logical_local_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_logical_local().get_range(dimension)#
 
@@ -13187,7 +13187,7 @@ id<Dimensions> get_logical_local_id() const noexcept;
 a@
 [source]
 ----
-size_t get_logical_local_id(int dimension) const noexcept;
+std::size_t get_logical_local_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_logical_local().get_id(dimension)#
 
@@ -13201,7 +13201,7 @@ range<Dimensions> get_physical_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_physical_local_range(int dimension) const noexcept;
+std::size_t get_physical_local_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_physical_local().get_range(dimension)#
 
@@ -13215,7 +13215,7 @@ id<Dimensions> get_physical_local_id() const noexcept;
 a@
 [source]
 ----
-size_t get_physical_local_id(int dimension) const noexcept;
+std::size_t get_physical_local_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_physical_local().get_id(dimension)#
 
@@ -13272,7 +13272,7 @@ id<Dimensions> get_group_id() const noexcept;
 a@
 [source]
 ----
-size_t get_group_id(int dimension) const noexcept;
+std::size_t get_group_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_group_id()[dimension]#.
 
@@ -13290,7 +13290,7 @@ a [code]#parallel_for_work_item# context.
 a@
 [source]
 ----
-size_t get_local_id(int dimension) const noexcept;
+std::size_t get_local_id(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_local_id()[dimension]#.
 
@@ -13308,7 +13308,7 @@ range<Dimensions> get_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_local_range(int dimension) const noexcept;
+std::size_t get_local_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_local_range()[dimension]#.
 
@@ -13322,14 +13322,14 @@ range<Dimensions> get_group_range() const noexcept;
 a@
 [source]
 ----
-size_t get_group_range(int dimension) const noexcept;
+std::size_t get_group_range(int dimension) const noexcept;
 ----
    a@ Equivalent to [code]#return get_group_range()[dimension]#.
 
 a@
 [source]
 ----
-size_t operator[](int dimension) const noexecpt;
+std::size_t operator[](int dimension) const noexecpt;
 ----
    a@ Equivalent to [code]#return get_group_id(dimension)#.
 
@@ -13344,7 +13344,7 @@ range<Dimensions> get_max_local_range() const noexcept;
 a@
 [source]
 ----
-size_t get_group_linear_id() const noexcept;
+std::size_t get_group_linear_id() const noexcept;
 ----
    a@ Get a linearized version of the <<work-group-id>>.
       Calculating a linear <<work-group-id>>
@@ -13353,14 +13353,14 @@ size_t get_group_linear_id() const noexcept;
 a@
 [source]
 ----
-size_t get_group_linear_range() const noexcept;
+std::size_t get_group_linear_range() const noexcept;
 ----
    a@ Return the total number of <<work-group,work-groups>> in the [code]#nd_range#.
 
 a@
 [source]
 ----
-size_t get_local_linear_id() const noexcept;
+std::size_t get_local_linear_id() const noexcept;
 ----
    a@ Get a linearized version of the calling work-item's <<local-id>>.
       Calculating a linear <<local-id>>
@@ -13372,7 +13372,7 @@ a [code]#parallel_for_work_item# context.
 a@
 [source]
 ----
-size_t get_local_linear_range() const noexcept;
+std::size_t get_local_linear_range() const noexcept;
 ----
    a@ Return the total number of work-items in the <<work-group>>.
 
@@ -17713,7 +17713,7 @@ context get_context() const
 a@
 [source]
 ----
-size_t size() const
+std::size_t size() const
 ----
    a@ Returns the size of the list
 
@@ -18088,7 +18088,7 @@ static constexpr std::size_t size() noexcept
 a@
 [source]
 ----
-size_t get_count() const
+std::size_t get_count() const
 ----
    a@ Returns the same value as [code]#size()#. Deprecated.
 a@
@@ -18104,7 +18104,7 @@ alignment as described in <<memory-layout-and-alignment>>.
 a@
 [source]
 ----
-size_t get_size() const
+std::size_t get_size() const
 ----
    a@ Returns the same value as [code]#byte_size()#. Deprecated.
 a@
@@ -18988,8 +18988,8 @@ explicit operator T() const
 static constexpr std::size_t byte_size() noexcept
 static constexpr std::size_t size() noexcept
 
-size_t get_size() const   // Deprecated
-size_t get_count() const  // Deprecated
+std::size_t get_size() const   // Deprecated
+std::size_t get_count() const  // Deprecated
 
 template <typename ConvertT,
           rounding_mode RoundingMode = rounding_mode::automatic>
@@ -21611,26 +21611,26 @@ stream(std::size_t totalBufferSize, std::size_t workItemBufferSize, handler& cgh
 a@
 [source]
 ----
-size_t size() const noexcept
+std::size_t size() const noexcept
 ----
    a@ Returns the total buffer size, in bytes.
 a@
 [source]
 ----
-size_t get_size() const
+std::size_t get_size() const
 ----
    a@ Returns the same value as [code]#size()#. Deprecated.
 a@
 [source]
 ----
-size_t get_work_item_buffer_size() const
+std::size_t get_work_item_buffer_size() const
 ----
    a@ Returns the buffer size per work-item, in bytes.
 
 a@
 [source]
 ----
-size_t get_max_statement_size() const
+std::size_t get_max_statement_size() const
 ----
    a@ Deprecated query with same functionality as [code]#get_work_item_buffer_size()#.
 


### PR DESCRIPTION
I happened to notice these are missing when resolving conflicts on a previous PR.  These were only missing from the document text.  The header synopses already had the "std::".