### PR TITLE
Add converting constructors to multi_ptr for generic address space

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -10387,6 +10387,28 @@ multi_ptr(std::nullptr_t)
 a@
 [source]
 ----
+template <access::address_space AS, access::decorated IsDecorated>
+multi_ptr(const multi_ptr<value_type, AS, IsDecorated>&)
+----
+   a@ Available only when:
+      [code]#(Space == access::address_space::generic_space && AS != access::address_space::constant_space)#.
+
+Constructs a [code]#generic_ptr# by copying the value of the right hand side [code]#multi_ptr#.
+
+a@
+[source]
+----
+template <access::address_space AS, access::decorated IsDecorated>
+multi_ptr(multi_ptr<value_type, AS, IsDecorated>&&)
+----
+   a@ Available only when:
+      [code]#(Space == access::address_space::generic_space && AS != access::address_space::constant_space)#.
+
+Constructs a [code]#generic_ptr# by moving the value of the right hand side [code]#multi_ptr#.
+
+a@
+[source]
+----
 template <typename AccDataT, int Dimensions,
           access_mode Mode,
           access::placeholder IsPlaceholder>

--- a/adoc/headers/multipointer.h
+++ b/adoc/headers/multipointer.h
@@ -65,6 +65,18 @@ class multi_ptr {
   multi_ptr(std::nullptr_t);
 
   // Available only when:
+  //   (Space == access::address_space::generic_space &&
+  //    AS != access::address_space::constant_space)
+  template <access::address_space AS, access::decorated IsDecorated>
+  multi_ptr(const multi_ptr<value_type, AS, IsDecorated>&);
+
+  // Available only when:
+  //   (Space == access::address_space::generic_space &&
+  //    AS != access::address_space::constant_space)
+  template <access::address_space AS, access::decorated IsDecorated>
+  multi_ptr(multi_ptr<value_type, AS, IsDecorated>&&);
+
+  // Available only when:
   //   (Space == access::address_space::global_space ||
   //    Space == access::address_space::generic_space) &&
   //   (std::is_same_v<std::remove_const_t<ElementType>, std::remove_const_t<AccDataT>>) &&


### PR DESCRIPTION
The generic_space specialization already had converting copy and move `operator=` overloads accepting any non-constant address space, but had no matching constructors. This meant assigning to an already-constructed `generic_ptr` worked, while direct initialization and passing as a function argument did not. The fix adds the two missing constructors with the same constraints as the existing assignment operators, making the interface consistent. Fixes #894.