### PR TITLE
Fix missing property_list in image get_access description tables

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -6603,7 +6603,7 @@ template <typename DataT,
                                  : access_mode::read_write),
          image_target Targ = image_target::device>
 unsampled_image_accessor<DataT, Dimensions, Mode, Targ>
-get_access(handler& commandGroupHandler)
+get_access(handler& commandGroupHandler, const property_list& propList = {})
 ----
    a@ Returns a valid [code]#unsampled_image_accessor# to the unsampled image
       with the specified data type, access mode and target in the command group.
@@ -6614,7 +6614,8 @@ a@
 template <typename DataT, access_mode Mode = (std::is_const_v<DataT>
                                                    ? access_mode::read
                                                    : access_mode::read_write)>
-host_unsampled_image_accessor<DataT, Dimensions, Mode> get_host_access();
+host_unsampled_image_accessor<DataT, Dimensions, Mode>
+get_host_access(const property_list& propList = {})
 ----
    a@ Returns a valid [code]#host_unsampled_image_accessor# to the unsampled
       image with the specified data type and access mode.
@@ -7015,7 +7016,7 @@ a@
 ----
 template <typename DataT, image_target Targ = image_target::device>
 sampled_image_accessor<DataT, Dimensions, Targ>
-get_access(handler& commandGroupHandler)
+get_access(handler& commandGroupHandler, const property_list& propList = {})
 ----
    a@ Returns a valid [code]#sampled_image_accessor# to the sampled image with
       the specified data type and target in the command group.
@@ -7024,7 +7025,8 @@ a@
 [source]
 ----
 template <typename DataT>
-host_sampled_image_accessor<DataT, Dimensions> get_host_access()
+host_sampled_image_accessor<DataT, Dimensions>
+get_host_access(const property_list& propList = {})
 ----
    a@ Returns a valid [code]#host_sampled_image_accessor# to the sampled image
       with the specified data type in the command group.


### PR DESCRIPTION
Fixes #994.
The header synopsis for both `unsampled_image` and `sampled_image` includes a `property_list` parameter on `get_access` and `get_host_access`, and DPC++ implements it that way too, but the description tables in the member function docs were missing it. This brings the prose descriptions in line with the synopsis for all four affected functions.