### PR TITLE
Render preprocessing statements in different color

### DIFF
--- a/adoc/config/rouge/lib/rouge/themes/sycl_spec.rb
+++ b/adoc/config/rouge/lib/rouge/themes/sycl_spec.rb
@@ -31,6 +31,12 @@ module Rouge
       style Comment,                          :fg => '#9acd32'
       style Comment::Multiline,               :fg => '#9acd32'
       style Comment::Single,                  :fg => '#9acd32'
+      # Give preprocessing statements a different color from comments.
+      # DarkOrchid3 (#9a32cd) is close to what Visual Studio Code uses in its
+      # Light Modern theme.  This is the same color we use for sycl_data_types
+      # (above), but those are very uncommon in our code listings now.
+      style Comment::Preproc,                 :fg => '#9a32cd'
+      style Comment::PreprocFile,             :fg => '#9a32cd'
       # Use a clearer white background
       style Text,                             :bg => '#ffffff'
 


### PR DESCRIPTION
@KornevNikita noted in #814 that comments and preprocessing statements have the same color in our source code listings, which looks ugly. Change the color of preprocessing statements to be something different.