### PR TITLE
Add integral overloads for `id` and `range` operators

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -12113,7 +12113,9 @@ is the cast to [code]#std::size_t#.
 a@
 [source]
 ----
-range operatorOP(const range& lhs, const std::size_t& rhs) noexcept;
+// Available only when std::is_integral_v<T> is true
+template <typename T>
+range operatorOP(const range& lhs, const T& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
       [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
@@ -12126,9 +12128,31 @@ Constructs and returns a new instance of the SYCL [code]#range# class
 template with the same dimensionality as [code]#lhs# [code]#range#,
 where each element of the new SYCL [code]#range# instance is the result
 of an element-wise [code]#OP# operator between each element of this
-SYCL [code]#range# and the [code]#rhs# [code]#std::size_t#. If
-the operator returns a [code]#bool#, the result is the cast to
+SYCL [code]#range# and the [code]#rhs# integral type. If
+the operator returns a [code]#bool#, the result is then cast to
 [code]#std::size_t#.
+
+a@
+[source]
+----
+// Available only when std::is_integral_v<T> is true
+template <typename T>
+range operatorOP(const T& lhs, const range& rhs) noexcept;
+----
+   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
+      [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
+      [code]#&#, [code]#|#, [code]#^#,
+      [code]#&&#, [code]#||#,
+      [code]#<#, [code]#>#, [code]#+<=+#,
+      [code]#>=#.
+
+Constructs and returns a new instance of the SYCL [code]#range# class
+template with the same dimensionality as the [code]#rhs# SYCL
+[code]#range#, where each element of the new SYCL [code]#range#
+instance is the result of an element-wise [code]#OP# operator between
+the [code]#lhs# integral type and each element of the
+[code]#rhs# SYCL [code]#range#. If the operator returns a
+[code]#bool#, the result is then cast to [code]#std::size_t#.
 
 a@
 [source]
@@ -12146,35 +12170,17 @@ to [code]#std::size_t#.
 a@
 [source]
 ----
-range& operatorOP(range& lhs, const std::size_t& rhs) noexcept;
+// Available only when std::is_integral_v<T> is true
+template <typename T>
+range& operatorOP(range& lhs, const T& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
 Assigns each element of [code]#lhs# [code]#range# instance with the
 result of an element-wise [code]#OP# operator between each element
-of [code]#lhs# [code]#range# and the [code]#rhs# [code]#std::size_t# and returns [code]#lhs# [code]#range#. If the
-operator returns a [code]#bool#, the result is the cast to
+of [code]#lhs# [code]#range# and the [code]#rhs# integral type and returns [code]#lhs# [code]#range#. If the
+operator returns a [code]#bool#, the result is then cast to
 [code]#std::size_t#.
-
-a@
-[source]
-----
-range operatorOP(const std::size_t& lhs, const range& rhs) noexcept;
-----
-   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#,
-      [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
-      [code]#&#, [code]#|#, [code]#^#,
-      [code]#&&#, [code]#||#,
-      [code]#<#, [code]#>#, [code]#+<=+#,
-      [code]#>=#.
-
-Constructs and returns a new instance of the SYCL [code]#range# class
-template with the same dimensionality as the [code]#rhs# SYCL
-[code]#range#, where each element of the new SYCL [code]#range#
-instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# [code]#std::size_t# and each element of the
-[code]#rhs# SYCL [code]#range#. If the operator returns a
-[code]#bool#, the result is the cast to [code]#std::size_t#.
 
 a@
 [source]
@@ -12459,7 +12465,9 @@ If the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id operatorOP(const id& lhs, const std::size_t& rhs) noexcept;
+// Available only when std::is_integral_v<T> is true
+template <typename T>
+id operatorOP(const id& lhs, const T& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
       [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
@@ -12468,9 +12476,27 @@ Constructs and returns a new instance of the SYCL [code]#id# class
 template with the same dimensionality as [code]#lhs# [code]#id#, where
 each element of the new SYCL [code]#id# instance is the result of an
 element-wise [code]#OP# operator between each element of [code]#lhs#
-[code]#id# and the [code]#rhs# [code]#std::size_t#. If the
-operator returns a [code]#bool# the result is the cast to
+[code]#id# and the [code]#rhs# integral type. If the
+operator returns a [code]#bool# the result is then cast to
 [code]#std::size_t#.
+
+a@
+[source]
+----
+// Only available when std::is_integral_v<T> is true
+template <typename T>
+id operatorOP(const T& lhs, const id& rhs) noexcept;
+----
+   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
+      [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
+
+Constructs and returns a new instance of the SYCL [code]#id# class
+template with the same dimensionality as the [code]#rhs# SYCL
+[code]#id#, where each element of the new SYCL [code]#id#
+instance is the result of an element-wise [code]#OP# operator between
+the [code]#lhs# integral type and each element of the
+[code]#rhs# SYCL [code]#id#. If the operator returns a
+[code]#bool# the result is then cast to [code]#std::size_t#.
 
 a@
 [source]
@@ -12490,32 +12516,17 @@ the operator returns a [code]#bool# the result is the cast to
 a@
 [source]
 ----
-id& operatorOP(id& lhs, const std::size_t& rhs) noexcept;
+template <typename T>
+id& operatorOP(id& lhs, const T& rhs) noexcept;
 ----
    a@ Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#,
       [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#|=#, [code]#^=#.
 
 Assigns each element of [code]#lhs# [code]#id# instance with the
 result of an element-wise [code]#OP# operator between each element
-of [code]#lhs# [code]#id# and the [code]#rhs# [code]#std::size_t#
+of [code]#lhs# [code]#id# and the [code]#rhs# integral type
 and returns [code]#lhs# [code]#id#. If the operator
-returns a [code]#bool# the result is the cast to [code]#std::size_t#.
-
-a@
-[source]
-----
-id operatorOP(const std::size_t& lhs, const id& rhs) noexcept;
-----
-   a@ Where [code]#OP# is: [code]#pass:[+]#, [code]#-#, [code]#*#, [code]#/#, [code]#%#, [code]#<<#, [code]#>>#,
-      [code]#&#, [code]#|#, [code]#^#, [code]#&&#, [code]#||#, [code]#<#, [code]#>#, [code]#+<=+#, [code]#>=#.
-
-Constructs and returns a new instance of the SYCL [code]#id# class
-template with the same dimensionality as the [code]#rhs# SYCL
-[code]#id#, where each element of the new SYCL [code]#id#
-instance is the result of an element-wise [code]#OP# operator between
-the [code]#lhs# [code]#std::size_t# and each element of the
-[code]#rhs# SYCL [code]#id#. If the operator returns a
-[code]#bool# the result is the cast to [code]#std::size_t#.
+returns a [code]#bool# the result is then cast to [code]#std::size_t#.
 
 a@
 [source]

--- a/adoc/headers/id.h
+++ b/adoc/headers/id.h
@@ -33,17 +33,27 @@ template <int Dimensions = 1> class id {
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   friend id operatorOP(const id& lhs, const id& rhs) noexcept { /* ... */
   }
-  friend id operatorOP(const id& lhs, const std::size_t& rhs) noexcept { /* ... */
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend id operatorOP(const id& lhs, const T& rhs) noexcept { /* ... */
+  }
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend id operatorOP(const T& lhs, const id& rhs) noexcept { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend id& operatorOP(id& lhs, const id& rhs) noexcept { /* ... */
   }
-  friend id& operatorOP(id& lhs, const std::size_t& rhs) noexcept { /* ... */
-  }
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend id operatorOP(const std::size_t& lhs, const id& rhs) noexcept { /* ... */
+  // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend id& operatorOP(id& lhs, const T& rhs) noexcept { /* ... */
   }
 
   // OP is unary +, -

--- a/adoc/headers/range.h
+++ b/adoc/headers/range.h
@@ -29,17 +29,27 @@ template <int Dimensions = 1> class range {
   // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
   friend range operatorOP(const range& lhs, const range& rhs) noexcept { /* ... */
   }
-  friend range operatorOP(const range& lhs, const std::size_t& rhs) noexcept { /* ... */
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend range operatorOP(const range& lhs, const T& rhs) noexcept { /* ... */
+  }
+
+  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend range operatorOP(const T& lhs, const range& rhs) noexcept { /* ... */
   }
 
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
   friend range& operatorOP(range& lhs, const range& rhs) noexcept { /* ... */
   }
-  friend range& operatorOP(range& lhs, const std::size_t& rhs) noexcept { /* ... */
-  }
 
-  // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
-  friend range operatorOP(const std::size_t& lhs, const range& rhs) noexcept { /* ... */
+  // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
+  // Available only when std::is_integral_v<T> is true
+  template <typename T>
+  friend range& operatorOP(range& lhs, const T& rhs) noexcept { /* ... */
   }
 
   // OP is unary +, -


### PR DESCRIPTION
Cherry pick #726 from main
(cherry picked from commit 226c77e694c33cd8ce1f677afb84546a20ec11cc)