### PR TITLE
Clarify "atomic_ref" with private address space

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -20496,6 +20496,11 @@ operations in device code with a syntax similar to the {cpp} standard
 [code]#std::atomic_ref#.
 The [code]#sycl::atomic_ref# class must not be used in host code.
 
+The referenced object of type [code]#T# must not reside in the private address
+space.
+If [code]#atomic_ref# is constructed with a reference to an object in the
+private address space, the behavior is undefined.
+
 Unlike [code]#std::atomic_ref#, [code]#sycl::atomic_ref# does not provide a
 default memory ordering for its operations.
 Instead, the application must specify a default ordering via the


### PR DESCRIPTION
Cherry pick #986 from main
(cherry picked from commit b1fb5a4b70f096572cb551d8030b82e39cd5dfcf)