### PR TITLE
Avoid some undefined attribute warnings

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -1675,22 +1675,23 @@ Some multi-dimensional objects can be viewed in a linear form.
 When this happens, the right-most term in the object's range varies fastest in
 the linearization.
 
-A three-dimensional element [code]#id{id0, id1, id2}# within a three-dimensional
-object of range [code]#range{r0, r1, r2}# has a linear position defined by:
+A three-dimensional element [code]#+id{id0, id1, id2}+# within a
+three-dimensional object of range [code]#+range{r0, r1, r2}+# has a linear
+position defined by:
 [latexmath]
 ++++
 id2 + (id1 \cdot r2) + (id0 \cdot r1 \cdot r2)
 ++++
 
-A two-dimensional element [code]#id{id0, id1}# within a two-dimensional
-[code]#range{r0, r1}# follows a similar equation:
+A two-dimensional element [code]#+id{id0, id1}+# within a two-dimensional
+[code]#+range{r0, r1}+# follows a similar equation:
 [latexmath]
 ++++
 id1 + (id0 \cdot r1)
 ++++
 
-A one-dimensional element [code]#id{id0}# within a one-dimensional range
-[code]#range{r0}# is equivalent to its linear form.
+A one-dimensional element [code]#+id{id0}+# within a one-dimensional range
+[code]#+range{r0}+# is equivalent to its linear form.
 
 
 [[sec:multi-dim-subscript]]
@@ -1700,11 +1701,11 @@ Some multi-dimensional objects can be indexed using the subscript operator where
 consecutive subscript operators correspond to each dimension.
 The right-most operator varies fastest, as with standard {cpp} arrays.
 Formally, a three-dimensional subscript access [code]#a[id0][id1][id2]#
-references the element at [code]#id{id0, id1, id2}#.
+references the element at [code]#+id{id0, id1, id2}+#.
 A two-dimensional subscript access [code]#a[id0][id1]# references the element at
-[code]#id{id0, id1}#.
+[code]#+id{id0, id1}+#.
 A one-dimensional subscript access [code]#a[id0]# references the element at
-[code]#id{id0}#.
+[code]#+id{id0}+#.
 
 
 == Implementation options

--- a/adoc/chapters/opencl_backend.adoc
+++ b/adoc/chapters/opencl_backend.adoc
@@ -491,7 +491,7 @@ The following section describes the OpenCL-specific API.
 === Construct SYCL objects from OpenCL ones
 
 The OpenCL backend provides the following specializations of the
-[code]#make_{sycl_class}# template functions which are defined in
+[code]#+make_{sycl_class}+# template functions which are defined in
 <<sec:backend-interoperability-make>>.
 These functions are in the [code]#sycl# namespace.
 
@@ -901,7 +901,7 @@ kernel query" column applies for kernels defined through OpenCL interop.
 |====
 | SYCL kernel query | OpenCL kernel query | Returned Value
 
-3+|With enqueued 3D SYCL global [code]#range# of [code]#range<3> R{r0,r1,r2}#
+3+|With enqueued 3D SYCL global [code]#range# of [code]#+range<3> R{r0,r1,r2}+#
 | nd_item::get_global_range(0) / item::get_range(0)
     | get_global_size(2)
     | [code]#r0#
@@ -921,7 +921,7 @@ kernel query" column applies for kernels defined through OpenCL interop.
     | get_global_id(0)
     | Value in range 0..([code]#r2-1)}#
 
-3+|With enqueued 2D SYCL global [code]#range# of [code]#range<2> R{r0,r1}#
+3+|With enqueued 2D SYCL global [code]#range# of [code]#+range<2> R{r0,r1}+#
 | nd_item::get_global_range(0) / item::get_range(0)
     | get_global_size(1)
     | [code]#r0#
@@ -935,7 +935,7 @@ kernel query" column applies for kernels defined through OpenCL interop.
     | get_global_id(0)
     | Value in range 0..([code]#r1-1)}#
 
-3+|With enqueued 1D SYCL global [code]#range# of [code]#range<1> R{r0}#
+3+|With enqueued 1D SYCL global [code]#range# of [code]#+range<1> R{r0}+#
 | nd_item::get_global_range(0) / item::get_range(0)
     | get_global_size(0)
     | [code]#r0#

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -281,13 +281,13 @@ include::{header_dir}/interop/templateFunctionMakeX.h[lines=4..-1]
 
 For each <<sycl-runtime>> class [code]#T# which supports <<sycl-application>>
 interoperability, a specialization of the appropriate template function
-[code]#make_{sycl_class}# where [code]#{sycl_class}# is the class name of
+[code]#+make_{sycl_class}+# where [code]#+{sycl_class}+# is the class name of
 [code]#T#, must be defined, which takes a <<sycl-application>> interoperability
 <<native-backend-object>> and constructs and returns an instance of [code]#T#.
 The availability and behavior of these template functions are defined by the
 <<backend>> specification document.
 
-Overloads of the [code]#make_{sycl_class}# function which take a SYCL
+Overloads of the [code]#+make_{sycl_class}+# function which take a SYCL
 <<context>> object as an argument must throw an [code]#exception# with the
 [code]#errc::backend_mismatch# error code if the backend of the provided SYCL
 context doesn't match the target backend.


### PR DESCRIPTION
I'd like to enable `attribute-missing=warn` in the Asciidoctor build in order to catch cases where we forgot to define an attribute.  However, doing so causes false warnings for things in `[code]` style that look like attributes.  Add escaping to these, which avoids the warning.

Unfortunately, I still cannot enable `attribute-missing=warn` because there are still the following false warnings:

```
asciidoctor: WARNING: skipping reference to missing attribute: n
asciidoctor: WARNING: skipping reference to missing attribute: objectbundle
asciidoctor: WARNING: skipping reference to missing attribute: objectbundle
```

I have no idea where these are coming from.  In fact, the word "objectbundle" doesn't even exist in our repo.