### PR TITLE
Fix kernel argument definition for named function objects

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17667,10 +17667,10 @@ a device copyable type in that case and the specialization is ignored.
 
 A SYCL application passes parameters to a kernel in different ways depending on
 whether the kernel is a named function object or a lambda expression.
-If the kernel is a named function object, the [code]#operator()# member function
-(or other member functions that it calls) may reference member variables inside
-the same named function object.
-Any such member variables become parameters to the kernel.
+If the kernel is a named function object, all member variables of the named
+function object become parameters to the kernel.
+An implementation may omit passing a member variable that it can prove is not
+used by the kernel, which is a form of dead argument elimination.
 If the kernel is a lambda expression, any variables captured by the lambda
 become parameters to the kernel.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17667,10 +17667,8 @@ a device copyable type in that case and the specialization is ignored.
 
 A SYCL application passes parameters to a kernel in different ways depending on
 whether the kernel is a named function object or a lambda expression.
-If the kernel is a named function object, all member variables of the named
+If the kernel is a named function object, all non-static member variables of the named
 function object become parameters to the kernel.
-An implementation may omit passing a member variable that it can prove is not
-used by the kernel, which is a form of dead argument elimination.
 If the kernel is a lambda expression, any variables captured by the lambda
 become parameters to the kernel.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -17667,8 +17667,8 @@ a device copyable type in that case and the specialization is ignored.
 
 A SYCL application passes parameters to a kernel in different ways depending on
 whether the kernel is a named function object or a lambda expression.
-If the kernel is a named function object, all non-static member variables of the named
-function object become parameters to the kernel.
+If the kernel is a named function object, all non-static member variables of the
+named function object become parameters to the kernel.
 If the kernel is a lambda expression, any variables captured by the lambda
 become parameters to the kernel.
 


### PR DESCRIPTION
Fixes #915.

The previous wording implied that only member variables referenced by `operator()` become kernel parameters, which breaks down when `operator()` calls a `SYCL_EXTERNAL` function defined in another translation unit — the compiler has no way to know which members are used there. The corrected text states that all member variables of the named function object are kernel parameters, and that an implementation may drop any it can prove are unused (dead argument elimination). This also aligns with how DPC++ already handles type checking for kernel objects.