### PR TITLE
[DO NOT MERGE] Test cross-documents reference format (ADOC,  HTML and PDF)

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -1,8 +1,13 @@
+ifdef::env-github,env-gitlab[]
+:relfileprefix: ../
+:relfilesuffix: .adoc
+endif::[]
+
 [[chapter:sycl-programming-interface]]
 = SYCL programming interface
 
 The SYCL programming interface provides a common abstracted feature set to one
-or more <<backend>> APIs.
+or more xref:chapters/glossary.adoc#backend[backend] APIs.
 This section describes the {cpp} library interface to the <<sycl-runtime>> which
 executes across those <<backend, SYCL backends>>.
 


### PR DESCRIPTION
Test new reference format **"One-for -all"**) which will allow to navigate over the documents by clicking highlighted references independently if it is ADOC (navigation between different ADOC documents) or generated HTML/PDF
