### PR TITLE
Refactor anatomy.cpp for USM and in_order queue

### DIFF
--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -79,7 +79,7 @@ the SYCL features that will be used.
 A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>.
 The application is structured in three scopes which specify the different
 sections; <<application-scope>>, <<command-group-scope>> and <<kernel-scope>>.
-The <<kernel-scope>> specifies a single kernel function that will be, or has
+The <<kernel-scope>> specifies a <<sycl-kernel-function>> that will be, or has
 been, compiled by a <<device-compiler>> and executed on a <<device>>.
 In this example <<kernel-scope>> is defined by lines 18 to 19, the body of the
 lambda passed to [code]#parallel_for#.
@@ -87,7 +87,8 @@ The <<command-group-scope>> specifies a unit of work which is comprised of a
 <<sycl-kernel-function>> and any associated requirements.
 In this example the kernel is launched using the [code]#parallel_for# queue
 shortcut on lines 17 to 20, which implicitly defines the <<command-group-scope>>
-around the kernel invocation.
+around the <<kernel-scope>>.
+All queue shortcuts can be found in <<sec:queue-class>>.
 The <<application-scope>> specifies all other code outside of a
 <<command-group-scope>>.
 These three scopes are used to control the application flow and the construction
@@ -115,21 +116,17 @@ In the case of [code]#parallel_for# the <<sycl-kernel-function>> will be
 executed over the given range from 0 to 1023.
 The different member functions to execute kernels can be found in
 <<subsec:invokingkernels>>.
-
-In this example the [code]#parallel_for# queue shortcut on lines 17 to 20 is
-used to implicitly define a command group containing a single
-<<sycl-kernel-function>>. All queue shortcuts can be found in <<sec:queue-class>>.
-
 All the requirements for a kernel to execute are defined in this
 <<command-group-scope>>, as described in <<sec:executionmodel>>.
-In this case [code]#myQueue# is constructed on line 11 with the
-[code]#property::queue::in_order# property, which causes commands submitted to
-the queue to execute in the order they are enqueued.
-No <<device>> is specified, so the queue selects the best underlying device to
-execute on, leaving the decision up to the runtime.
+Additionally, in this example, [code]#myQueue# is constructed on line 11 with
+the [code]#property::queue::in_order# property, which causes commands submitted
+to the queue to execute in the order they were enqueued.
+No <<device>> is specified in the queue constructor, so the constructor selects
+the best underlying device to execute on, leaving the decision up to the
+runtime.
 
 In SYCL, data that is required within a <<sycl-kernel-function>> must be
-contained within a <<usm>>, <<image>>, or <<buffer>> allocation, as described in
+contained within a <<usm>> allocation, <<image>>, or <<buffer>> as described in
 <<sec:memory.model>>.
 In this example we use a USM device allocation, created with
 [code]#malloc_device# on line 14, which returns a pointer to memory accessible

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -81,10 +81,13 @@ The application is structured in three scopes which specify the different
 sections; <<application-scope>>, <<command-group-scope>> and <<kernel-scope>>.
 The <<kernel-scope>> specifies a single kernel function that will be, or has
 been, compiled by a <<device-compiler>> and executed on a <<device>>.
-In this example <<kernel-scope>> is defined by lines 25 to 26.
+In this example <<kernel-scope>> is defined by lines 18 to 19, the body of the
+lambda passed to [code]#parallel_for#.
 The <<command-group-scope>> specifies a unit of work which is comprised of a
-<<sycl-kernel-function>> and <<accessor,accessors>>.
-In this example <<command-group-scope>> is defined by lines 20 to 28.
+<<sycl-kernel-function>> and any associated requirements.
+In this example the kernel is launched using the [code]#parallel_for# queue
+shortcut on lines 17 to 20, which implicitly defines the <<command-group-scope>>
+around the kernel invocation.
 The <<application-scope>> specifies all other code outside of a
 <<command-group-scope>>.
 These three scopes are used to control the application flow and the construction
@@ -114,27 +117,35 @@ The different member functions to execute kernels can be found in
 <<subsec:invokingkernels>>.
 
 A <<command-group-scope>> is the syntactic scope wrapped by the construction of
-a <<command-group-function-object>> as seen on line 19.
-The <<command-group-function-object>> may invoke only a single
-<<sycl-kernel-function>>, and it takes a parameter of type command group
-[code]#handler#, which is constructed by the runtime.
+a <<command-group-function-object>>.
+In this example the [code]#parallel_for# queue shortcut on lines 17 to 20 is
+used to implicitly define a command group containing a single
+<<sycl-kernel-function>>.
+Alternatively, [code]#myQueue.submit# may be called with an explicit
+<<command-group-function-object>>, which takes a parameter of type command group
+[code]#handler# constructed by the runtime, and may invoke only a single
+<<sycl-kernel-function>>.
 
 All the requirements for a kernel to execute are defined in this
 <<command-group-scope>>, as described in <<sec:executionmodel>>.
-In this case the constructor used for [code]#myQueue# on line 9 is the default
-constructor, which allows the queue to select the best underlying device to
+In this case [code]#myQueue# is constructed on line 11 with the
+[code]#property::queue::in_order# property, which causes commands submitted to
+the queue to execute in the order they are enqueued.
+No <<device>> is specified, so the queue selects the best underlying device to
 execute on, leaving the decision up to the runtime.
 
 In SYCL, data that is required within a <<sycl-kernel-function>> must be
 contained within a <<buffer>>, <<image>>, or <<usm>> allocation, as described in
 <<sec:memory.model>>.
