### PR TITLE
Fix capitalization

### DIFF
--- a/adoc/extensions/sycl_khr_dynamic_addrspace_cast.adoc
+++ b/adoc/extensions/sycl_khr_dynamic_addrspace_cast.adoc
@@ -4,8 +4,8 @@
 This extension introduces a [code]#dynamic_addrspace_cast# function with the
 same semantics as [code]#sycl::address_space_cast# to align with the
 [code]#static_addrspace_cast# function defined by the
-SYCL_KHR_STATIC_ADDRSPACE_CAST extension, and clarifies the expected behavior of
-a dynamic address space cast.
+<<sec:khr-static-addrspace-cast,sycl_khr_static_addrspace_cast>> extension, and
+clarifies the expected behavior of a dynamic address space cast.
 
 [[sec:khr-dynamic-addrspace-cast-dependencies]]
 == Dependencies


### PR DESCRIPTION
The name of a KHR extension should be lower case.  It also seemed good to make the name into a link.