### PR TITLE
Improve default allocator wording

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -5137,11 +5137,9 @@ can supply their own allocator class.
 }
 ----
 
-When an allocator returns a [code]#nullptr#, the runtime cannot allocate data on
-the host.
-Note that in this case the runtime will raise an error if it requires host
-memory but it is not available (e.g when moving data across <<backend>>
-contexts).
+Note that if the runtime requires host memory (e.g., when moving data across
+<<backend>> contexts), but the allocator fails to allocate the memory, then the
+runtime will raise an error.
 
 In some cases, the implementation may retain a copy of the allocator object even
 after the buffer is destroyed.
@@ -5166,8 +5164,6 @@ STL-based libraries (e.g, Intel's TBB provides an allocator).
 ==== Default allocators
 
 A default allocator is always defined by the implementation.
-For allocations greater than size zero, when successful it is guaranteed to
-return non-[code]#nullptr# and new memory positions every call.
 The default allocator for const buffers will remove the const-ness of the type
 (therefore, the default allocator for a buffer of type [code]#const int# will be
 an [code]#Allocator<int>)#.


### PR DESCRIPTION
Cherry pick #649 from main
(cherry picked from commit a009088c33706ba593d5bb52fcf75e550a612b9f)