### PR TITLE
Note removal of the 1.2.1 "device_selector" class

### DIFF
--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -289,6 +289,7 @@ Changes in the SYCL [code]#vec# class described in <<sec:vector.type>>:
   * [code]#operator[]# was added;
   * unary [code]#pass:[operator+()]# and [code]#operator-()# were added;
 
+The [code]#device_selector# class has been removed.
 The device selection now relies on a simpler API based on ranking functions used
 as <<device-selector,device selectors>> described in <<sec:device-selector>>.
 


### PR DESCRIPTION
The SYCL 2020 specification removed the `device_selector` class, which was part of SYCL 1.2.1.  Add this to the "What has changed" appendix.

Closes #1016