### PR TITLE
Define {cpp23}

### DIFF
--- a/adoc/syclbase.adoc
+++ b/adoc/syclbase.adoc
@@ -78,6 +78,7 @@ include::config/api_xrefs.adoc[]
 // Asciidoctor uses ++ to denote spans, so use these attributes instead
 :cpp17: pass:[C++17]
 :cpp20: pass:[C++20]
+:cpp23: pass:[C++23]
 // Fortunately, the cpp macro for C++ is defined by default in AsciiDoctor
 
 // Use these to format a non-normative note.  The Asciidoc source:


### PR DESCRIPTION
This attribute is defined in the "main" branch, but not in the "sycl-2020" branch.  Add it.

Closes #984