### PR TITLE
Note removal of the 1.2.1 "device_selector" class

### DIFF
--- a/adoc/chapters/what_changed.adoc
+++ b/adoc/chapters/what_changed.adoc
@@ -281,6 +281,7 @@ Changes in the SYCL [code]#vec# class described in <<sec:vector.type>>:
   * [code]#operator[]# was added;
   * unary [code]#pass:[operator+()]# and [code]#operator-()# were added;
 
+The [code]#device_selector# class has been removed.
 The device selection now relies on a simpler API based on ranking functions used
 as <<device-selector,device selectors>> described in <<sec:device-selector>>.
 


### PR DESCRIPTION
Cherry pick #1018 from main
(cherry picked from commit 252e0796d69ae5e574471052a75754f6f4ade1ad)