### PR TITLE
Hyphenate "sub-device"

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1575,8 +1575,8 @@ objects returned by [api]#device::get_devices#.
 
 A device can be partitioned into multiple devices, by calling the
 [code]#device::create_sub_devices# member function template.
-The resulting [code]#device# objects are considered sub devices, and it is valid
-to partition these sub devices further.
+The resulting [code]#device# objects are considered sub-devices, and it is valid
+to partition these sub-devices further.
 The range of support for this feature is <<backend>> and device specific and can
 be queried for through [api]#device::get_info#.
 
@@ -1750,13 +1750,13 @@ std::vector<device> create_sub_devices(std::size_t count) const
 _Constraints:_ Available only when [code]#Prop# is
 [api]#info::partition_property::partition_equally#.
 
-_Returns:_ A [code]#std::vector# of sub devices partitioned from this
+_Returns:_ A [code]#std::vector# of sub-devices partitioned from this
 [code]#device# object based on the [code]#count# parameter.
-The returned vector contains as many sub devices as can be created such that
-each sub device contains [code]#count# compute units.
+The returned vector contains as many sub-devices as can be created such that
+each sub-device contains [code]#count# compute units.
 If the device's total number of compute units (as returned by
 [api]#info::device::max_compute_units#) is not evenly divided by [code]#count#,
-then the remaining compute units are not included in any of the sub devices.
+then the remaining compute units are not included in any of the sub-devices.
 
 _Throws:_
 
@@ -1779,9 +1779,9 @@ std::vector<device> create_sub_devices(const std::vector<std::size_t>& counts) c
 _Constraints:_ Available only when [code]#Prop# is
 [api]#info::partition_property::partition_by_counts#.
 
-_Returns:_ A [code]#std::vector# of sub devices partitioned from this
+_Returns:_ A [code]#std::vector# of sub-devices partitioned from this
 [code]#device# object based on the [code]#counts# parameter.
-For each non-zero value _M_ in the [code]#counts# vector, a sub device with _M_
+For each non-zero value _M_ in the [code]#counts# vector, a sub-device with _M_
 compute units is created.
 
 _Throws:_
@@ -1792,7 +1792,7 @@ _Throws:_
 
 * An [code]#exception# with the [code]#errc::invalid# error code if the number
   of non-zero values in [code]#counts# exceeds the device's maximum number of
