### PR TITLE
Removing contradictory statement about context

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -154,8 +154,6 @@ When a group of devices can be grouped together on the same context, they have
 some visibility of each other's memory objects.
 The SYCL runtime can assume that memory is visible across all devices in the
 same <<context>>.
-Not all devices exposed from the same <<platform>> can be grouped together in
-the same <<context>>.
 
 A SYCL application executes on the host as a standard {cpp} program.
 <<device,Devices>> are exposed through different <<backend, SYCL backends>> to


### PR DESCRIPTION
This sentence is contradictory because we say in section 4.6.2 "Platform class":

> Each platform has an associated default context which contains all of
> the root devices in the platform.

Therefore, it must be that all devices in the same platform *can* be grouped into the same context.