-We construct a buffer on line 16.
-Access to the <<buffer>> is controlled via an <<accessor>> which is constructed
-on line 21.
-The <<buffer>> is used to keep track of access to the data and the <<accessor>>
-is used to request access to the data on a queue, as well as to track the
-dependencies between <<sycl-kernel-function>>.
-In this example the <<accessor>> is used to write to the data buffer on line 26.
+In this example we use a USM device allocation, created with
+[code]#malloc_device# on line 14, which returns a pointer to memory accessible
+on the <<device>> associated with [code]#myQueue#.
+The kernel writes through this pointer on line 19.
+Because device allocations are not accessible from the host, the results are
+explicitly copied back into a host [code]##std::vector## using
+[code]#myQueue.copy# on line 23, and the call to [code]#myQueue.wait# on line 25
+ensures all enqueued operations have completed before the host reads the data.
+Finally, the device allocation is released with [code]#free# on line 32.
 
 
 [[sec:platformmodel]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -72,16 +72,18 @@ run in parallel on any device available.
 ----
 include::{code_dir}/anatomy.cpp[lines=4..-1]
 ----
-At line 2 we [code]#{hash}include# the SYCL header files, which provide all of 
-of the SYCL features that will be used. 
+At line 2 we [code]#{hash}include# the SYCL header files, which provide all of
+of the SYCL features that will be used.
 
-A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>. The application 
-is primarily comprised of two components: host code, and device code. The device code 
-is defined inside of the lambda function passed as the second argument to 
-[code]#myQueue.parallel_for# on line 17. The device code, also known as a kernel, 
-will be compiled by a <<device-compiler>> in order to be executed on a <<device>>. 
-The kernel body is found on lines 18-19 and belongs to the <<kernel-scope>>. All the 
-surrounding code belongs to the <<application-scope>>. 
+A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>.
+The application is primarily comprised of two components: host code, and device
+code.
+The device code is defined inside of the lambda function passed as the second
+argument to [code]#myQueue.parallel_for# on line 17.
+The device code, also known as a kernel, will be compiled by a
+<<device-compiler>> in order to be executed on a <<device>>.
+The kernel body is found on lines 18-19 and belongs to the <<kernel-scope>>.
+All the surrounding code belongs to the <<application-scope>>.
 
 The [code]#parallel_for# member function creates an instance of a <<kernel>>,
 which is the entity that will be enqueued within a command group.
@@ -91,34 +93,42 @@ The different member functions to execute kernels can be found in
 <<subsec:invokingkernels>>.
 
 This example makes use of a universal shared memory (<<usm>>)
-[code]#malloc_device# allocation. On line 14 [code]#dataDevice# is a pointer to 
-memory acecssible on the <<device>> associated with [code]#myQueue#. Once kernel 
-execution is complete the results must be moved back to host so that it can be 
-accessed by the host to print to the console. This is done on line
-23 with [code]#myQueue.copy()#.
+[code]#malloc_device# allocation.
+On line 14 [code]#dataDevice# is a pointer to memory acecssible on the
+<<device>> associated with [code]#myQueue#.
+Once kernel execution is complete the results must be moved back to host so that
+it can be accessed by the host to print to the console.
+This is done on line 23 with [code]#myQueue.copy()#.
 
-By default a <<queue>> executes command submitted to it out of order. In this case 
-there are two commands submitted to [code]#myQueue#: [code]#myQueue.parallel_for()#, 
-and [code]#myQueue.copy()#. Out of order execution creates the possibility for the copy command 
-to be executed before parallel_for the application would output nonsense. In order to prevent this 
-race condition we make use of the [code]#in_order()# property passed to the queue constructor. 
-[code]#in_order()# tells the queue to execute commands in the order that they are 
-submitted to the queue. This is very useful for simple applications, like our example, 
-it is important to consider the behavior very carefully in more complex applications 
-as you could potentially be leaving performance on the table. Instead dependences should 
-be expressed explicitly by passing the <<event>> returned by each command to all commands 
-that depend upon its completion.
+By default a <<queue>> executes command submitted to it out of order.
+In this case there are two commands submitted to [code]#myQueue#:
+[code]#myQueue.parallel_for()#, and [code]#myQueue.copy()#.
+Out of order execution creates the possibility for the copy command to be
+executed before parallel_for the application would output nonsense.
+In order to prevent this race condition we make use of the [code]#in_order()#
+property passed to the queue constructor.
+[code]#in_order()# tells the queue to execute commands in the order that they
+are submitted to the queue.
+This is very useful for simple applications, like our example, it is important
+to consider the behavior very carefully in more complex applications as you
+could potentially be leaving performance on the table.
+Instead dependences should be expressed explicitly by passing the <<event>>
+returned by each command to all commands that depend upon its completion.
 
-The commands submitted to [code]#myQueue# are executed asynchronously from the host code.
-The host code will continue to execute unless explicitly told to wait. This is useful if 
-there are other tasks that can be performed on the host while a device is executing it's 
-command(s). But similar to dependences between commands, the application should ensure that 
-results from a device are availble on the host before executing any code that relies on 
-those results. On lines 28 and 29 we output the result of the device code to the console, so 
-we make sure to call [code]#myQueue.wait()# before attempting to do so. 
+The commands submitted to [code]#myQueue# are executed asynchronously from the
+host code.
+The host code will continue to execute unless explicitly told to wait.
+This is useful if there are other tasks that can be performed on the host while
+a device is executing it's command(s).
+But similar to dependences between commands, the application should ensure that
+results from a device are availble on the host before executing any code that
+relies on those results.
+On lines 28 and 29 we output the result of the device code to the console, so we
+make sure to call [code]#myQueue.wait()# before attempting to do so.
 
-On line 32 we call [code]#free()# to deallocate the memory on the device. It is important to 
-do this to prevent memory leaks on a device, as c++ will not do so for you. 
+On line 32 we call [code]#free()# to deallocate the memory on the device.
+It is important to do this to prevent memory leaks on a device, as c++ will not
+do so for you.
 
 
 [[sec:platformmodel]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -72,43 +72,16 @@ run in parallel on any device available.
 ----
 include::{code_dir}/anatomy.cpp[lines=4..-1]
 ----
+At line 2 we [code]#{hash}include# the SYCL header files, which provide all of 
+of the SYCL features that will be used. 
 
-At line 1, we [code]#{hash}include# the SYCL header files, which provide all of
-the SYCL features that will be used.
-
-A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>.
-The application is structured in three scopes which specify the different
-sections; <<application-scope>>, <<command-group-scope>> and <<kernel-scope>>.
-The <<kernel-scope>> specifies a <<sycl-kernel-function>> that will be, or has
-been, compiled by a <<device-compiler>> and executed on a <<device>>.
-In this example <<kernel-scope>> is defined by lines 18 to 19, the body of the
-lambda passed to [code]#parallel_for#.
-The <<command-group-scope>> specifies a unit of work which is comprised of a
-<<sycl-kernel-function>> and any associated requirements.
-In this example the kernel is launched using the [code]#parallel_for# queue
-shortcut on lines 17 to 20, which implicitly defines the <<command-group-scope>>
-around the <<kernel-scope>>.
-All queue shortcuts can be found in <<sec:queue-class>>.
-The <<application-scope>> specifies all other code outside of a
-<<command-group-scope>>.
-These three scopes are used to control the application flow and the construction
-and lifetimes of the various objects used within SYCL, as explained in
-<<sec:managing-object-lifetimes>>.
-
-A <<sycl-kernel-function>> is the scoped block of code that will be compiled
-using a device compiler.
-This code may be defined by the body of a lambda expression or by the
-[code]#operator()# function of a function object.
-Each instance of the <<sycl-kernel-function>> will be executed as a single,
-though not necessarily entirely independent, flow of execution and has to adhere
-to restrictions on what operations may be allowed to enable device compilers to
-safely compile it to a range of underlying devices.
-
-The [code]#parallel_for# member function can be templated with a class.
-This class is used to manually name the kernel when desired, such as to avoid a
-compiler-generated name when debugging a kernel defined through a lambda, to
-provide a known name with which to apply build options to a kernel, or to ensure
-compatibility with multiple compiler-pass implementations.
+A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>. The application 
+is primarily comprised of two components: host code, and device code. The device code 
+is defined inside of the lambda function passed as the second argument to 
+[code]#myQueue.parallel_for# on line 17. The device code, also known as a kernel, 
+will be compiled by a <<device-compiler>> in order to be executed on a <<device>>. 
+The kernel body is found on lines 18-19 and belongs to the <<kernel-scope>>. All the 
+surrounding code belongs to the <<application-scope>>. 
 
 The [code]#parallel_for# member function creates an instance of a <<kernel>>,
 which is the entity that will be enqueued within a command group.
@@ -116,27 +89,36 @@ In the case of [code]#parallel_for# the <<sycl-kernel-function>> will be
 executed over the given range from 0 to 1023.
 The different member functions to execute kernels can be found in
 <<subsec:invokingkernels>>.
-All the requirements for a kernel to execute are defined in this
-<<command-group-scope>>, as described in <<sec:executionmodel>>.
-Additionally, in this example, [code]#myQueue# is constructed on line 11 with
-the [code]#property::queue::in_order# property, which causes commands submitted
-to the queue to execute in the order they were enqueued.
-No <<device>> is specified in the queue constructor, so the constructor selects
-the best underlying device to execute on, leaving the decision up to the
-runtime.
 
-In SYCL, data that is required within a <<sycl-kernel-function>> must be
-contained within a <<usm>> allocation, <<image>>, or <<buffer>> as described in
-<<sec:memory.model>>.
-In this example we use a USM device allocation, created with
-[code]#malloc_device# on line 14, which returns a pointer to memory accessible
-on the <<device>> associated with [code]#myQueue#.
-The kernel writes through this pointer on line 19.
-Because device allocations are not accessible from the host, the results are
-explicitly copied back to the host [code]##std::vector## using
-[code]#myQueue.copy# on line 23, and the call to [code]#myQueue.wait# on line 25
-ensures all enqueued operations have completed before the host reads the data.
-Finally, the device allocation is released with [code]#free# on line 32.
+This example makes use of a universal shared memory (<<usm>>)
+[code]#malloc_device# allocation. On line 14 [code]#dataDevice# is a pointer to 
+memory acecssible on the <<device>> associated with [code]#myQueue#. Once kernel 
+execution is complete the results must be moved back to host so that it can be 
+accessed by the host to print to the console. This is done on line
+23 with [code]#myQueue.copy()#.
+
+By default a <<queue>> executes command submitted to it out of order. In this case 
+there are two commands submitted to [code]#myQueue#: [code]#myQueue.parallel_for()#, 
+and [code]#myQueue.copy()#. Out of order execution creates the possibility for the copy command 
+to be executed before parallel_for the application would output nonsense. In order to prevent this 
+race condition we make use of the [code]#in_order()# property passed to the queue constructor. 
+[code]#in_order()# tells the queue to execute commands in the order that they are 
+submitted to the queue. This is very useful for simple applications, like our example, 
+it is important to consider the behavior very carefully in more complex applications 
+as you could potentially be leaving performance on the table. Instead dependences should 
+be expressed explicitly by passing the <<event>> returned by each command to all commands 
+that depend upon its completion.
+
+The commands submitted to [code]#myQueue# are executed asynchronously from the host code.
+The host code will continue to execute unless explicitly told to wait. This is useful if 
+there are other tasks that can be performed on the host while a device is executing it's 
+command(s). But similar to dependences between commands, the application should ensure that 
+results from a device are availble on the host before executing any code that relies on 
+those results. On lines 28 and 29 we output the result of the device code to the console, so 
+we make sure to call [code]#myQueue.wait()# before attempting to do so. 
+
+On line 32 we call [code]#free()# to deallocate the memory on the device. It is important to 
+do this to prevent memory leaks on a device, as c++ will not do so for you. 
 
 
 [[sec:platformmodel]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -75,61 +75,46 @@ include::{code_dir}/anatomy.cpp[lines=4..-1]
 At line 2 we [code]#{hash}include# the SYCL header files, which provide all of
 of the SYCL features that will be used.
 
-A SYCL application runs on a <<sec:platformmodel, SYCL Platform>>.
-The application is primarily comprised of two components: host code, and device
-code.
-The device code is defined inside of the lambda function passed as the second
-argument to [code]#myQueue.parallel_for# on line 17.
-The device code, also known as a kernel, will be compiled by a
-<<device-compiler>> in order to be executed on a <<device>>.
-The kernel body is found on lines 18-19 and belongs to the <<kernel-scope>>.
-All the surrounding code belongs to the <<application-scope>>.
-
-The [code]#parallel_for# member function creates an instance of a <<kernel>>,
-which is the entity that will be enqueued within a command group.
-In the case of [code]#parallel_for# the <<sycl-kernel-function>> will be
-executed over the given range from 0 to 1023.
-The different member functions to execute kernels can be found in
-<<subsec:invokingkernels>>.
-
-This example makes use of a universal shared memory (<<usm>>)
-[code]#malloc_device# allocation.
-On line 14 [code]#dataDevice# is a pointer to memory acecssible on the
-<<device>> associated with [code]#myQueue#.
-Once kernel execution is complete the results must be moved back to host so that
-it can be accessed by the host to print to the console.
-This is done on line 23 with [code]#myQueue.copy()#.
-
-By default a <<queue>> executes command submitted to it out of order.
-In this case there are two commands submitted to [code]#myQueue#:
-[code]#myQueue.parallel_for()#, and [code]#myQueue.copy()#.
-Out of order execution creates the possibility for the copy command to be
-executed before parallel_for the application would output nonsense.
-In order to prevent this race condition we make use of the [code]#in_order()#
-property passed to the queue constructor.
-[code]#in_order()# tells the queue to execute commands in the order that they
-are submitted to the queue.
-This is very useful for simple applications, like our example, it is important
-to consider the behavior very carefully in more complex applications as you
-could potentially be leaving performance on the table.
-Instead dependences should be expressed explicitly by passing the <<event>>
-returned by each command to all commands that depend upon its completion.
-
+At line 11 we instantiate a <<queue>> with the [code]#in_order# property.
+A queue is bound to a <<device>>, if you do not specify a device with a selector
+function, the SYCL runtime will choose one automatically.
+A queue will execute commands submitted to it on it's associated device.
+In our case commands will be executed in a first in first out (FIFO) fashion
+because of the [code]#in_order# property passed to our queue's constructor.
 The commands submitted to [code]#myQueue# are executed asynchronously from the
 host code.
+
+At line 14 we use [code]#malloc_device# to allocate memory on the <<device>>
+associated with our queue and store a universal shared memory (USM) pointer to
+the memory in [code]#dataDevice#.
+This memory is only accessible on the device.
+
+The application can be decomposed in to two components: code that is executed on
+the host, and code that is executed on a device.
+From line 17 to line 20 the device code is defined as a <<sycl-kernel-function>>
+passed as the second argument to [code]#myQueue.parallel_for#.
+The device code will be compiled by a <<device-compiler>> in order to be able to
+be executed on the <<device>> associated with [code]#myQueue#.
+
+The [code]#parallel_for# queue member function will invoke the compiled
+<<sycl-kernel-function>> over the given range from 0 to 1023.
+The different member functions to execute <<kernel>> can be found in
+<<subsec:invokingkernels>>.
+
+At line 23 we copy back the result from the device memory back into the vector
+in host memory.
+
+At line 25 we call [code]#myQueue.wait()#.
 The host code will continue to execute unless explicitly told to wait.
 This is useful if there are other tasks that can be performed on the host while
 a device is executing it's command(s).
 But similar to dependences between commands, the application should ensure that
 results from a device are availble on the host before executing any code that
 relies on those results.
-On lines 28 and 29 we output the result of the device code to the console, so we
-make sure to call [code]#myQueue.wait()# before attempting to do so.
 
-On line 32 we call [code]#free()# to deallocate the memory on the device.
+At line 32 we call [code]#free()# to deallocate the memory on the device.
 It is important to do this to prevent memory leaks on a device, as c++ will not
 do so for you.
-
 
 [[sec:platformmodel]]
 == The SYCL platform model

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -85,7 +85,7 @@ The commands submitted to [code]#myQueue# are executed asynchronously from the
 host code.
 
 At line 14 we use [code]#malloc_device# to allocate memory on the <<device>>
-associated with our queue and store a universal shared memory (USM) pointer to
+associated with our queue and store a universal shared memory <<usm>> pointer to
 the memory in [code]#dataDevice#.
 This memory is only accessible on the device.
 

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -116,15 +116,9 @@ executed over the given range from 0 to 1023.
 The different member functions to execute kernels can be found in
 <<subsec:invokingkernels>>.
 
-A <<command-group-scope>> is the syntactic scope wrapped by the construction of
-a <<command-group-function-object>>.
 In this example the [code]#parallel_for# queue shortcut on lines 17 to 20 is
 used to implicitly define a command group containing a single
-<<sycl-kernel-function>>.
-Alternatively, [code]#myQueue.submit# may be called with an explicit
-<<command-group-function-object>>, which takes a parameter of type command group
-[code]#handler# constructed by the runtime, and may invoke only a single
-<<sycl-kernel-function>>.
+<<sycl-kernel-function>>. All queue shortcuts can be found in <<sec:queue-class>>.
 
 All the requirements for a kernel to execute are defined in this
 <<command-group-scope>>, as described in <<sec:executionmodel>>.
@@ -135,14 +129,14 @@ No <<device>> is specified, so the queue selects the best underlying device to
 execute on, leaving the decision up to the runtime.
 
 In SYCL, data that is required within a <<sycl-kernel-function>> must be
-contained within a <<buffer>>, <<image>>, or <<usm>> allocation, as described in
+contained within a <<usm>>, <<image>>, or <<buffer>> allocation, as described in
 <<sec:memory.model>>.
 In this example we use a USM device allocation, created with
 [code]#malloc_device# on line 14, which returns a pointer to memory accessible
 on the <<device>> associated with [code]#myQueue#.
 The kernel writes through this pointer on line 19.
 Because device allocations are not accessible from the host, the results are
-explicitly copied back into a host [code]##std::vector## using
+explicitly copied back to the host [code]##std::vector## using
 [code]#myQueue.copy# on line 23, and the call to [code]#myQueue.wait# on line 25
 ensures all enqueued operations have completed before the host reads the data.
 Finally, the device allocation is released with [code]#free# on line 32.

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -115,7 +115,7 @@ completed.
 At lines 28 to 29 we print the host memory, which now contains a copy of the
 device memory.
 
-At line 32, the device allocation [code]#dataDevice# is released with
+At line 32 the device allocation [code]#dataDevice# is released with
 [code]#free#.
 
 [[sec:platformmodel]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -89,32 +89,33 @@ associated with our queue and store a universal shared memory (USM) pointer to
 the memory in [code]#dataDevice#.
 This memory is only accessible on the device.
 
-The application can be decomposed in to two components: code that is executed on
-the host, and code that is executed on a device.
-From line 17 to line 20 the device code is defined as a <<sycl-kernel-function>>
-passed as the second argument to [code]#myQueue.parallel_for#.
-The device code will be compiled by a <<device-compiler>> in order to be able to
-be executed on the <<device>> associated with [code]#myQueue#.
+In lines 17 to 20, [code]#parallel_for# does three conceptual things:
 
-The [code]#parallel_for# queue member function will invoke the compiled
-<<sycl-kernel-function>> over the given range from 0 to 1023.
-The different member functions to execute <<kernel>> can be found in
-<<subsec:invokingkernels>>.
+  1. The <<sycl-kernel-function>> (defined here as a lambda), passed as the
+    second argument to [code]#parallel_for#, is compiled by a
+    <<device-compiler>> into a <<kernel>> that can be ran on the <<device>>
+    associated with [code]#myQueue#.
+  2. A command that invokes the <<kernel>> on the <<device>> is submitted to [code]#myQueue#, 
+    and the <<kernel>> is executed asynchronously from the host. 
+  3. The command decomposes the range 0 to 1023 into <<work-item, work-items>>.
+    For each <<work-item>> the <<sycl-kernel-function>> is invoked once on the
+    device.
 
-At line 23 we copy back the result from the device memory back into the vector
-in host memory.
+The different <<queue>> member functions used to invoke a
+<<sycl-kernel-function>> can be found in <<subsec:invokingkernels>>.
 
-At line 25 we call [code]#myQueue.wait()#.
-The host code will continue to execute unless explicitly told to wait.
-This is useful if there are other tasks that can be performed on the host while
-a device is executing it's command(s).
-But similar to dependences between commands, the application should ensure that
-results from a device are availble on the host before executing any code that
-relies on those results.
+At line 23 we use the [code]#copy# member function to submit a copy command to copy the results from the 
+<<device, device's>> memory back into host memory.
 
-At line 32 we call [code]#free()# to deallocate the memory on the device.
-It is important to do this to prevent memory leaks on a device, as c++ will not
-do so for you.
+At line 25 we call [code]#wait# to block the host until all commands submitted
+to [code]#myQueue# (the [code]#parallel_for# and the [code]#copy#) have
+completed.
+
+At lines 28 to 29 we print the host memory, which now contains a copy of the
+device memory.
+
+At line 32, the device allocation [code]#dataDevice# is released with
+[code]#free#.
 
 [[sec:platformmodel]]
 == The SYCL platform model

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -95,8 +95,9 @@ In lines 17 to 20, [code]#parallel_for# does three conceptual things:
     second argument to [code]#parallel_for#, is compiled by a
     <<device-compiler>> into a <<kernel>> that can be ran on the <<device>>
     associated with [code]#myQueue#.
-  2. A command that invokes the <<kernel>> on the <<device>> is submitted to [code]#myQueue#, 
-    and the <<kernel>> is executed asynchronously from the host. 
+  2. A command that invokes the <<kernel>> on the <<device>> is submitted to
+    [code]#myQueue#, and the <<kernel>> is executed asynchronously from the
+    host.
   3. The command decomposes the range 0 to 1023 into <<work-item, work-items>>.
     For each <<work-item>> the <<sycl-kernel-function>> is invoked once on the
     device.
@@ -104,8 +105,8 @@ In lines 17 to 20, [code]#parallel_for# does three conceptual things:
 The different <<queue>> member functions used to invoke a
 <<sycl-kernel-function>> can be found in <<subsec:invokingkernels>>.
 
-At line 23 we use the [code]#copy# member function to submit a copy command to copy the results from the 
-<<device, device's>> memory back into host memory.
+At line 23 we use the [code]#copy# member function to submit a copy command to
+copy the results from the <<device, device's>> memory back into host memory.
 
 At line 25 we call [code]#wait# to block the host until all commands submitted
 to [code]#myQueue# (the [code]#parallel_for# and the [code]#copy#) have

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -100,7 +100,7 @@ In lines 17 to 20, [code]#parallel_for# does three conceptual things:
     host.
   3. The command decomposes the range 0 to 1023 into <<work-item, work-items>>.
     For each <<work-item>> the <<sycl-kernel-function>> is invoked once on the
-    device.
+    device, and these invocations may be executed in parallel.
 
 The different <<queue>> member functions used to invoke a
 <<sycl-kernel-function>> can be found in <<subsec:invokingkernels>>.

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -85,7 +85,7 @@ The commands submitted to [code]#myQueue# are executed asynchronously from the
 host code.
 
 At line 14 we use [code]#malloc_device# to allocate memory on the <<device>>
-associated with our queue and store a universal shared memory <<usm>> pointer to
+associated with our queue and store a unified shared memory (<<usm>>) pointer to
 the memory in [code]#dataDevice#.
 This memory is only accessible on the device.
 

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -75,7 +75,7 @@ include::{code_dir}/anatomy.cpp[lines=4..-1]
 At line 2 we [code]#{hash}include# the SYCL header files, which provide all of
 of the SYCL features that will be used.
 
-At line 11 we instantiate a <<queue>> with the [code]#in_order# property.
+At line 14 we instantiate a <<queue>> with the [code]#in_order# property.
 A queue is bound to a <<device>>, if you do not specify a device with a selector
 function, the SYCL runtime will choose one automatically.
 A queue will execute commands submitted to it on it's associated device.
@@ -84,12 +84,12 @@ because of the [code]#in_order# property passed to our queue's constructor.
 The commands submitted to [code]#myQueue# are executed asynchronously from the
 host code.
 
-At line 14 we use [code]#malloc_device# to allocate memory on the <<device>>
+At line 17 we use [code]#malloc_device# to allocate memory on the <<device>>
 associated with our queue and store a unified shared memory (<<usm>>) pointer to
 the memory in [code]#dataDevice#.
 This memory is only accessible on the device.
 
-In lines 17 to 20, [code]#parallel_for# does three conceptual things:
+In lines 20 to 23, [code]#parallel_for# does three conceptual things:
 
   1. The <<sycl-kernel-function>> (defined here as a lambda), passed as the
     second argument to [code]#parallel_for#, is compiled by a
@@ -105,17 +105,17 @@ In lines 17 to 20, [code]#parallel_for# does three conceptual things:
 The different <<queue>> member functions used to invoke a
 <<sycl-kernel-function>> can be found in <<subsec:invokingkernels>>.
 
-At line 23 we use the [code]#copy# member function to submit a copy command to
+At line 26 we use the [code]#copy# member function to submit a copy command to
 copy the results from the <<device, device's>> memory back into host memory.
 
-At line 25 we call [code]#wait# to block the host until all commands submitted
+At line 28 we call [code]#wait# to block the host until all commands submitted
 to [code]#myQueue# (the [code]#parallel_for# and the [code]#copy#) have
 completed.
 
-At lines 28 to 29 we print the host memory, which now contains a copy of the
-device memory.
+In lines 31 and 32 we print the results from the host memory, which now contains
+a copy of the device memory.
 
-At line 32 the device allocation [code]#dataDevice# is released with
+At line 35 the device allocation [code]#dataDevice# is released with
 [code]#free#.
 
 [[sec:platformmodel]]

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -93,7 +93,7 @@ In lines 17 to 20, [code]#parallel_for# does three conceptual things:
 
   1. The <<sycl-kernel-function>> (defined here as a lambda), passed as the
     second argument to [code]#parallel_for#, is compiled by a
-    <<device-compiler>> into a <<kernel>> that can be ran on the <<device>>
+    <<device-compiler>> into a <<kernel>> that can be run on the <<device>>
     associated with [code]#myQueue#.
   2. A command that invokes the <<kernel>> on the <<device>> is submitted to
     [code]#myQueue#, and the <<kernel>> is executed asynchronously from the

--- a/adoc/chapters/architecture.adoc
+++ b/adoc/chapters/architecture.adoc
@@ -75,7 +75,7 @@ include::{code_dir}/anatomy.cpp[lines=4..-1]
 At line 2 we [code]#{hash}include# the SYCL header files, which provide all of
 of the SYCL features that will be used.
 
-At line 14 we instantiate a <<queue>> with the [code]#in_order# property.
+At line 13 we instantiate a <<queue>> with the [code]#in_order# property.
 A queue is bound to a <<device>>, if you do not specify a device with a selector
 function, the SYCL runtime will choose one automatically.
 A queue will execute commands submitted to it on it's associated device.
@@ -84,12 +84,12 @@ because of the [code]#in_order# property passed to our queue's constructor.
 The commands submitted to [code]#myQueue# are executed asynchronously from the
 host code.
 
-At line 17 we use [code]#malloc_device# to allocate memory on the <<device>>
+At line 16 we use [code]#malloc_device# to allocate memory on the <<device>>
 associated with our queue and store a unified shared memory (<<usm>>) pointer to
 the memory in [code]#dataDevice#.
 This memory is only accessible on the device.
 
-In lines 20 to 23, [code]#parallel_for# does three conceptual things:
+In lines 19 to 22, [code]#parallel_for# does three conceptual things:
 
   1. The <<sycl-kernel-function>> (defined here as a lambda), passed as the
     second argument to [code]#parallel_for#, is compiled by a
@@ -105,17 +105,17 @@ In lines 20 to 23, [code]#parallel_for# does three conceptual things:
 The different <<queue>> member functions used to invoke a
 <<sycl-kernel-function>> can be found in <<subsec:invokingkernels>>.
 
-At line 26 we use the [code]#copy# member function to submit a copy command to
+At line 25 we use the [code]#copy# member function to submit a copy command to
 copy the results from the <<device, device's>> memory back into host memory.
 
-At line 28 we call [code]#wait# to block the host until all commands submitted
+At line 27 we call [code]#wait# to block the host until all commands submitted
 to [code]#myQueue# (the [code]#parallel_for# and the [code]#copy#) have
 completed.
 
-In lines 31 and 32 we print the results from the host memory, which now contains
+In lines 30 and 31 we print the results from the host memory, which now contains
 a copy of the device memory.
 
-At line 35 the device allocation [code]#dataDevice# is released with
+At line 34 the device allocation [code]#dataDevice# is released with
 [code]#free#.
 
 [[sec:platformmodel]]

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2011-2026 The Khronos Group, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <iostream>
 #include <sycl/sycl.hpp>
 #include <vector>

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -1,39 +1,26 @@
-// Copyright (c) 2011-2026 The Khronos Group, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 #include <iostream>
 #include <sycl/sycl.hpp>
-using namespace sycl;  // (optional) avoids need for "sycl::" before SYCL names
+using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
-  int data[1024];  // Allocate data to be worked on
-
   // Create a default queue to enqueue work to the default device
-  queue myQueue;
+  queue myQueue{};
+  // Allocate shared memory to be worked on on the default device
+  int *A_shared = malloc_shared<int>(1024, myQueue);
 
-  // By wrapping all the SYCL work in a {} block, we ensure
-  // all SYCL tasks must complete before exiting the block,
-  // because the destructor of resultBuf will wait
-  {
-    // Wrap our data variable in a buffer
-    buffer resultBuf{data, {1024}};
+  // Enqueue a parallel_for task with 1024 work-items
+  myQueue.parallel_for(1024, [=](id<1> idx) {
+    // Initialize each buffer element with its own rank number starting at 0
+    A_shared[idx] = idx;
+  }); // End of the kernel function
 
-    // Create a command group to issue commands to the queue
-    myQueue.submit([&](handler& cgh) {
-      // Request write access to the buffer without initialization
-      accessor writeResult{resultBuf, cgh, write_only, no_init};
+  myQueue.wait(); // Wait for the queue to finish executing on the device
 
-      // Enqueue a parallel_for task with 1024 work-items
-      cgh.parallel_for(1024, [=](id<1> idx) {
-        // Initialize each buffer element with its own rank number starting at 0
-        writeResult[idx] = idx;
-      });  // End of the kernel function
-    });    // End of our commands for this queue
-  }  // End of scope, so we wait for work producing resultBuf to complete
+  // Reclaim memory on the host and the device
+  free(A_shared, myQueue);
 
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout << "data[" << i << "] = " << data[i] << std::endl;
-
+    std::cout << "A_shared[" << i << "] = " << A_shared[i] << std::endl;
   return 0;
 }

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -2,25 +2,32 @@
 #include <sycl/sycl.hpp>
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
+std::vector<int> A_host(1024);
+
 int main() {
   // Create a default queue to enqueue work to the default device
-  queue myQueue{};
+  queue myQueue{property::queue::in_order()};
+
   // Allocate shared memory to be worked on on the default device
-  int *A_shared = malloc_shared<int>(1024, myQueue);
+  int *A_device = malloc_device<int>(1024, myQueue);
 
   // Enqueue a parallel_for task with 1024 work-items
   myQueue.parallel_for(1024, [=](id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
-    A_shared[idx] = idx;
+    A_device[idx] = idx;
   }); // End of the kernel function
+
+  // Copy the results back to the device from the host
+  myQueue.copy(A_device, A_host.data(), 1024);
 
   myQueue.wait(); // Wait for the queue to finish executing on the device
 
-  // Reclaim memory on the host and the device
-  free(A_shared, myQueue);
-
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout << "A_shared[" << i << "] = " << A_shared[i] << std::endl;
+    std::cout << "A_shared[" << i << "] = " << A_host[i] << std::endl;
+
+  // Reclaim memory on the host and the device
+  free(A_device, myQueue);
+
   return 0;
 }

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -1,14 +1,16 @@
 #include <iostream>
 #include <sycl/sycl.hpp>
+#include <vector>
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
-std::vector<int> A_host(1024);
-
 int main() {
-  // Create a default queue to enqueue work to the default device
+  // Allocate host memory to store the results
+  std::vector<int> A_host(1024);
+
+  // Create an in order queue to enqueue work to the default device
   queue myQueue{property::queue::in_order()};
 
-  // Allocate shared memory to be worked on on the default device
+  // Allocate device memory to be worked on
   int *A_device = malloc_device<int>(1024, myQueue);
 
   // Enqueue a parallel_for task with 1024 work-items
@@ -17,16 +19,16 @@ int main() {
     A_device[idx] = idx;
   }); // End of the kernel function
 
-  // Copy the results back to the device from the host
+  // Copy the results back to the host from the device
   myQueue.copy(A_device, A_host.data(), 1024);
 
-  myQueue.wait(); // Wait for the queue to finish executing on the device
+  myQueue.wait(); // Wait for the queue to finish executing all the tasks
 
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout << "A_shared[" << i << "] = " << A_host[i] << std::endl;
+    std::cout << "A_host[" << i << "] = " << A_host[i] << std::endl;
 
-  // Reclaim memory on the host and the device
+  // Free device memory
   free(A_device, myQueue);
 
   return 0;

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -8,31 +8,31 @@ using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
   // Allocate host memory to store the results
-  std::vector<int> A_host(1024);
+  std::vector<int> dataHost(1024);
 
   // Create an in order queue to enqueue work to the default device
   queue myQueue{property::queue::in_order()};
 
   // Allocate device memory to be worked on
-  int *A_device = malloc_device<int>(1024, myQueue);
+  int *dataDevice = malloc_device<int>(1024, myQueue);
 
   // Enqueue a parallel_for task with 1024 work-items
   myQueue.parallel_for(1024, [=](id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
-    A_device[idx] = idx;
+    dataDevice[idx] = idx;
   }); // End of the kernel function
 
   // Copy the results back to the host from the device
-  myQueue.copy(A_device, A_host.data(), 1024);
+  myQueue.copy(dataDevice, dataHost.data(), 1024);
 
   myQueue.wait(); // Wait for the queue to finish executing all the tasks
 
   // Print result
   for (int i = 0; i < 1024; i++)
-    std::cout << "A_host[" << i << "] = " << A_host[i] << std::endl;
+    std::cout << "dataHost[" << i << "] = " << dataHost[i] << std::endl;
 
   // Free device memory
-  free(A_device, myQueue);
+  free(dataDevice, myQueue);
 
   return 0;
 }

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <sycl/sycl.hpp>
 #include <vector>
-using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
   // Declare number of work items
@@ -14,13 +13,13 @@ int main() {
   std::vector<int> dataHost(N);
 
   // Create an in order queue to enqueue work to the default device
-  queue myQueue{property::queue::in_order()};
+  sycl::queue myQueue{sycl::property::queue::in_order()};
 
   // Allocate device memory to be worked on
-  int *dataDevice = malloc_device<int>(N, myQueue);
+  int *dataDevice = sycl::malloc_device<int>(N, myQueue);
 
   // Enqueue a parallel_for task with 1024 work-items
-  myQueue.parallel_for(N, [=](id<1> idx) {
+  myQueue.parallel_for(N, [=](sycl::id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
     dataDevice[idx] = idx;
   }); // End of the kernel function
@@ -35,7 +34,7 @@ int main() {
     std::cout << "dataHost[" << i << "] = " << dataHost[i] << std::endl;
 
   // Free device memory
-  free(dataDevice, myQueue);
+  sycl::free(dataDevice, myQueue);
 
   return 0;
 }

--- a/adoc/code/anatomy.cpp
+++ b/adoc/code/anatomy.cpp
@@ -7,28 +7,31 @@
 using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
 
 int main() {
+  // Declare number of work items
+  constexpr size_t N = 1024;
+
   // Allocate host memory to store the results
-  std::vector<int> dataHost(1024);
+  std::vector<int> dataHost(N);
 
   // Create an in order queue to enqueue work to the default device
   queue myQueue{property::queue::in_order()};
 
   // Allocate device memory to be worked on
-  int *dataDevice = malloc_device<int>(1024, myQueue);
+  int *dataDevice = malloc_device<int>(N, myQueue);
 
   // Enqueue a parallel_for task with 1024 work-items
-  myQueue.parallel_for(1024, [=](id<1> idx) {
+  myQueue.parallel_for(N, [=](id<1> idx) {
     // Initialize each buffer element with its own rank number starting at 0
     dataDevice[idx] = idx;
   }); // End of the kernel function
 
   // Copy the results back to the host from the device
-  myQueue.copy(dataDevice, dataHost.data(), 1024);
+  myQueue.copy(dataDevice, dataHost.data(), N);
 
   myQueue.wait(); // Wait for the queue to finish executing all the tasks
 
   // Print result
-  for (int i = 0; i < 1024; i++)
+  for (int i = 0; i < N; i++)
     std::cout << "dataHost[" << i << "] = " << dataHost[i] << std::endl;
 
   // Free device memory


### PR DESCRIPTION
1. Updated `anatomy.cpp` to use `malloc_device`. We did not use `malloc_shared` in order to demonstrate the in_order behavior.
2. Modified accompanying description to reference the updated code and clarify that the command group scope is created implicitly because of the `parallel_for` queue shortcut.  

Thank you for taking the time to review my pr and do not hesitate to reach out for clarification if needed.