-  sub devices (as returned by [api]#info::device::partition_max_sub_devices#) or
+  sub-devices (as returned by [api]#info::device::partition_max_sub_devices#) or
   if the total of all the values in the [code]#counts# vector exceeds the total
   number of compute units in the device (as returned by
   [api]#info::device::max_compute_units#).
@@ -1810,32 +1810,32 @@ create_sub_devices(info::partition_affinity_domain domain) const
 _Constraints:_ Available only when [code]#Prop# is
 [api]#info::partition_property::partition_by_affinity_domain#.
 
-_Returns:_ A [code]#std::vector# of sub devices partitioned from this
+_Returns:_ A [code]#std::vector# of sub-devices partitioned from this
 [code]#device# object based on the [code]#domain# parameter, which must be one
 of the following values:
 
-* [api]#info::partition_affinity_domain::numa#: Split the device into sub
-  devices comprised of compute units that share a NUMA node.
+* [api]#info::partition_affinity_domain::numa#: Split the device into
+  sub-devices comprised of compute units that share a NUMA node.
 
-* [api]#info::partition_affinity_domain::L4_cache#: Split the device into sub
-  devices comprised of compute units that share a level 4 data cache.
+* [api]#info::partition_affinity_domain::L4_cache#: Split the device into
+  sub-devices comprised of compute units that share a level 4 data cache.
 
-* [api]#info::partition_affinity_domain::L3_cache#: Split the device into sub
-  devices comprised of compute units that share a level 3 data cache.
+* [api]#info::partition_affinity_domain::L3_cache#: Split the device into
+  sub-devices comprised of compute units that share a level 3 data cache.
 
-* [api]#info::partition_affinity_domain::L2_cache#: Split the device into sub
-  devices comprised of compute units that share a level 2 data cache.
+* [api]#info::partition_affinity_domain::L2_cache#: Split the device into
+  sub-devices comprised of compute units that share a level 2 data cache.
 
-* [api]#info::partition_affinity_domain::L1_cache#: Split the device into sub
-  devices comprised of compute units that share a level 1 data cache.
+* [api]#info::partition_affinity_domain::L1_cache#: Split the device into
+  sub-devices comprised of compute units that share a level 1 data cache.
 
 * [api]#info::partition_affinity_domain::next_partitionable#: Split the device
   along the next partitionable affinity domain.
-  The implementation shall find the first level along which the device or sub
-  device may be further subdivided in the order [code]#numa#, [code]#L4_cache#,
-  [code]#L3_cache#, [code]#L2_cache#, [code]#L1_cache#, and partition the device
-  into sub devices comprised of compute units that share memory subsystems at
-  this level.
+  The implementation shall find the first level along which the device or
+  sub-device may be further subdivided in the order [code]#numa#,
+  [code]#L4_cache#, [code]#L3_cache#, [code]#L2_cache#, [code]#L1_cache#, and
+  partition the device into sub-devices comprised of compute units that share
+  memory subsystems at this level.
   The user may determine what happened via
   [api]#info::device::partition_type_affinity_domain#.
 
@@ -3209,11 +3209,11 @@ struct parent_device {
 
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
-_Returns:_ The parent device to which this sub device is a child if this is a
-sub device.
+_Returns:_ The parent device to which this sub-device is a child if this is a
+sub-device.
 
 _Throws:_ An [code]#exception# with the [code]#errc::invalid# error code if this
-device is not a sub device.
+device is not a sub-device.
 
 '''
 
@@ -3229,7 +3229,7 @@ struct partition_max_sub_devices {
 
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
-_Returns:_ The maximum number of sub devices that can be created when this
+_Returns:_ The maximum number of sub-devices that can be created when this
 device is partitioned.
 The value returned cannot exceed the value returned by
 [api]#info::device::max_compute_units#.
@@ -3251,7 +3251,7 @@ _Remarks:_ Template parameter to [api]#device::get_info#.
 _Returns:_ A [code]#std::vector# of the partition properties supported by this
 device.
 An element is returned in this vector only if the device can be partitioned into
-at least two sub devices along that partition property.
+at least two sub-devices along that partition property.
 
 '''
 
@@ -3271,7 +3271,7 @@ _Returns:_ A [code]#std::vector# of the partition affinity domains supported by
 this device when partitioning with
 [api]#info::partition_property::partition_by_affinity_domain#.
 An element is returned in this vector only if the device can be partitioned into
-at least two sub devices along that affinity domain.
+at least two sub-devices along that affinity domain.
 
 '''
 
@@ -3288,7 +3288,7 @@ struct partition_type_property {
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ The partition property of this device.
-If this device is not a sub device then the return value is
+If this device is not a sub-device then the return value is
 [api]#info::partition_property::no_partition#, otherwise it is one of the
 following values:
 
@@ -3311,7 +3311,7 @@ struct partition_type_affinity_domain {
 _Remarks:_ Template parameter to [api]#device::get_info#.
 
 _Returns:_ The partition affinity domain of this device.
-If this device is not a sub device or the sub device was not partitioned with
+If this device is not a sub-device or the sub-device was not partitioned with
 [api]#info::partition_property::partition_by_affinity_domain# then the return
 value is [api]#info::partition_affinity_domain::not_applicable#, otherwise it is
 one of the following values:


### PR DESCRIPTION
We sometimes spelled this "sub device" and sometimes "sub-device". Consistently use the hyphenated form.

Closes #945