### PR TITLE
Fix old formatting mistake

### DIFF
--- a/adoc/headers/hostTask/classInteropHandle/getnativeX.h
+++ b/adoc/headers/hostTask/classInteropHandle/getnativeX.h
@@ -1,13 +1,11 @@
-headers / hostTask / classInteropHandle /
-    getnativeX.h
-    // Copyright (c) 2011-2026 The Khronos Group, Inc.
-    // SPDX-License-Identifier: MIT
+// Copyright (c) 2011-2026 The Khronos Group, Inc.
+// SPDX-License-Identifier: MIT
 
-    template <backend Backend, typename DataT, int Dims, access_mode AccMode,
-              target AccTarget, access::placeholder IsPlaceholder>
-    backend_return_t<Backend, buffer<DataT, Dims>>
-    get_native_mem(const accessor<DataT, Dims, AccMode, AccTarget, // (1)
-                                  IsPlaceholder>& bufferAcc) const;
+template <backend Backend, typename DataT, int Dims, access_mode AccMode,
+          target AccTarget, access::placeholder IsPlaceholder>
+backend_return_t<Backend, buffer<DataT, Dims>>
+get_native_mem(const accessor<DataT, Dims, AccMode, AccTarget, // (1)
+                              IsPlaceholder>& bufferAcc) const;
 
 template <backend Backend, typename DataT, int Dims, access_mode AccMode>
 backend_return_t<Backend, unsampled_image<Dims>> get_native_mem( // (2)


### PR DESCRIPTION
I noticed this while updating the copyright dates.

Fix an old formatting mistake with this synopsis.  This appears to have been introduced in #269 when clang format was run over all the synopsis headers.