### PR TITLE
Fix "latest" badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!-- to update to newer CI when going public [![SPEC master](https://img.shields.io/badge/SPEC-master-red.svg?logo=adobe-acrobat-reader)](https://khronosgroup.github.io/SYCL-Docs/sycl/sycl.pdf) -->
 [![SPEC 2020-10](https://img.shields.io/badge/SPEC-2020--11-orange.svg?logo=adobe-acrobat-reader)](https://www.khronos.org/registry/SYCL/specs/sycl-2020/pdf/sycl-2020.pdf)
 [![SPEC 2020-10](https://img.shields.io/badge/SPEC-2020--11-orange.svg?logo=HTML5)](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html)
-[![SPEC latest](https://img.shields.io/badge/SPEC-latest-red.svg?logo=adobe-acrobat-reader)](https://github.com/KhronosGroup/SYCL-Docs/actions?query=branch%3ASYCL-2020%2Fmaster+is%3Asuccess)
+[![SPEC latest](https://img.shields.io/badge/SPEC-latest-red.svg?logo=adobe-acrobat-reader)](https://github.com/KhronosGroup/SYCL-Docs/actions?query=branch%3Amain+is%3Asuccess)
 [![Join the Slack group](https://img.shields.io/badge/chat-on%20slack-blue.svg?logo=slack)](https://khr.io/slack)
 
 # SYCL Open Source Specification


### PR DESCRIPTION
While testing the badges on the GitHub README, I noticed that the badge for "SPEC latest" was pointing to the wrong branch.  We renamed the main branch from "SYCL-2020/master" to "main" some time ago, and we should have updated the badge also.