### PR TITLE
Clarify Unified Addressing

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11174,12 +11174,12 @@ include::{code_dir}/usm_device.cpp[lines=4..-1]
 
 === Unified addressing
 
-Unified Addressing guarantees that all devices in a given SYCL <<context>>
-will use a unified address space.
+Unified Addressing guarantees that all devices in a given SYCL <<context>> will
+use a unified address space.
 Pointer values in the unified address space will always refer to the same
 location in memory.
-The unified address space encompasses the host and all devices in a given
-SYCL <<context>>.
+The unified address space encompasses the host and all devices in a given SYCL
+<<context>>.
 Note that this does not require addresses in the unified address space to be
 accessible on all devices, just that pointer values will be consistent.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11174,10 +11174,12 @@ include::{code_dir}/usm_device.cpp[lines=4..-1]
 
 === Unified addressing
 
-Unified Addressing guarantees that all devices will use a unified address space.
+Unified Addressing guarantees that all devices in a given SYCL <<context>>
+will use a unified address space.
 Pointer values in the unified address space will always refer to the same
 location in memory.
-The unified address space encompasses the host and one or more devices.
+The unified address space encompasses the host and all devices in a given
+SYCL <<context>>.
 Note that this does not require addresses in the unified address space to be
 accessible on all devices, just that pointer values will be consistent.
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11179,16 +11179,16 @@ device code, providing the following guarantees for pointer values to objects
 that have overlapping lifetimes:
 
   * A USM pointer is different from all non-USM memory addresses on the host.
-  * A USM host memory pointer allocated from context C has a value that is
+  * A USM host memory pointer allocated from context _C_ has a value that is
     different from all other USM host memory pointers (regardless of context),
     different from all USM shared memory pointers (regardless of context), and
-    different from all USM device memory pointers allocated from context C.
-  * A USM shared memory pointer allocated from context C has a value that is
+    different from all USM device memory pointers allocated from context _C_.
+  * A USM shared memory pointer allocated from context _C_ has a value that is
     different from all other USM shared memory pointers (regardless of context),
     different from all USM host memory pointers (regardless of context), and
-    different from all USM device memory pointers allocated from context C.
-  * A USM device memory pointer allocated from context C has a value that is
-    different from all other USM pointers allocated from context C.
+    different from all USM device memory pointers allocated from context _C_.
+  * A USM device memory pointer allocated from context _C_ has a value that is
+    different from all other USM pointers allocated from context _C_.
 
 === Kinds of unified shared memory
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11174,9 +11174,8 @@ include::{code_dir}/usm_device.cpp[lines=4..-1]
 
 === Unified addressing
 
-USM allocations have pointer values that are unique across both host code and
-device code, providing the following guarantees for pointer values to objects
-that have overlapping lifetimes:
+The following guarantees apply to the pointer values of USM allocations for
+objects with overlapping lifetimes:
 
   * A USM pointer is different from all non-USM memory addresses on the host.
   * A USM host memory pointer allocated from context _C_ has a value that is

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -11174,15 +11174,21 @@ include::{code_dir}/usm_device.cpp[lines=4..-1]
 
 === Unified addressing
 
-Unified Addressing guarantees that all devices in a given SYCL <<context>> will
-use a unified address space.
-Pointer values in the unified address space will always refer to the same
-location in memory.
-The unified address space encompasses the host and all devices in a given SYCL
-<<context>>.
-Note that this does not require addresses in the unified address space to be
-accessible on all devices, just that pointer values will be consistent.
+USM allocations have pointer values that are unique across both host code and
+device code, providing the following guarantees for pointer values to objects
+that have overlapping lifetimes:
 
+  * A USM pointer is different from all non-USM memory addresses on the host.
+  * A USM host memory pointer allocated from context C has a value that is
+    different from all other USM host memory pointers (regardless of context),
+    different from all USM shared memory pointers (regardless of context), and
+    different from all USM device memory pointers allocated from context C.
+  * A USM shared memory pointer allocated from context C has a value that is
+    different from all other USM shared memory pointers (regardless of context),
+    different from all USM host memory pointers (regardless of context), and
+    different from all USM device memory pointers allocated from context C.
+  * A USM device memory pointer allocated from context C has a value that is
+    different from all other USM pointers allocated from context C.
 
 === Kinds of unified shared memory
 


### PR DESCRIPTION
Unified Addressing should only be within a single context (and the host).