### PR TITLE
Refactoring table sec:accessors-command-buffer-members

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -8065,7 +8065,7 @@ the sum of [code]#accessRange# and [code]#accessOffset# exceeds the range of
 
 
 [[sec:accessors-command-buffer-members]]
-====== Member functions of the [code]#accessor# class
+====== Member functions
 
 .[apidef]#accessor::swap#
 [source,role=synopsis,id=api:accessor-swap]


### PR DESCRIPTION
This PR refactor the `Table 29. Member functions of the accessor class`.

It demonstrate:

## Transformation of table into section

- The name of the new section, is the name of the table (no change)
- The anchor link it's created as replacing  in `table id` the word `table.` with`sec:` and then replacing the `.` with `-`
`[[table.accessors.command.buffer.members]] -> [[sec:accessors-command-buffer-members]]` 

## Transformation of the cell into sub section:

- The new title for each cell is `{classname}::{function-name}`
- The new `id` is named `api:{section-prefix}-{function-name}`. So the old `[source]` is replaced to `[source,role=synopsis,id=api:{section-prefix}-{function-name}]`
  - Particular care is taken for `c++ operator`, where for example `operator=(` is not a valid name for a anchor. For the particular `=(` we sanitize it to `operator-asign`: The new anchor is now `api:accessors-command-buffer-members-operator-assign`
- Merging of overload.  We merge overload in the same subsection by adding a prefix (to mimic other part of the spec)
- Not showed here, but we also take care of the core indentation of the text inside the description cell.
- Each cell is separated by `\n'''\n` to follow current style. 

## Changing old reference to new one

- We take care of updating old table link to new section link

## Note 
- It's not the best table, as the level are so deep that we don't have a link. I can do a more "shallow" table if that help.
- Reflow mess-around a little bit the diff
- Sorry for the last "empty new-line" added. Maybe be painful to remove. It doesn't change anything in the render, but I can invest more time to try to fix it.